### PR TITLE
fix(docs): add 404 redirect for versionless URLs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -66,13 +66,14 @@ jobs:
       - name: Determine version and alias
         id: version
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
-            echo "alias=${{ github.event.inputs.alias }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.ref_type }}" == "tag" ]]; then
+          # Check if running from a tag (works for both push and workflow_dispatch)
+          if [[ "$GITHUB_REF_NAME" == v* ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "alias=latest" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.version }}" != "dev" ]]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "alias=${{ github.event.inputs.alias }}" >> "$GITHUB_OUTPUT"
           else
             echo "version=dev" >> "$GITHUB_OUTPUT"
             echo "alias=" >> "$GITHUB_OUTPUT"
@@ -97,6 +98,8 @@ jobs:
           mkdir -p artifact
           git -C gh-pages-branch checkout -- . 2>/dev/null || true
           cp -r gh-pages-branch/* artifact/ 2>/dev/null || cp -r site/* artifact/
+          # Copy 404.html to root for GitHub Pages fallback redirects
+          cp docs/404.html artifact/404.html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <script>
+    // Redirect non-versioned paths to /latest/
+    var path = window.location.pathname;
+    var defined = ['latest', 'dev', '0.8.0', '0.9.0', '0.9.1', '0.9.2', '1.0.0'];
+    var firstSegment = path.split('/').filter(Boolean)[0];
+
+    // If path doesn't start with a known version, redirect to /latest/
+    if (firstSegment && defined.indexOf(firstSegment) === -1) {
+      window.location.replace('/latest' + path + window.location.search + window.location.hash);
+    }
+  </script>
+</head>
+<body>
+  <p>Redirecting...</p>
+  <p>If not redirected, go to <a href="/latest/">documentation</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add custom 404.html that redirects non-versioned paths (e.g., `/getting-started/`) to `/latest/` prefix
- Fix docs workflow version detection to correctly identify tag refs when running via workflow_dispatch
- Keep README links clean without `/latest/` prefix since 404 redirect handles them

## Changes

- `docs/404.html` - Custom 404 page with JS redirect logic
- `.github/workflows/docs.yaml` - Copy 404.html to artifact, fix version detection
- `README.md` - Revert to clean URLs (404 redirect will handle them)

## Test plan

- [ ] Verify `/getting-started/` redirects to `/latest/getting-started/`
- [ ] Verify `/latest/getting-started/` works directly
- [ ] Verify version-specific paths like `/0.9.0/` work
- [ ] Verify workflow correctly detects version from tag refs