### PR TITLE
refactor: change controller API domain to cf.k8s.lex.la

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ spec:
 | `--api-token` | `CF_API_TOKEN` | | Cloudflare API token |
 | `--cluster-domain` | `CF_CLUSTER_DOMAIN` | `cluster.local` | Kubernetes cluster domain |
 | `--gateway-class-name` | `CF_GATEWAY_CLASS_NAME` | `cloudflare-tunnel` | GatewayClass name to watch |
-| `--controller-name` | `CF_CONTROLLER_NAME` | `cloudflare.com/tunnel-controller` | Controller name |
+| `--controller-name` | `CF_CONTROLLER_NAME` | `cf.k8s.lex.la/tunnel-controller` | Controller name |
 | `--metrics-addr` | `CF_METRICS_ADDR` | `:8080` | Metrics endpoint address |
 | `--health-addr` | `CF_HEALTH_ADDR` | `:8081` | Health probe endpoint address |
 | `--log-level` | `CF_LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |

--- a/charts/cloudflare-tunnel-gateway-controller/README.md
+++ b/charts/cloudflare-tunnel-gateway-controller/README.md
@@ -120,9 +120,9 @@ spec:
 | cloudflare.apiToken | string | `""` | Cloudflare API token with Tunnel permissions (REQUIRED unless apiTokenSecretName is set) Required scopes: Account.Cloudflare Tunnel:Edit, Zone.DNS:Edit Leave empty if using apiTokenSecretName for external secret |
 | cloudflare.apiTokenSecretName | string | `""` | Existing secret name containing API token (key: api-token) If set, apiToken value is ignored Use this for external secret management (e.g., External Secrets Operator) |
 | cloudflare.tunnelId | string | `""` | Cloudflare Tunnel ID (REQUIRED at install time - must not be empty) Get from: Zero Trust Dashboard > Networks > Tunnels Example: "550e8400-e29b-41d4-a716-446655440000" or "my-tunnel-abc-123" |
-| controller | object | `{"clusterDomain":"cluster.local","controllerName":"cloudflare.com/tunnel-controller","gatewayClassName":"cloudflare-tunnel","logFormat":"json","logLevel":"info"}` | Controller configuration |
+| controller | object | `{"clusterDomain":"cluster.local","controllerName":"cf.k8s.lex.la/tunnel-controller","gatewayClassName":"cloudflare-tunnel","logFormat":"json","logLevel":"info"}` | Controller configuration |
 | controller.clusterDomain | string | `"cluster.local"` | Kubernetes cluster domain for service DNS resolution |
-| controller.controllerName | string | `"cloudflare.com/tunnel-controller"` | Controller name for GatewayClass (must be unique in cluster) |
+| controller.controllerName | string | `"cf.k8s.lex.la/tunnel-controller"` | Controller name for GatewayClass (must be unique in cluster) |
 | controller.gatewayClassName | string | `"cloudflare-tunnel"` | GatewayClass name to watch |
 | controller.logFormat | string | `"json"` | Log format (json, text) |
 | controller.logLevel | string | `"info"` | Log level (debug, info, warn, error) |

--- a/charts/cloudflare-tunnel-gateway-controller/examples/production-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/production-values.yaml
@@ -33,7 +33,7 @@ controller:
   logLevel: "info"
   logFormat: "json"
   gatewayClassName: "cloudflare-tunnel"
-  controllerName: "cloudflare.com/tunnel-controller"
+  controllerName: "cf.k8s.lex.la/tunnel-controller"
   clusterDomain: "cluster.local"
 
 # High availability configuration

--- a/charts/cloudflare-tunnel-gateway-controller/tests/deployment_test.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/tests/deployment_test.yaml
@@ -730,7 +730,7 @@ tests:
       - template: deployment.yaml
         contains:
           path: spec.template.spec.containers[0].args
-          content: "--controller-name=cloudflare.com/tunnel-controller"
+          content: "--controller-name=cf.k8s.lex.la/tunnel-controller"
 
   - it: should use default clusterDomain
     set:

--- a/charts/cloudflare-tunnel-gateway-controller/tests/gatewayclass_test.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/tests/gatewayclass_test.yaml
@@ -28,7 +28,7 @@ tests:
       - template: gatewayclass.yaml
         equal:
           path: spec.controllerName
-          value: cloudflare.com/tunnel-controller
+          value: cf.k8s.lex.la/tunnel-controller
 
   - it: should use custom gateway class name
     set:

--- a/charts/cloudflare-tunnel-gateway-controller/values.schema.json
+++ b/charts/cloudflare-tunnel-gateway-controller/values.schema.json
@@ -38,7 +38,7 @@
         "controllerName": {
           "type": "string",
           "description": "Controller name for GatewayClass",
-          "default": "cloudflare.com/tunnel-controller"
+          "default": "cf.k8s.lex.la/tunnel-controller"
         },
         "clusterDomain": {
           "type": "string",

--- a/charts/cloudflare-tunnel-gateway-controller/values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/values.yaml
@@ -25,7 +25,7 @@ controller:
   # -- GatewayClass name to watch
   gatewayClassName: "cloudflare-tunnel"
   # -- Controller name for GatewayClass (must be unique in cluster)
-  controllerName: "cloudflare.com/tunnel-controller"
+  controllerName: "cf.k8s.lex.la/tunnel-controller"
   # -- Kubernetes cluster domain for service DNS resolution
   clusterDomain: "cluster.local"
   # -- Log level (debug, info, warn, error)

--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -50,7 +50,7 @@ func init() {
 	rootCmd.Flags().String("api-token", "", "Cloudflare API token (or use CF_API_TOKEN env var)")
 	rootCmd.Flags().String("cluster-domain", "cluster.local", "Kubernetes cluster domain")
 	rootCmd.Flags().String("gateway-class-name", "cloudflare-tunnel", "GatewayClass name to watch")
-	rootCmd.Flags().String("controller-name", "cloudflare.com/tunnel-controller", "Controller name for GatewayClass")
+	rootCmd.Flags().String("controller-name", "cf.k8s.lex.la/tunnel-controller", "Controller name for GatewayClass")
 	rootCmd.Flags().String("metrics-addr", ":8080", "Address for metrics endpoint")
 	rootCmd.Flags().String("health-addr", ":8081", "Address for health probe endpoint")
 
@@ -77,7 +77,7 @@ func initConfig() {
 
 	viper.SetDefault("cluster-domain", "cluster.local")
 	viper.SetDefault("gateway-class-name", "cloudflare-tunnel")
-	viper.SetDefault("controller-name", "cloudflare.com/tunnel-controller")
+	viper.SetDefault("controller-name", "cf.k8s.lex.la/tunnel-controller")
 	viper.SetDefault("metrics-addr", ":8080")
 	viper.SetDefault("health-addr", ":8081")
 	viper.SetDefault("log-level", "info")

--- a/deploy/samples/gatewayclass.yaml
+++ b/deploy/samples/gatewayclass.yaml
@@ -3,4 +3,4 @@ kind: GatewayClass
 metadata:
   name: cloudflare-tunnel
 spec:
-  controllerName: cloudflare.com/tunnel-controller
+  controllerName: cf.k8s.lex.la/tunnel-controller


### PR DESCRIPTION
Change the default controller name from cloudflare.com/tunnel-controller
to cf.k8s.lex.la/tunnel-controller in preparation for adding GatewayClassConfig CRD.

Updated in:
- CLI flag defaults (cmd/controller/cmd/root.go)
- Helm chart values and schema
- Sample manifests and examples
- Unit tests
- Documentation