### PR TITLE
fix(ci): source PR number from pr-metadata artifact for upload-sarif

### DIFF
--- a/.github/workflows/pr-privileged.yaml
+++ b/.github/workflows/pr-privileged.yaml
@@ -17,6 +17,23 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request'
     steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read and validate PR number
+        id: pr
+        run: |
+          PR_NUMBER=$(cat pr-number.txt)
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: Invalid PR number: $PR_NUMBER"
+            exit 1
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
       - name: Download SARIF artifact
         id: download-sarif
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -32,7 +49,7 @@ jobs:
         with:
           sarif_file: trivy-fs-results.sarif
           category: trivy-filesystem
-          ref: refs/pull/${{ github.event.workflow_run.pull_requests[0].number }}/merge
+          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
           sha: ${{ github.event.workflow_run.head_sha }}
 
   notify:


### PR DESCRIPTION
## Summary

After #214 and #215, SARIF upload still fails. Real error in the latest run:

```text
ref 'refs/pull//merge' not found in this repository
```

`github.event.workflow_run.pull_requests` is **empty** in the workflow_run payload for PRs opened by GitHub Apps (Renovate, Dependabot). So `pull_requests[0].number` expands to nothing and the ref becomes `refs/pull//merge`.

The `notify` job in the same workflow already sidesteps this by reading the PR number from a `pr-metadata` artifact written by `pr.yaml`. Apply the same pattern to `upload-sarif`.

## Changes

- `.github/workflows/pr-privileged.yaml`: download `pr-metadata` artifact, parse `pr-number.txt`, and use the resulting PR number to build `refs/pull/N/merge`. Robust for both user PRs and GitHub App PRs.

## Testing

- [ ] All tests pass locally (no Go changes)
- [ ] Linters pass locally (no Go changes)
- [ ] Markdown linting passes (no markdown changes)
- [x] Manual verification: takes effect on next PR run after merge

## Documentation

- [ ] README updated (not needed)
- [ ] Code comments added (mirrors existing pattern in same workflow)
- [ ] CLAUDE.md updated (not needed)

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] No breaking changes
- [ ] Related issues referenced (none)
