### PR TITLE
fix(chart): convert config blob to JSON for Helm OCI compatibility

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -414,13 +414,16 @@ jobs:
           helm package "${CHART_PATH}"
           CHART_FILE="${CHART_NAME}-${VERSION}.tgz"
 
-          # Extract Chart.yaml for config layer
+          # Extract Chart.yaml and convert to JSON for config layer
+          # Helm OCI spec requires JSON config blob (helm does json.Marshal(metadata))
+          # See: https://github.com/helm/helm/blob/main/pkg/registry/client.go
           tar --extract --gzip --file "${CHART_FILE}" "${CHART_NAME}/Chart.yaml"
+          yq eval --output-format=json "${CHART_NAME}/Chart.yaml" > "${CHART_NAME}/config.json"
 
           # Push chart using oras for full path control
           # Media types per Helm OCI spec: https://helm.sh/docs/topics/registries/
           oras push "${CHART_REPO}:${VERSION}" \
-            --config "${CHART_NAME}/Chart.yaml:application/vnd.cncf.helm.config.v1+json" \
+            --config "${CHART_NAME}/config.json:application/vnd.cncf.helm.config.v1+json" \
             "${CHART_FILE}:application/vnd.cncf.helm.chart.content.v1.tar+gzip"
 
           rm --recursive --force "${CHART_NAME}"


### PR DESCRIPTION
## Summary

- Fix Helm chart installation failure caused by YAML config blob instead of JSON
- Convert Chart.yaml to JSON using yq before pushing to OCI registry
- Helm OCI spec requires JSON config blob (helm uses json.Marshal internally)

## Problem

`helm install` failed with:
```
invalid character 'a' looking for beginning of value
```

Root cause: oras push was using Chart.yaml (YAML) directly as config blob, but Helm expects JSON.

## Solution

Use `yq eval --output-format=json` to convert Chart.yaml to JSON before pushing.

## Test plan

- [ ] Merge and create v0.7.3 tag
- [ ] Verify chart installation works: `helm install test oci://ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller/chart --version 0.7.3`