### PR TITLE
fix(chart): regenerate README.md with helm-docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,9 @@ helm package charts/cloudflare-tunnel-gateway-controller
 # Run helm-unittest
 helm unittest charts/cloudflare-tunnel-gateway-controller
 
+# Generate README from values.yaml (REQUIRED before commit)
+helm-docs charts/cloudflare-tunnel-gateway-controller
+
 # Lint chart
 helm lint charts/cloudflare-tunnel-gateway-controller
 
@@ -264,6 +267,9 @@ Before creating a PR, verify all checklist items from `.github/pull_request_temp
    - All tests pass locally (`go test ./...`)
    - Linters pass locally (`golangci-lint run`)
    - Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
+   - Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller`)
+   - Helm lint passes (`helm lint charts/cloudflare-tunnel-gateway-controller`)
+   - Helm README is up to date (`helm-docs charts/cloudflare-tunnel-gateway-controller`)
    - Manual testing completed (if applicable)
 
 2. **Documentation**

--- a/charts/cloudflare-tunnel-gateway-controller/README.md
+++ b/charts/cloudflare-tunnel-gateway-controller/README.md
@@ -228,16 +228,22 @@ spec:
 | fullnameOverride | string | `""` | Override the full release name |
 | gatewayClass | object | `{"create":true}` | GatewayClass configuration |
 | gatewayClass.create | bool | `true` | Create GatewayClass resource |
-| gatewayClassConfig | object | `{"cloudflareCredentialsSecretRef":{"key":"","name":"","namespace":""},"cloudflared":{"awg":{"interfacePrefix":"awg-cfd","secretName":""},"enabled":true,"namespace":"cloudflare-tunnel-system","protocol":"","replicas":1},"create":false,"name":"","tunnelID":"","tunnelTokenSecretRef":{"key":"","name":"","namespace":""}}` | GatewayClassConfig configuration This is the main configuration section for Cloudflare Tunnel settings. All tunnel-specific settings are now in GatewayClassConfig CRD. |
+| gatewayClassConfig | object | `{"cloudflareCredentialsSecretRef":{"key":"","name":"","namespace":""},"cloudflared":{"awg":{"interfacePrefix":"awg-cfd","secretName":""},"enabled":true,"livenessProbe":{"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":20,"successThreshold":1,"timeoutSeconds":5},"namespace":"cloudflare-tunnel-system","protocol":"","replicas":1},"create":false,"name":"","tunnelID":"","tunnelTokenSecretRef":{"key":"","name":"","namespace":""}}` | GatewayClassConfig configuration This is the main configuration section for Cloudflare Tunnel settings. All tunnel-specific settings are now in GatewayClassConfig CRD. |
 | gatewayClassConfig.cloudflareCredentialsSecretRef | object | `{"key":"","name":"","namespace":""}` | Reference to Secret containing Cloudflare API credentials (REQUIRED) The Secret must contain an "api-token" key with a valid Cloudflare API token. Optionally, it can contain an "account-id" key; if not present, account ID is auto-detected. |
 | gatewayClassConfig.cloudflareCredentialsSecretRef.key | string | `""` | Key in the Secret containing the API token (defaults to "api-token") |
 | gatewayClassConfig.cloudflareCredentialsSecretRef.name | string | `""` | Name of the Secret containing API credentials |
 | gatewayClassConfig.cloudflareCredentialsSecretRef.namespace | string | `""` | Namespace of the Secret (defaults to release namespace) |
-| gatewayClassConfig.cloudflared | object | `{"awg":{"interfacePrefix":"awg-cfd","secretName":""},"enabled":true,"namespace":"cloudflare-tunnel-system","protocol":"","replicas":1}` | Cloudflared deployment configuration |
+| gatewayClassConfig.cloudflared | object | `{"awg":{"interfacePrefix":"awg-cfd","secretName":""},"enabled":true,"livenessProbe":{"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":20,"successThreshold":1,"timeoutSeconds":5},"namespace":"cloudflare-tunnel-system","protocol":"","replicas":1}` | Cloudflared deployment configuration |
 | gatewayClassConfig.cloudflared.awg | object | `{"interfacePrefix":"awg-cfd","secretName":""}` | AmneziaWG sidecar configuration |
 | gatewayClassConfig.cloudflared.awg.interfacePrefix | string | `"awg-cfd"` | AWG interface name prefix (kernel auto-numbers: prefix0, prefix1, etc.) |
 | gatewayClassConfig.cloudflared.awg.secretName | string | `""` | Secret name containing AWG config (enables AWG sidecar) |
 | gatewayClassConfig.cloudflared.enabled | bool | `true` | Enable cloudflared deployment management (default: true) |
+| gatewayClassConfig.cloudflared.livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":20,"successThreshold":1,"timeoutSeconds":5}` | Liveness probe configuration for cloudflared |
+| gatewayClassConfig.cloudflared.livenessProbe.failureThreshold | int | `3` | Number of failures before container restart |
+| gatewayClassConfig.cloudflared.livenessProbe.initialDelaySeconds | int | `30` | Seconds before liveness probe is initiated |
+| gatewayClassConfig.cloudflared.livenessProbe.periodSeconds | int | `20` | How often to perform the probe |
+| gatewayClassConfig.cloudflared.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for probe to be considered successful |
+| gatewayClassConfig.cloudflared.livenessProbe.timeoutSeconds | int | `5` | Seconds after which probe times out |
 | gatewayClassConfig.cloudflared.namespace | string | `"cloudflare-tunnel-system"` | Namespace for cloudflared deployment |
 | gatewayClassConfig.cloudflared.protocol | string | `""` | Transport protocol (auto, quic, http2) |
 | gatewayClassConfig.cloudflared.replicas | int | `1` | Number of cloudflared replicas |


### PR DESCRIPTION
## Summary

Fix missing livenessProbe documentation in Helm chart README.md and prevent future occurrences by adding helm-docs to pre-commit checks.

## Changes

- Regenerate README.md with helm-docs to include livenessProbe parameters
- Add helm-docs, helm unittest, and helm lint to CLAUDE.md Pre-PR Checklist

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

## Documentation

- [x] README updated (if needed)
- [ ] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [ ] Breaking changes documented (if any)
- [ ] Related issues referenced (if any)

## Additional Notes

This fixes a CI failure in PR #98 where Lint Chart step failed due to outdated README.md.