### PR TITLE
fix(docs): use GitHub Actions Pages deployment with mike

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ on:
         required: false
 
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 
@@ -34,8 +34,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Deploy Documentation
+  build:
+    name: Build Documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -43,10 +43,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git
+      - name: Checkout gh-pages branch
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages:gh-pages || true
+          git worktree add gh-pages-branch gh-pages || git worktree add gh-pages-branch --detach
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -57,6 +57,11 @@ jobs:
 
       - name: Install dependencies
         run: pip install --requirement requirements-docs.txt
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Determine version and alias
         id: version
@@ -73,18 +78,39 @@ jobs:
             echo "alias=" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Deploy with mike
+      - name: Deploy with mike (local)
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           ALIAS="${{ steps.version.outputs.alias }}"
 
           if [[ -n "$ALIAS" ]]; then
-            mike deploy --push --update-aliases "${VERSION}" "${ALIAS}"
+            mike deploy --update-aliases "${VERSION}" "${ALIAS}"
+            mike set-default latest
           else
-            mike deploy --push "${VERSION}"
+            mike deploy "${VERSION}"
           fi
 
-      - name: Set default version
-        if: steps.version.outputs.alias == 'latest'
+      - name: Prepare artifact
         run: |
-          mike set-default --push latest
+          # mike builds into gh-pages branch worktree
+          # Copy the built site to artifact directory
+          mkdir -p artifact
+          git -C gh-pages-branch checkout -- . 2>/dev/null || true
+          cp -r gh-pages-branch/* artifact/ 2>/dev/null || cp -r site/* artifact/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: artifact/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Pull Request

## Summary

Fix documentation deployment to work with GitHub Actions workflow-based Pages deployment.

## Changes

- Rewrite docs.yaml to use mike with GitHub Actions Pages workflow deployment
- Checkout gh-pages branch as worktree to preserve existing versions
- Use upload-pages-artifact and deploy-pages actions instead of mike --push

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [ ] Manual testing completed (if applicable)

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

Previous workflow used `mike deploy --push` which pushes to gh-pages branch, but GitHub Pages was configured with workflow-based deployment (build_type: workflow). This fix uses mike locally and deploys via GitHub Actions artifact upload.