### PR TITLE
docs: update Gateway API version to v1.4.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ What actually happened.
 
 - **Controller Version**: [e.g., v0.1.0]
 - **Kubernetes Version**: [e.g., v1.31.0]
-- **Gateway API Version**: [e.g., v1.2.0]
+- **Gateway API Version**: [e.g., v1.4.0]
 - **cloudflared Version**: [e.g., 2024.11.0]
 - **Deployment Method**: [Helm/Manual/Other]
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Enables routing traffic through Cloudflare Tunnel using standard Gateway API res
 
 ```bash
 # 1. Install Gateway API CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
 
 # 2. Add Helm repository
 helm registry login ghcr.io
@@ -108,7 +108,7 @@ See [charts/cloudflare-tunnel-gateway-controller/README.md](charts/cloudflare-tu
 #### 1. Install Gateway API CRDs
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
 ```
 
 #### 2. Create namespace

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -80,7 +80,7 @@ export CF_API_TOKEN="your-api-token"
 
 ```bash
 # Install Gateway API CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
 
 # Create namespace
 kubectl create namespace cloudflare-tunnel-system


### PR DESCRIPTION
Update Gateway API CRD installation links and examples from v1.2.0 to
v1.4.0 to match the version used in go.mod.