### PR TITLE
fix(ci): separate Helm chart OCI path from container image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -258,11 +258,11 @@ jobs:
           # Package chart
           helm package "${CHART_PATH}"
 
-          # Push to GHCR
+          # Push to GHCR (using /chart subpath to avoid conflict with container image)
           CHART_FILE="${CHART_NAME}-${VERSION}.tgz"
-          helm push "${CHART_FILE}" oci://ghcr.io/${{ github.repository_owner }}
+          helm push "${CHART_FILE}" oci://ghcr.io/${{ github.repository }}/chart
 
-          echo "Chart pushed: oci://ghcr.io/${{ github.repository_owner }}/${CHART_NAME}:${VERSION}"
+          echo "Chart pushed: oci://ghcr.io/${{ github.repository }}/chart:${VERSION}"
 
       - name: Generate chart summary
         run: |
@@ -272,12 +272,12 @@ jobs:
           {
             echo "## Helm Chart"
             echo ""
-            echo "**Chart**: \`oci://ghcr.io/${{ github.repository_owner }}/${CHART_NAME}:${VERSION}\`"
+            echo "**Chart**: \`oci://ghcr.io/${{ github.repository }}/chart:${VERSION}\`"
             echo ""
             echo "### Installation"
             echo "\`\`\`bash"
             echo "helm install ${CHART_NAME} \\"
-            echo "  oci://ghcr.io/${{ github.repository_owner }}/${CHART_NAME} \\"
+            echo "  oci://ghcr.io/${{ github.repository }}/chart \\"
             echo "  --version ${VERSION}"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ helm registry login ghcr.io
 
 # 3. Install the controller
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-tunnel-system \
   --create-namespace \
   --set config.tunnelID=YOUR_TUNNEL_ID \
@@ -95,7 +95,7 @@ The **Account Settings: Read** permission is required for auto-detecting the Acc
 
 ```bash
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-tunnel-system \
   --create-namespace \
   --values values.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/README.md
+++ b/charts/cloudflare-tunnel-gateway-controller/README.md
@@ -38,7 +38,7 @@ Kubernetes: `>=1.25.0-0`
 
 ```bash
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --version 0.1.0 \
   --namespace cloudflare-tunnel-system \
   --create-namespace \
@@ -114,7 +114,7 @@ To use multiple Cloudflare Tunnels in the same cluster, deploy multiple instance
 ```bash
 # First tunnel for production apps
 helm install controller-prod \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-system \
   --set controller.gatewayClassName=cloudflare-tunnel-prod \
   --set cloudflare.tunnelId="PROD_TUNNEL_ID" \
@@ -122,7 +122,7 @@ helm install controller-prod \
 
 # Second tunnel for staging apps
 helm install controller-staging \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-system \
   --set controller.gatewayClassName=cloudflare-tunnel-staging \
   --set cloudflare.tunnelId="STAGING_TUNNEL_ID" \

--- a/charts/cloudflare-tunnel-gateway-controller/README.md.gotmpl
+++ b/charts/cloudflare-tunnel-gateway-controller/README.md.gotmpl
@@ -30,7 +30,7 @@
 
 ```bash
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --version {{ template "chart.version" . }} \
   --namespace cloudflare-tunnel-system \
   --create-namespace \
@@ -106,7 +106,7 @@ To use multiple Cloudflare Tunnels in the same cluster, deploy multiple instance
 ```bash
 # First tunnel for production apps
 helm install controller-prod \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-system \
   --set controller.gatewayClassName=cloudflare-tunnel-prod \
   --set cloudflare.tunnelId="PROD_TUNNEL_ID" \
@@ -114,7 +114,7 @@ helm install controller-prod \
 
 # Second tunnel for staging apps
 helm install controller-staging \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-system \
   --set controller.gatewayClassName=cloudflare-tunnel-staging \
   --set cloudflare.tunnelId="STAGING_TUNNEL_ID" \

--- a/charts/cloudflare-tunnel-gateway-controller/TROUBLESHOOTING.md
+++ b/charts/cloudflare-tunnel-gateway-controller/TROUBLESHOOTING.md
@@ -53,7 +53,7 @@ helm lint charts/cloudflare-tunnel-gateway-controller -f my-values.yaml
 
 # Dry-run installation to catch errors
 helm install --dry-run --debug my-release \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   -f my-values.yaml
 ```
 
@@ -66,7 +66,7 @@ helm install --dry-run --debug my-release \
 ```bash
 # Ensure you're using the correct OCI registry URL
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --version 0.1.0
 
 # For private registries, authenticate first
@@ -599,7 +599,7 @@ After updating:
 
 ```bash
 helm upgrade cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   -f values.yaml \
   -n cloudflare-tunnel-system
 

--- a/charts/cloudflare-tunnel-gateway-controller/examples/awg-sidecar-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/awg-sidecar-values.yaml
@@ -22,7 +22,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values awg-sidecar-values.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/examples/basic-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/basic-values.yaml
@@ -14,7 +14,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values basic-values.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/examples/external-secrets-operator.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/external-secrets-operator.yaml
@@ -20,7 +20,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values external-secrets-operator.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/examples/external-secrets-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/external-secrets-values.yaml
@@ -19,7 +19,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values external-secrets-values.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/examples/managed-cloudflared-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/managed-cloudflared-values.yaml
@@ -17,7 +17,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values managed-cloudflared-values.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/examples/production-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/production-values.yaml
@@ -26,7 +26,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values production-values.yaml


### PR DESCRIPTION
## Summary

Fix OCI artifact conflict where Helm chart was overwriting container image in GHCR. Both artifacts were published to the same path, making container image inaccessible.

## Changes

- Move Helm chart to `/chart` subpath in OCI registry
- Update all documentation references to new chart path
- Image: `ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller:VERSION`
- Chart: `oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart`

## Testing

- [ ] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [ ] Manual testing completed (if applicable)

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed)

## Versioning

- [ ] Chart version bumped in `charts/*/Chart.yaml` (if chart changes)
- [ ] App version matches Chart appVersion (for releases)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

Related feature request for Helm OCI index support: https://github.com/helm/helm/issues/31582

Tested OCI index approach locally but Helm CLI doesn't support selecting artifacts from OCI Image Index by artifactType.