### PR TITLE
fix(ci): use refs/pull/N/head for upload-sarif

### DIFF
--- a/.github/workflows/pr-privileged.yaml
+++ b/.github/workflows/pr-privileged.yaml
@@ -49,7 +49,7 @@ jobs:
         with:
           sarif_file: trivy-fs-results.sarif
           category: trivy-filesystem
-          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
           sha: ${{ github.event.workflow_run.head_sha }}
 
   notify:


### PR DESCRIPTION
## Summary

Privileged SARIF upload fails on every PR with:

```
ref is a pull request merge but commit_oid is not a merge commit
```

`workflow_run.head_sha` is the PR branch tip, not the virtual merge commit, so pairing it with `refs/pull/N/merge` mismatches what the codeql endpoint expects.

## Changes

- `.github/workflows/pr-privileged.yaml`: switch ref to `refs/pull/N/head` (alternate PR-scope ref accepted by upload-sarif, and the one whose tip is the PR head_sha)