### PR TITLE
fix(ci): update yq v4.53.2 sha256 to match actual asset

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -420,7 +420,7 @@ jobs:
         run: |
           # renovate: datasource=github-releases depName=mikefarah/yq
           YQ_VERSION="4.53.2"
-          YQ_SHA256="a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7"
+          YQ_SHA256="d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b"
           wget --quiet "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" --output-document yq
           echo "${YQ_SHA256}  yq" | sha256sum --check --strict
           chmod +x yq


### PR DESCRIPTION
Release workflow for v2.0.3 tag failed at 'Install yq' step:

```
sha256sum: WARNING: 1 computed checksum did NOT match
yq: FAILED
```

Renovate's customManager only matches VERSION= lines, leaves SHA256 stale on version bump. Update to actual sha256 of yq_linux_amd64 at v4.53.2: `d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b`.

Follow-up worth tracking: extend renovate customManager to track SHA alongside VERSION.