### PR TITLE
ci(chart): migrate Helm chart to oras push with new OCI path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -408,21 +408,30 @@ jobs:
           CHART_PATH="charts/cloudflare-tunnel-gateway-controller"
           CHART_NAME="cloudflare-tunnel-gateway-controller"
           REGISTRY="ghcr.io/${{ github.repository_owner }}"
+          CHART_REPO="${REGISTRY}/${CHART_NAME}/chart"
 
           # Package chart
           helm package "${CHART_PATH}"
           CHART_FILE="${CHART_NAME}-${VERSION}.tgz"
 
-          # Push chart with helm (creates VERSION tag)
-          helm push "${CHART_FILE}" "oci://${REGISTRY}/${CHART_NAME}-chart"
+          # Extract Chart.yaml for config layer
+          tar --extract --gzip --file "${CHART_FILE}" "${CHART_NAME}/Chart.yaml"
 
-          echo "Chart pushed: oci://${REGISTRY}/${CHART_NAME}-chart:${VERSION}"
+          # Push chart using oras for full path control
+          # Media types per Helm OCI spec: https://helm.sh/docs/topics/registries/
+          oras push "${CHART_REPO}:${VERSION}" \
+            --config "${CHART_NAME}/Chart.yaml:application/vnd.cncf.helm.config.v1+json" \
+            "${CHART_FILE}:application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+
+          rm --recursive --force "${CHART_NAME}"
+
+          echo "Chart pushed: oci://${CHART_REPO}:${VERSION}"
 
           # Add additional semver tags (matching container image pattern)
           MAJOR_MINOR=$(echo "${VERSION}" | cut --delimiter=. --fields=1,2)
           MAJOR=$(echo "${VERSION}" | cut --delimiter=. --fields=1)
 
-          oras tag "${REGISTRY}/${CHART_NAME}-chart:${VERSION}" \
+          oras tag "${CHART_REPO}:${VERSION}" \
             "${MAJOR_MINOR}" \
             "${MAJOR}" \
             "latest"
@@ -434,14 +443,15 @@ jobs:
           CHART_NAME="cloudflare-tunnel-gateway-controller"
           CHART_PATH="charts/${CHART_NAME}"
           REGISTRY="ghcr.io/${{ github.repository_owner }}"
+          CHART_REPO="${REGISTRY}/${CHART_NAME}/chart"
 
           # Push artifacthub-repo.yml with special tag for verification
           # See: https://artifacthub.io/docs/topics/repositories/helm-charts/#oci-support
-          oras push "${REGISTRY}/${CHART_NAME}-chart:artifacthub.io" \
+          oras push "${CHART_REPO}:artifacthub.io" \
             --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
             "${CHART_PATH}/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml"
 
-          echo "Artifact Hub metadata pushed to: ${REGISTRY}/${CHART_NAME}-chart:artifacthub.io"
+          echo "Artifact Hub metadata pushed to: ${CHART_REPO}:artifacthub.io"
 
       - name: Sign Helm chart with cosign
         env:
@@ -450,15 +460,16 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           CHART_NAME="cloudflare-tunnel-gateway-controller"
           REGISTRY="ghcr.io/${{ github.repository_owner }}"
+          CHART_REPO="${REGISTRY}/${CHART_NAME}/chart"
 
           # Get chart digest for signing
-          CHART_DIGEST=$(oras manifest fetch "${REGISTRY}/${CHART_NAME}-chart:${VERSION}" --descriptor | jq -r '.digest')
+          CHART_DIGEST=$(oras manifest fetch "${CHART_REPO}:${VERSION}" --descriptor | jq --raw-output '.digest')
 
           # Sign the chart by digest (immutable reference)
-          echo "Signing ${REGISTRY}/${CHART_NAME}-chart@${CHART_DIGEST}"
-          cosign sign --yes "${REGISTRY}/${CHART_NAME}-chart@${CHART_DIGEST}"
+          echo "Signing ${CHART_REPO}@${CHART_DIGEST}"
+          cosign sign --yes "${CHART_REPO}@${CHART_DIGEST}"
 
-          echo "Chart signed: ${REGISTRY}/${CHART_NAME}-chart@${CHART_DIGEST}"
+          echo "Chart signed: ${CHART_REPO}@${CHART_DIGEST}"
 
       - name: Generate chart summary
         run: |
@@ -475,7 +486,7 @@ jobs:
             echo "### Installation"
             echo "\`\`\`bash"
             echo "helm install ${CHART_NAME} \\"
-            echo "  oci://ghcr.io/${{ github.repository_owner }}/${CHART_NAME}-chart \\"
+            echo "  oci://ghcr.io/${{ github.repository_owner }}/${CHART_NAME}/chart \\"
             echo "  --version ${VERSION}"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Release](https://img.shields.io/github/v/release/lexfrei/cloudflare-tunnel-gateway-controller)](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/releases)
 [![CI](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/actions/workflows/pr.yaml/badge.svg)](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/actions/workflows/pr.yaml)
 
-> **Note:** The Helm chart is published to a separate OCI path (`cloudflare-tunnel-gateway-controller-chart`) to avoid conflicts with container image tags. Available tags: `VERSION`, `MAJOR.MINOR`, `MAJOR`, `latest`.
+> **Note:** The Helm chart is published at `cloudflare-tunnel-gateway-controller/chart` subpath because Helm CLI doesn't support OCI Image Index with `artifactType` selection. Once [helm/helm#31582](https://github.com/helm/helm/issues/31582) is resolved, the chart will be available at `oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller`. Available tags: `VERSION`, `MAJOR.MINOR`, `MAJOR`, `latest`.
 
 Kubernetes controller implementing Gateway API for Cloudflare Tunnel.
 
@@ -30,7 +30,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/downloa
 
 # 2. Install the controller
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-tunnel-system \
   --create-namespace \
   --set config.tunnelID=YOUR_TUNNEL_ID \
@@ -94,7 +94,7 @@ Helm is the only supported installation method. It handles CRD installation, RBA
 
 ```bash
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-tunnel-system \
   --create-namespace \
   --values values.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/README.md
+++ b/charts/cloudflare-tunnel-gateway-controller/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel-gateway-controller
 
-> **Note:** The Helm chart is published to a separate OCI path (`cloudflare-tunnel-gateway-controller-chart`) because Helm CLI doesn't support OCI Image Index with `artifactType` selection. Once [helm/helm#31582](https://github.com/helm/helm/issues/31582) is resolved, the chart will be available at `oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller`.
+> **Note:** The Helm chart is published at `cloudflare-tunnel-gateway-controller/chart` subpath because Helm CLI doesn't support OCI Image Index with `artifactType` selection. Once [helm/helm#31582](https://github.com/helm/helm/issues/31582) is resolved, the chart will be available at `oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller`. Available tags: `VERSION`, `MAJOR.MINOR`, `MAJOR`, `latest`.
 
 [![Release](https://img.shields.io/github/v/release/lexfrei/cloudflare-tunnel-gateway-controller)](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/releases)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudflare-tunnel-gateway-controller)](https://artifacthub.io/packages/search?repo=cloudflare-tunnel-gateway-controller)
@@ -75,7 +75,7 @@ The **Account Settings: Read** permission is required for auto-detecting the Acc
 
 ```bash
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --version 0.1.0 \
   --namespace cloudflare-tunnel-system \
   --create-namespace \
@@ -153,7 +153,7 @@ To use multiple Cloudflare Tunnels in the same cluster, deploy multiple instance
 ```bash
 # First tunnel for production apps
 helm install controller-prod \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-system \
   --set controller.gatewayClassName=cloudflare-tunnel-prod \
   --set cloudflare.tunnelId="PROD_TUNNEL_ID" \
@@ -161,7 +161,7 @@ helm install controller-prod \
 
 # Second tunnel for staging apps
 helm install controller-staging \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-system \
   --set controller.gatewayClassName=cloudflare-tunnel-staging \
   --set cloudflare.tunnelId="STAGING_TUNNEL_ID" \

--- a/charts/cloudflare-tunnel-gateway-controller/README.md.gotmpl
+++ b/charts/cloudflare-tunnel-gateway-controller/README.md.gotmpl
@@ -1,6 +1,6 @@
 {{ template "chart.header" . }}
 
-> **Note:** The Helm chart is published to a separate OCI path (`cloudflare-tunnel-gateway-controller-chart`) because Helm CLI doesn't support OCI Image Index with `artifactType` selection. Once [helm/helm#31582](https://github.com/helm/helm/issues/31582) is resolved, the chart will be available at `oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller`.
+> **Note:** The Helm chart is published at `cloudflare-tunnel-gateway-controller/chart` subpath because Helm CLI doesn't support OCI Image Index with `artifactType` selection. Once [helm/helm#31582](https://github.com/helm/helm/issues/31582) is resolved, the chart will be available at `oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller`. Available tags: `VERSION`, `MAJOR.MINOR`, `MAJOR`, `latest`.
 
 {{ template "chart.deprecationWarning" . }}
 
@@ -69,7 +69,7 @@ The **Account Settings: Read** permission is required for auto-detecting the Acc
 
 ```bash
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --version {{ template "chart.version" . }} \
   --namespace cloudflare-tunnel-system \
   --create-namespace \
@@ -147,7 +147,7 @@ To use multiple Cloudflare Tunnels in the same cluster, deploy multiple instance
 ```bash
 # First tunnel for production apps
 helm install controller-prod \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-system \
   --set controller.gatewayClassName=cloudflare-tunnel-prod \
   --set cloudflare.tunnelId="PROD_TUNNEL_ID" \
@@ -155,7 +155,7 @@ helm install controller-prod \
 
 # Second tunnel for staging apps
 helm install controller-staging \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-system \
   --set controller.gatewayClassName=cloudflare-tunnel-staging \
   --set cloudflare.tunnelId="STAGING_TUNNEL_ID" \

--- a/charts/cloudflare-tunnel-gateway-controller/examples/awg-sidecar-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/awg-sidecar-values.yaml
@@ -22,7 +22,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values awg-sidecar-values.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/examples/basic-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/basic-values.yaml
@@ -14,7 +14,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values basic-values.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/examples/external-secrets-operator.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/external-secrets-operator.yaml
@@ -20,7 +20,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values external-secrets-operator.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/examples/external-secrets-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/external-secrets-values.yaml
@@ -19,7 +19,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values external-secrets-values.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/examples/managed-cloudflared-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/managed-cloudflared-values.yaml
@@ -17,7 +17,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values managed-cloudflared-values.yaml

--- a/charts/cloudflare-tunnel-gateway-controller/examples/production-values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/examples/production-values.yaml
@@ -26,7 +26,7 @@
 #
 # Usage:
 #   helm install cloudflare-tunnel-gateway-controller \
-#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+#     oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
 #     --namespace cloudflare-tunnel-system \
 #     --create-namespace \
 #     --values production-values.yaml

--- a/docs/AWG_QUICKSTART.md
+++ b/docs/AWG_QUICKSTART.md
@@ -115,7 +115,7 @@ Install the controller:
 
 ```bash
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --namespace cloudflare-tunnel-system \
   --values awg-values.yaml
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -53,7 +53,7 @@ helm lint charts/cloudflare-tunnel-gateway-controller -f my-values.yaml
 
 # Dry-run installation to catch errors
 helm install --dry-run --debug my-release \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   -f my-values.yaml
 ```
 
@@ -66,7 +66,7 @@ helm install --dry-run --debug my-release \
 ```bash
 # Ensure you're using the correct OCI registry URL
 helm install cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   --version 0.1.0
 
 # For private registries, authenticate first
@@ -626,7 +626,7 @@ After updating:
 
 ```bash
 helm upgrade cloudflare-tunnel-gateway-controller \
-  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart \
+  oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart \
   -f values.yaml \
   -n cloudflare-tunnel-system
 


### PR DESCRIPTION
## Summary

- Migrate from `helm push` to `oras push` for full control over OCI artifact path
- Fix `oras tag` and `cosign sign` failures caused by incorrect path resolution
- Update all documentation references to new chart path

## Changes

**Old path:** `ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-chart/cloudflare-tunnel-gateway-controller:VERSION`
**New path:** `ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart:VERSION`

The `helm push` command creates a nested path with the chart name, which caused `oras tag` and `cosign` to fail because they tried to access a non-existent path. Using `oras push` gives full control over the OCI path.

## Test plan

- [ ] Merge and create v0.7.2 tag
- [ ] Verify chart is published to correct path
- [ ] Verify `oras tag` creates additional tags (MAJOR.MINOR, MAJOR, latest)
- [ ] Verify `cosign sign` successfully signs the chart
- [ ] Verify `helm install` works with new path