### PR TITLE
chore(renovate): run go mod vendor + import-path updates post-bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
   "labels": ["dependencies"],
   "platformAutomerge": true,
   "automergeStrategy": "squash",
-  "postUpdateOptions": ["gomodTidy"],
+  "postUpdateOptions": ["gomodTidy", "gomodVendor", "gomodUpdateImportPaths"],
   "packageRules": [
     {
       "description": "Automerge minor and patch updates",


### PR DESCRIPTION
## Summary

PR #208 (`renovate/kubernetes-monorepo`) and any other Renovate PR that bumps a Go module fails the Lint step with `inconsistent vendoring` — `go.mod` is updated but `vendor/modules.txt` is not, because the Renovate config only runs `go mod tidy` post-update, never `go mod vendor`.

## Changes

- `renovate.json`: add two `postUpdateOptions`:
  - `gomodVendor` — runs `go mod vendor` so `vendor/modules.txt` tracks `go.mod`
  - `gomodUpdateImportPaths` — rewrites import paths on major-version bumps (vX → vY)

## Testing

- [ ] All tests pass locally (config-only change)
- [ ] Linters pass locally (config-only change)
- [ ] Markdown linting passes (no markdown changes)
- [x] Manual verification: takes effect when Renovate next rebases gomod PRs

## Documentation

- [ ] README updated (not needed)
- [ ] Code comments added (config-only)
- [ ] CLAUDE.md updated (not needed)

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] No breaking changes
- [ ] Related issues referenced (none)
