### PR TITLE
fix(ci): pass both ref and sha to upload-sarif

### DIFF
--- a/.github/workflows/pr-privileged.yaml
+++ b/.github/workflows/pr-privileged.yaml
@@ -32,7 +32,8 @@ jobs:
         with:
           sarif_file: trivy-fs-results.sarif
           category: trivy-filesystem
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          sha: ${{ github.event.workflow_run.head_sha }}
 
   notify:
     name: Notify PR


### PR DESCRIPTION
## Summary

`PR Privileged Actions` workflow has been failing on every PR since the workflow was created — 19 of the last 20 runs are red. The "Upload SARIF to GitHub Security" job aborts with `Both 'ref' and 'sha' are required if one of them is provided` because the workflow set `ref` to a commit SHA and never set `sha`. Result: Trivy security findings from PR scans were never uploaded to GitHub Code Scanning.

## Changes

- `.github/workflows/pr-privileged.yaml`: pass `head_branch` as `ref` and `head_sha` as `sha` per GitHub's documented pattern for `workflow_run`-triggered SARIF uploads.

The other jobs in the same workflow (label + comment) are unaffected and were already running fine.

## Testing

- [ ] All tests pass locally (no Go changes)
- [ ] Linters pass locally (no Go changes)
- [ ] Markdown linting passes (no markdown changes)
- [x] Manual testing: cannot test workflow_run dispatch from a feature branch; will verify on first PR run after merge

## Documentation

- [ ] README updated (not needed)
- [ ] Code comments added (single-line config change)
- [ ] CLAUDE.md updated (not needed)

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] No breaking changes
- [ ] Related issues referenced (none)

## Additional Notes

Cannot dry-run the privileged workflow before merge because `workflow_run` dispatches the default-branch copy of the workflow file. Verification happens on the first PR after this lands.
