### PR TITLE
fix(lint): unblock Renovate automerge by fixing goconst on master

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
     goconst:
       min-len: 2
       min-occurrences: 2
+      ignore-tests: true
     gocritic:
       disabled-checks:
         - dupImport

--- a/internal/cfmetrics/metrics.go
+++ b/internal/cfmetrics/metrics.go
@@ -8,6 +8,16 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// Prometheus label names used across metric definitions.
+const (
+	labelStatus    = "status"
+	labelType      = "type"
+	labelMethod    = "method"
+	labelOperation = "operation"
+	labelErrorType = "error_type"
+	labelResource  = "resource"
+)
+
 // Collector provides metrics recording interface.
 // This allows components to record metrics without direct prometheus dependency.
 //
@@ -152,14 +162,14 @@ func (c *prometheusCollector) initSyncMetrics() {
 			Help:    "Duration of route synchronization to Cloudflare",
 			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
 		},
-		[]string{"status"},
+		[]string{labelStatus},
 	)
 	c.syncedRoutes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cftunnel_synced_routes",
 			Help: "Number of routes synced by type",
 		},
-		[]string{"type"},
+		[]string{labelType},
 	)
 	c.ingressRulesTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -172,14 +182,14 @@ func (c *prometheusCollector) initSyncMetrics() {
 			Name: "cftunnel_failed_backend_refs",
 			Help: "Number of failed backend references",
 		},
-		[]string{"type"},
+		[]string{labelType},
 	)
 	c.syncErrorsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cftunnel_sync_errors_total",
 			Help: "Total sync errors by type",
 		},
-		[]string{"error_type"},
+		[]string{labelErrorType},
 	)
 }
 
@@ -190,21 +200,21 @@ func (c *prometheusCollector) initAPIMetrics() {
 			Help:    "Duration of Cloudflare API calls",
 			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
 		},
-		[]string{"method", "resource"},
+		[]string{labelMethod, labelResource},
 	)
 	c.apiCallsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cftunnel_cloudflare_api_calls_total",
 			Help: "Total Cloudflare API calls",
 		},
-		[]string{"method", "resource", "status"},
+		[]string{labelMethod, labelResource, labelStatus},
 	)
 	c.apiErrorsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cftunnel_cloudflare_api_errors_total",
 			Help: "Total Cloudflare API errors by type",
 		},
-		[]string{"method", "error_type"},
+		[]string{labelMethod, labelErrorType},
 	)
 }
 
@@ -215,21 +225,21 @@ func (c *prometheusCollector) initHelmMetrics() {
 			Help:    "Duration of Helm operations",
 			Buckets: []float64{0.5, 1, 2.5, 5, 10, 30, 60},
 		},
-		[]string{"operation"},
+		[]string{labelOperation},
 	)
 	c.helmOpsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cftunnel_helm_operations_total",
 			Help: "Total Helm operations",
 		},
-		[]string{"operation", "status"},
+		[]string{labelOperation, labelStatus},
 	)
 	c.helmErrorsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cftunnel_helm_errors_total",
 			Help: "Total Helm errors by type",
 		},
-		[]string{"operation", "error_type"},
+		[]string{labelOperation, labelErrorType},
 	)
 	c.helmChartInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -247,14 +257,14 @@ func (c *prometheusCollector) initIngressMetrics() {
 			Help:    "Duration of ingress rule building",
 			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5},
 		},
-		[]string{"type"},
+		[]string{labelType},
 	)
 	c.backendRefValidation = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cftunnel_backend_ref_validation_total",
 			Help: "Backend reference validation results",
 		},
-		[]string{"type", "result", "reason"},
+		[]string{labelType, "result", "reason"},
 	)
 }
 

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -46,6 +46,10 @@ const (
 	// msgReferencesResolved is the standard message for ResolvedRefs condition.
 	msgReferencesResolved = "References resolved"
 
+	// msgGatewayAccepted is the standard message for Accepted/Programmed conditions
+	// on Gateways managed by this controller.
+	msgGatewayAccepted = "Gateway accepted by cloudflare-tunnel controller"
+
 	// kindSecret is the resource kind for Kubernetes Secrets.
 	kindSecret = "Secret"
 
@@ -427,7 +431,7 @@ func (r *GatewayReconciler) updateStatus(
 				ObservedGeneration: freshGateway.Generation,
 				LastTransitionTime: now,
 				Reason:             string(gatewayv1.GatewayReasonAccepted),
-				Message:            "Gateway accepted by cloudflare-tunnel controller",
+				Message:            msgGatewayAccepted,
 			},
 			{
 				Type:               string(gatewayv1.GatewayConditionProgrammed),
@@ -593,7 +597,7 @@ func (r *GatewayReconciler) setCloudflaredErrorStatus(
 				ObservedGeneration: freshGateway.Generation,
 				LastTransitionTime: now,
 				Reason:             string(gatewayv1.GatewayReasonAccepted),
-				Message:            "Gateway accepted by cloudflare-tunnel controller",
+				Message:            msgGatewayAccepted,
 			},
 			{
 				Type:               string(gatewayv1.GatewayConditionProgrammed),

--- a/internal/helm/cloudflared.go
+++ b/internal/helm/cloudflared.go
@@ -1,5 +1,25 @@
 package helm
 
+// Helm values map keys used when assembling cloudflared chart values.
+const (
+	keyName            = "name"
+	keyImage           = "image"
+	keyCommand         = "command"
+	keyShellFlag       = "-c"
+	keySecurityContext = "securityContext"
+	keyRunAsUser       = "runAsUser"
+	keyRunAsNonRoot    = "runAsNonRoot"
+	keyMountPath       = "mountPath"
+	keyMemory          = "memory"
+	keyShell           = "sh"
+
+	volNameAWGConfig  = "awg-config"
+	volNameAWGRuntime = "awg-runtime"
+	volNameTunDevice  = "tun-device"
+
+	pathDevNetTun = "/dev/net/tun"
+)
+
 // CloudflaredValues holds configuration for cloudflare-tunnel Helm chart.
 type CloudflaredValues struct {
 	TunnelToken   string
@@ -278,78 +298,78 @@ fi`
 	return map[string]any{
 		"initContainers": []any{
 			map[string]any{
-				"name":  "wait-for-awg",
-				"image": "busybox:1.36",
-				"command": []any{
-					"sh", "-c", "echo 'Waiting for AWG...' && sleep 5 && echo 'Done'",
+				keyName:  "wait-for-awg",
+				keyImage: "busybox:1.36",
+				keyCommand: []any{
+					keyShell, keyShellFlag, "echo 'Waiting for AWG...' && sleep 5 && echo 'Done'",
 				},
-				"securityContext": map[string]any{
-					"runAsUser":    0,
-					"runAsNonRoot": false,
+				keySecurityContext: map[string]any{
+					keyRunAsUser:    0,
+					keyRunAsNonRoot: false,
 				},
 			},
 		},
 		"containers": []any{
 			map[string]any{
-				"name":            "amneziawg",
-				"image":           "ghcr.io/zeozeozeo/amneziawg-client:latest",
+				keyName:           "amneziawg",
+				keyImage:          "ghcr.io/zeozeozeo/amneziawg-client:latest",
 				"imagePullPolicy": "IfNotPresent",
 				"stdin":           true,
 				"tty":             true,
-				"command":         []any{"sh", "-c", wrapperScript},
-				"securityContext": map[string]any{
-					"privileged":   true,
-					"runAsUser":    0,
-					"runAsNonRoot": false,
+				keyCommand:        []any{keyShell, keyShellFlag, wrapperScript},
+				keySecurityContext: map[string]any{
+					"privileged":    true,
+					keyRunAsUser:    0,
+					keyRunAsNonRoot: false,
 				},
 				"lifecycle": map[string]any{
 					"preStop": map[string]any{
 						"exec": map[string]any{
-							"command": []any{"sh", "-c", preStopScript},
+							keyCommand: []any{keyShell, keyShellFlag, preStopScript},
 						},
 					},
 				},
 				"volumeMounts": []any{
 					map[string]any{
-						"name":      "awg-config",
-						"mountPath": "/config",
-						"readOnly":  true,
+						keyName:      volNameAWGConfig,
+						keyMountPath: "/config",
+						"readOnly":   true,
 					},
 					map[string]any{
-						"name":      "awg-runtime",
-						"mountPath": "/run/awg",
+						keyName:      volNameAWGRuntime,
+						keyMountPath: "/run/awg",
 					},
 					map[string]any{
-						"name":      "tun-device",
-						"mountPath": "/dev/net/tun",
+						keyName:      volNameTunDevice,
+						keyMountPath: pathDevNetTun,
 					},
 				},
 				"resources": map[string]any{
 					"requests": map[string]any{
-						"cpu":    "10m",
-						"memory": "32Mi",
+						"cpu":     "10m",
+						keyMemory: "32Mi",
 					},
 					"limits": map[string]any{
-						"memory": "64Mi",
+						keyMemory: "64Mi",
 					},
 				},
 			},
 		},
 		"extraVolumes": []any{
 			map[string]any{
-				"name": "awg-config",
+				keyName: volNameAWGConfig,
 				"secret": map[string]any{
 					"secretName": sidecar.ConfigSecretName,
 				},
 			},
 			map[string]any{
-				"name": "awg-runtime",
+				keyName: volNameAWGRuntime,
 				"emptyDir": map[string]any{
 					"medium": "Memory",
 				},
 			},
 			map[string]any{
-				"name": "tun-device",
+				keyName: volNameTunDevice,
 				"hostPath": map[string]any{
 					"path": "/dev/net/tun",
 					"type": "CharDevice",

--- a/internal/proxy/filter.go
+++ b/internal/proxy/filter.go
@@ -335,7 +335,7 @@ func (f *requestMirror) ProcessRequest(req *http.Request) *http.Response {
 			}
 		}()
 
-		resp, doErr := mirrorClient.Do(mirrorReq) //nolint:gosec // mirror URL comes from trusted config
+		resp, doErr := mirrorClient.Do(mirrorReq)
 		if doErr == nil {
 			resp.Body.Close()
 		}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -104,7 +104,6 @@ func (h *Handler) proxyToBackend(writer http.ResponseWriter, req *http.Request, 
 	// Per Gateway API spec: return 500 when backend refs cannot be resolved.
 	if result.BackendIdx < 0 || result.BackendIdx >= len(result.Rule.Backends) {
 		if len(result.Rule.Backends) > 0 {
-			//nolint:gosec // G706 false positive: backend_count is len() — not user input
 			slog.Warn("all backends have zero weight; no traffic routed per Gateway API spec",
 				slog.Int("backend_count", len(result.Rule.Backends)))
 		}


### PR DESCRIPTION
## Summary

`golangci-lint` Lint check is failing on master, which blocks every open Renovate PR from auto-merging. Root cause: `goconst` flags repeated string literals in test files (table-driven test fixtures legitimately repeat strings by design) and a handful of duplicated literals in production code, plus two `//nolint:gosec` directives that the linter no longer considers active.

## Changes

- Set `goconst.ignore-tests: true` so the linter skips `_test.go` files entirely (both reporting and counting). Test fixture strings like `"prod"`, `"example.com"`, or repeated header names in table-driven tests are no longer flagged.
- Remove two `//nolint:gosec` directives in `internal/proxy/filter.go` and `internal/proxy/handler.go` that `nolintlint` reported as unused — gosec no longer fires on the underlying lines.
- Hoist duplicated literals in production code to package-scope constants:
  - `internal/cfmetrics/metrics.go`: Prometheus label names (`status`, `type`, `method`, `operation`, `error_type`, `resource`)
  - `internal/controller/gateway_controller.go`: shared `Accepted`/`Programmed` condition message
  - `internal/helm/cloudflared.go`: cloudflared chart value keys (k8s pod spec field names + AWG sidecar identifiers)

`min-occurrences: 2` is preserved in the config so future genuine duplication in production code keeps getting flagged.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run` — 0 issues)
- [ ] Markdown linting passes (no markdown changes)
- [ ] Manual testing completed (lint-only fix; controller behaviour unchanged)

## Documentation

- [ ] README updated (not needed)
- [ ] Code comments added for complex logic (constants are self-documenting)
- [ ] CLAUDE.md updated (no workflow change)

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] No breaking changes
- [ ] Related issues referenced (none)

## Additional Notes

Once this lands, the 13 currently-open Renovate PRs should re-run CI and Renovate's `platformAutomerge` will pick them up.
