### PR TITLE
fix(helm): pass registry client to Pull action for Helm v4

### DIFF
--- a/internal/helm/manager.go
+++ b/internal/helm/manager.go
@@ -104,7 +104,11 @@ func (m *Manager) LoadChart(_ context.Context, chartRef, version string) (chart.
 
 	slog.Info("pulling chart from registry", "ref", chartRef, "version", version)
 
-	pullClient := action.NewPull(action.WithConfig(new(action.Configuration)))
+	pullConfig := &action.Configuration{
+		RegistryClient: m.registryClient,
+	}
+
+	pullClient := action.NewPull(action.WithConfig(pullConfig))
 	pullClient.Settings = m.settings
 	pullClient.Version = version
 	pullClient.DestDir = os.TempDir()


### PR DESCRIPTION
## Summary

- Fix OCI registry client initialization for Helm v4 SDK
- Pass `RegistryClient` to `action.Configuration` when creating Pull action
- Resolves "missing registry client" error when pulling charts from OCI registries

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` passes with 0 issues
- [x] `go test -race ./internal/helm/...` passes
- [x] Container image built and pushed to `ttl.sh/cloudflare-tunnel-gateway-controller:1h` for testing