### PR TITLE
ci(release): auto-generate changelog from conventional commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -439,16 +439,20 @@ jobs:
             fi
           done <<< "$COMMITS"
 
-          # Convert to YAML string for annotation
-          CHANGELOG_YAML=$(cat "$CHANGELOG_FILE")
-          rm "$CHANGELOG_FILE"
-
-          # Save to output using heredoc
-          {
-            echo "yaml<<EOF"
-            echo "$CHANGELOG_YAML"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          # Check if changelog is empty (only chore/ci/test commits)
+          if [ "$(cat "$CHANGELOG_FILE")" = "[]" ]; then
+            echo "No user-facing changes found, skipping changelog annotation"
+            rm "$CHANGELOG_FILE"
+            echo "yaml=" >> "$GITHUB_OUTPUT"
+          else
+            CHANGELOG_YAML=$(cat "$CHANGELOG_FILE")
+            rm "$CHANGELOG_FILE"
+            {
+              echo "yaml<<EOF"
+              echo "$CHANGELOG_YAML"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Update Chart version and changelog
         env:
@@ -627,6 +631,11 @@ jobs:
               fi
             fi
           done <<< "$COMMITS"
+
+          # Fallback for empty changelog
+          if [ -z "$CHANGELOG_SECTION" ]; then
+            CHANGELOG_SECTION="No user-facing changes in this release."
+          fi
 
           # Build release notes
           {


### PR DESCRIPTION
## Summary

Implements automatic changelog generation from conventional commits for Helm chart releases.

## Changes

- Add changelog generation step in publish-chart job using yq for safe YAML handling
- Generate `artifacthub.io/changes` annotation from commits between releases
- Add release notes generation in create-release job with emoji formatting
- Handle empty changelog gracefully (skip annotation / show fallback message)

Mapping:
- `feat` → added (✨)
- `fix` → fixed (🐛)
- `security` → security (🔒)
- `refactor`, `docs`, `perf`, `build` → changed (🔄)

Closes #33

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [x] Manual testing completed (if applicable)

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

Uses yq with `strenv()` function for safe YAML generation, properly handling special characters in commit messages (colons, quotes, hashes).