### PR TITLE
refactor(api): drop controller-runtime scheme.Builder dependency

### DIFF
--- a/api/v1alpha1/gatewayclassconfig_types.go
+++ b/api/v1alpha1/gatewayclassconfig_types.go
@@ -180,10 +180,6 @@ type GatewayClassConfigList struct {
 	Items []GatewayClassConfig `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&GatewayClassConfig{}, &GatewayClassConfigList{})
-}
-
 // IsCloudflaredEnabled returns whether cloudflared management is enabled.
 // Defaults to true if not explicitly set.
 func (c *GatewayClassConfigSpec) IsCloudflaredEnabled() bool {

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -1,8 +1,9 @@
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 //nolint:gochecknoglobals // kubebuilder-standard scheme registration
@@ -10,9 +11,16 @@ var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "cf.k8s.lex.la", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	// SchemeBuilder collects functions that register the API types with a runtime.Scheme.
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, &GatewayClassConfig{}, &GatewayClassConfigList{})
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+
+	return nil
+}


### PR DESCRIPTION
## Summary

`sigs.k8s.io/controller-runtime/pkg/scheme.Builder` is deprecated upstream (the godoc says: "This helper is only useful in api packages, but api packages should be easy to import and hence have minimal dependencies. Typically, these dependencies include only the standard library, k8s.io/apimachinery and other api packages."). The newer staticcheck pulled in by helm v4.2.0 + controller-runtime v0.24.1 flags it as SA1019 and fails Lint on those Renovate PRs.

## Changes

- `api/v1alpha1/groupversion_info.go`:
  - Drop `sigs.k8s.io/controller-runtime/pkg/scheme` import.
  - Build `SchemeBuilder` with `runtime.NewSchemeBuilder(addKnownTypes)`.
  - Register `GatewayClassConfig` and `GatewayClassConfigList` via `runtime.Scheme.AddKnownTypes` + `metav1.AddToGroupVersion` inside `addKnownTypes`.
- `api/v1alpha1/gatewayclassconfig_types.go`: remove the now-empty `init()` that used the old `SchemeBuilder.Register` helper.

The exported `SchemeBuilder` and `AddToScheme` names are preserved, so the controller's scheme registration in `cmd/controller` keeps working unchanged.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run` — 0 issues)
- [ ] Markdown linting passes (no markdown changes)
- [x] Manual testing: scheme registration verified by full controller test suite (`internal/controller/`)

## Documentation

- [ ] README updated (not needed)
- [ ] Code comments added (godoc preserved + clarified)
- [ ] CLAUDE.md updated (no workflow change)

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] No breaking changes (public API of v1alpha1 unchanged)
- [ ] Related issues referenced (none)
