### PR TITLE
chore(renovate): apply config migration (formatting only)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,32 +8,55 @@
     ":prConcurrentLimitNone",
     "helpers:pinGitHubActionDigests"
   ],
-  "labels": ["dependencies"],
+  "labels": [
+    "dependencies"
+  ],
   "platformAutomerge": true,
   "automergeStrategy": "squash",
-  "postUpdateOptions": ["gomodTidy", "gomodVendor", "gomodUpdateImportPaths"],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodVendor",
+    "gomodUpdateImportPaths"
+  ],
   "packageRules": [
     {
       "description": "Automerge minor and patch updates",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true
     },
     {
       "description": "Automerge all GitHub Actions updates including major",
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "automerge": true
     },
     {
       "description": "Pin Go version in Containerfile",
-      "matchManagers": ["dockerfile"],
-      "matchPackageNames": ["docker.io/library/golang"],
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchPackageNames": [
+        "docker.io/library/golang"
+      ],
       "versioning": "docker"
     },
     {
       "description": "Allow Renovate to bump go directive in go.mod",
-      "matchManagers": ["gomod"],
-      "matchDepNames": ["go"],
-      "matchDepTypes": ["golang"],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchDepTypes": [
+        "golang"
+      ],
       "rangeStrategy": "bump"
     }
   ],
@@ -41,7 +64,9 @@
     {
       "customType": "regex",
       "description": "Update Go version in GitHub Actions",
-      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "fileMatch": [
+        "^\\.github/workflows/.*\\.ya?ml$"
+      ],
       "matchStrings": [
         "go-version:\\s*['\"]?(?<currentValue>[\\d.]+)['\"]?"
       ],
@@ -51,7 +76,9 @@
     {
       "customType": "regex",
       "description": "Update versioned binaries in GitHub Actions workflows",
-      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "fileMatch": [
+        "^\\.github/workflows/.*\\.ya?ml$"
+      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s+[A-Z_]+VERSION=\"(?<currentValue>.*?)\""
       ]


### PR DESCRIPTION
## Summary

Renovate's Dependency Dashboard offered a Config Migration PR. Ran Renovate 43.150.0's `MigrationsService.run` locally against `renovate.json` to see what it wanted. The only diff is JSON formatting (single-element arrays expanded to one value per line). Parsed-and-deep-compared, the config is identical to what we already had.

Applying the formatting locally so Renovate stops offering the migration.

## Changes

- `renovate.json`: arrays reformatted to one-element-per-line (Renovate's preferred shape). No semantic config changes.

## Testing

- [ ] All tests pass locally (no Go changes)
- [ ] Linters pass locally (no Go changes)
- [ ] Markdown linting passes (no markdown changes)
- [x] Manual verification: `MigrationsService.run` output deep-equals input

## Documentation

- [ ] README updated (not needed)
- [ ] Code comments added (config-only)
- [ ] CLAUDE.md updated (not needed)

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] No breaking changes (semantically identical config)
- [ ] Related issues referenced (none)
