### PR TITLE
fix(ci): use refs/pull/N/merge for upload-sarif ref

### DIFF
--- a/.github/workflows/pr-privileged.yaml
+++ b/.github/workflows/pr-privileged.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           sarif_file: trivy-fs-results.sarif
           category: trivy-filesystem
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: refs/pull/${{ github.event.workflow_run.pull_requests[0].number }}/merge
           sha: ${{ github.event.workflow_run.head_sha }}
 
   notify:


### PR DESCRIPTION
## Summary

#214 wired up both `ref` and `sha` for `upload-sarif`, fixing the "Both 'ref' and 'sha' are required" error. But the action now rejects the request with a fresh error:

```text
renovate/github-codeql-action-digest does not match /^refs\/(heads|pull|tags)\/.*$/.
```

`github.event.workflow_run.head_branch` returns a bare branch name (e.g., `renovate/foo`), but the SARIF upload endpoint requires a fully-qualified Git ref.

## Changes

- `.github/workflows/pr-privileged.yaml`: build the ref as `refs/pull/<N>/merge` from `pull_requests[0].number` in the workflow_run payload. This is the canonical form for PR-triggered uploads and correctly associates results with the PR in Code Scanning.

## Testing

- [ ] All tests pass locally (no Go changes)
- [ ] Linters pass locally (no Go changes)
- [ ] Markdown linting passes (no markdown changes)
- [x] Manual testing: verifies on first PR run after merge (workflow_run runs the default-branch copy)

## Documentation

- [ ] README updated (not needed)
- [ ] Code comments added (single-line config change)
- [ ] CLAUDE.md updated (not needed)

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] No breaking changes
- [ ] Related issues referenced (none)
