### PR TITLE
fix(helm): use correct metadata map keys from Helm v4 SDK

### DIFF
--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -227,7 +227,7 @@ func (r *GatewayReconciler) upgradeCloudflaredIfNeeded(
 		return errors.Wrap(err, "failed to create chart accessor")
 	}
 
-	currentVersion := chartAccessor.MetadataAsMap()["version"]
+	currentVersion := chartAccessor.MetadataAsMap()["Version"]
 	if currentVersion == latestVersion {
 		return nil
 	}

--- a/internal/helm/manager.go
+++ b/internal/helm/manager.go
@@ -279,8 +279,8 @@ func (m *Manager) recordChartInfo(ctx context.Context, loadedChart chart.Charter
 	}
 
 	metadata := accessor.MetadataAsMap()
-	name, _ := metadata["name"].(string)
-	version, _ := metadata["version"].(string)
-	appVersion, _ := metadata["appVersion"].(string)
+	name, _ := metadata["Name"].(string)
+	version, _ := metadata["Version"].(string)
+	appVersion, _ := metadata["AppVersion"].(string)
 	m.metrics.RecordHelmChartInfo(ctx, name, version, appVersion)
 }


### PR DESCRIPTION
# Pull Request

## Summary

Fix version comparison during cloudflared upgrades showing `from: null` in controller logs.

## Changes

- Use correct metadata map keys matching Helm v4's `structToMap()` output
- Helm v4 returns Go struct field names as keys (e.g., `Version` instead of `version`)

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

Root cause: Helm v4's internal `structToMap()` function uses `field.Name` from Go reflection, which returns PascalCase field names. The code was using camelCase keys (`version`, `name`, `appVersion`) which returned nil.