### PR TITLE
feat(proxy): support backend HTTP/2 cleartext (h2c)

### DIFF
--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -199,6 +199,26 @@ This is because Cloudflare Tunnel terminates TLS at Cloudflare's edge, not
 in the cluster. However, `hostname` and `allowedRoutes` are validated per
 Gateway API specification.
 
+## Backend Protocol (`Service.spec.ports[].appProtocol`)
+
+The L7 proxy reads the backend Service port's `appProtocol` to pick the upstream
+transport. Only one Kubernetes-defined value is implemented today:
+
+| `appProtocol` | Supported | Notes |
+| --- | --- | --- |
+| _(unset)_ | Yes | Default — proxy speaks HTTP/1.1 to the backend |
+| `kubernetes.io/h2c` | Yes | Proxy speaks HTTP/2 cleartext (prior knowledge) |
+| `kubernetes.io/ws` | No | Backend WebSocket not implemented; treated as default HTTP — no conformance coverage |
+| `kubernetes.io/wss` | No | Backend WebSocket-over-TLS not implemented; treated as default HTTP |
+| any other value | No | Logged with a warning at conversion time; proxy falls back to default HTTP/1.1 |
+
+The conformance test `HTTPRouteBackendProtocolWebSocket` is not testable on
+this controller via the upstream Gateway API conformance suite because the
+test's `websocket.Dial` connects directly to the Gateway address
+(`*.cfargotunnel.com`) — same structural limitation as the gRPC conformance
+tests documented above. WebSocket backends may be supported separately via
+e2e validation in a future change.
+
 ## Route Types Not Supported
 
 | Route Type | Status | Reason |

--- a/docs/gateway-api/supported-resources.md
+++ b/docs/gateway-api/supported-resources.md
@@ -77,8 +77,21 @@ only path-based routing through the Cloudflare Tunnel API is available.
 | `spec.rules[].backendRefs[].namespace` | Yes | Cross-namespace refs require ReferenceGrant |
 | `spec.rules[].backendRefs[].port` | Yes | Service port |
 | `spec.rules[].backendRefs[].weight` | Yes | Requires L7 proxy for traffic splitting; without proxy, highest weight wins |
-| `spec.rules[].backendRefs[].filters` | No | Not implemented |
+| `spec.rules[].backendRefs[].filters` | Yes | Per-backend filters applied after rule-level filters; requires L7 proxy |
 | `spec.rules[].timeouts` | Yes | Requires L7 proxy |
+
+### Backend Protocol (`appProtocol`)
+
+When an HTTPRoute references a Service whose target port sets `appProtocol`, the
+L7 proxy selects the upstream transport accordingly:
+
+| `Service.spec.ports[].appProtocol` | Supported | Notes |
+| --- | --- | --- |
+| `kubernetes.io/h2c` | Yes | Proxy speaks HTTP/2 cleartext (prior knowledge) to the backend |
+| _(unset)_ | Yes | Proxy speaks HTTP/1.1 to the backend (default) |
+| `kubernetes.io/ws` | No | Backend WebSocket not implemented; see [Backend Protocol limitations](limitations.md#backend-protocol-servicespecportsappprotocol) |
+| `kubernetes.io/wss` | No | Backend WebSocket-over-TLS not implemented; see [Backend Protocol limitations](limitations.md#backend-protocol-servicespecportsappprotocol) |
+| any other value | No | Logged with a warning; proxy falls back to default HTTP/1.1 |
 
 ### Filters
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/net v0.54.0
 	helm.sh/helm/v4 v4.2.0
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
@@ -179,7 +180,6 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -36,7 +36,7 @@ TEST_NAMESPACE="conformance-test"
 RELEASE_NAME="cftunnel"
 CONTROLLER_IMAGE="controller:dev"
 PROXY_IMAGE="proxy:dev"
-GATEWAY_API_VERSION="v1.5.0"
+GATEWAY_API_VERSION="v1.5.1"
 
 # --- Flags ---
 RUN_TESTS=false

--- a/internal/controller/grpcroute_controller.go
+++ b/internal/controller/grpcroute_controller.go
@@ -103,7 +103,11 @@ func (r *GRPCRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		configResolver:        r.RouteSyncer.ConfigResolver,
 		findRoutesForGateway:  r.findRoutesForGateway,
 		findRoutesForRefGrant: r.findRoutesForReferenceGrant,
-		getAllRelevantRoutes:  r.getAllRelevantRoutes,
+		// GRPCRoute is tunnel-only; the tunnel ingress config is not
+		// protocol-aware, so Service-side changes (appProtocol or otherwise)
+		// don't require a re-sync. Watching Services here would only add
+		// reconcile churn.
+		getAllRelevantRoutes: r.getAllRelevantRoutes,
 	})
 }
 

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -150,6 +150,7 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		configResolver:        r.RouteSyncer.ConfigResolver,
 		findRoutesForGateway:  r.findRoutesForGateway,
 		findRoutesForRefGrant: r.findRoutesForReferenceGrant,
+		findRoutesForService:  r.findRoutesForService,
 		getAllRelevantRoutes:  r.getAllRelevantRoutes,
 	})
 }
@@ -191,6 +192,32 @@ func (r *HTTPRouteReconciler) findRoutesForGateway(
 	}
 
 	return FindRoutesForGateway(ctx, r.Client, obj, r.ControllerName, routes)
+}
+
+// findRoutesForService enqueues every HTTPRoute managed by our controller that
+// references the given Service in any of its backendRefs. A Service-side change
+// (e.g. appProtocol added to a port) must trigger a reconcile so the proxy
+// config stays current. Routes belonging to other GatewayClasses are filtered
+// out — mirroring findRoutesForReferenceGrant.
+func (r *HTTPRouteReconciler) findRoutesForService(
+	ctx context.Context,
+	obj client.Object,
+) []reconcile.Request {
+	var routeList gatewayv1.HTTPRouteList
+	if err := r.List(ctx, &routeList); err != nil {
+		return nil
+	}
+
+	routes := make([]Route, 0, len(routeList.Items))
+
+	for i := range routeList.Items {
+		route := &routeList.Items[i]
+		if r.isRouteForOurGateway(ctx, route) {
+			routes = append(routes, HTTPRouteWrapper{route})
+		}
+	}
+
+	return FindRoutesForService(obj, routes)
 }
 
 func (r *HTTPRouteReconciler) findRoutesForReferenceGrant(

--- a/internal/controller/httproute_controller_test.go
+++ b/internal/controller/httproute_controller_test.go
@@ -676,6 +676,230 @@ func TestHTTPRouteReconciler_FindRoutesForGateway(t *testing.T) {
 	assert.Equal(t, "default", requests[0].Namespace)
 }
 
+func TestHTTPRouteReconciler_FindRoutesForService(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	port := gatewayv1.PortNumber(8081)
+
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-tunnel"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "test-controller"},
+	}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cloudflare-tunnel",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+
+	// route-h2c references svc-grpc and is attached to our Gateway.
+	routeH2C := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-h2c", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "test-gateway"}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "svc-grpc",
+									Port: &port,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// route-other references svc-other; must NOT be enqueued for svc-grpc.
+	routeOther := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-other", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "test-gateway"}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "svc-other",
+									Port: &port,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// route-foreign is attached to a Gateway from another controller; must NOT
+	// be enqueued even though it references svc-grpc.
+	foreignClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-tunnel"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "other-controller"},
+	}
+
+	foreignGateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "foreign-gateway", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "other-tunnel",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+
+	routeForeign := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-foreign", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "foreign-gateway"}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "svc-grpc",
+									Port: &port,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-grpc", Namespace: "default"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gatewayClass, gateway, foreignClass, foreignGateway, routeH2C, routeOther, routeForeign, svc).
+		Build()
+
+	r := &HTTPRouteReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		// Initialize the binding validator the way SetupWithManager does, so
+		// the test exercises the real validator path (not a nil-receiver hole).
+		bindingValidator: routebinding.NewValidator(fakeClient),
+	}
+
+	requests := r.findRoutesForService(context.Background(), svc)
+
+	require.Len(t, requests, 1,
+		"only the route referencing svc-grpc that's bound to our Gateway should be enqueued (foreign-controller routes filtered out)")
+	assert.Equal(t, "route-h2c", requests[0].Name)
+	assert.Equal(t, "default", requests[0].Namespace)
+}
+
+func TestHTTPRouteReconciler_FindRoutesForService_CrossNamespace(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+	require.NoError(t, gatewayv1beta1.Install(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	port := gatewayv1.PortNumber(8081)
+	servicesNS := gatewayv1.Namespace("services-ns")
+
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-tunnel"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "test-controller"},
+	}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "routes-ns"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cloudflare-tunnel",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+
+	// Route in routes-ns explicitly references a Service in services-ns.
+	routeXNS := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "cross-ns-route", Namespace: "routes-ns"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "test-gateway"}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name:      "shared",
+									Namespace: &servicesNS,
+									Port:      &port,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svcMatch := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "services-ns"}}
+	// A same-name Service in the route's namespace must NOT match — the
+	// backendRef has an explicit namespace selector.
+	svcSameName := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "routes-ns"}}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gatewayClass, gateway, routeXNS, svcMatch, svcSameName).
+		Build()
+
+	r := &HTTPRouteReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		ControllerName:   "test-controller",
+		bindingValidator: routebinding.NewValidator(fakeClient),
+	}
+
+	t.Run("service in target namespace enqueues the cross-ns route", func(t *testing.T) {
+		t.Parallel()
+
+		got := r.findRoutesForService(context.Background(), svcMatch)
+		require.Len(t, got, 1)
+		assert.Equal(t, "cross-ns-route", got[0].Name)
+		assert.Equal(t, "routes-ns", got[0].Namespace)
+	})
+
+	t.Run("service with same name in a different namespace is ignored", func(t *testing.T) {
+		t.Parallel()
+
+		got := r.findRoutesForService(context.Background(), svcSameName)
+		assert.Empty(t, got,
+			"backendRef has an explicit namespace; a same-name Service in the route's own namespace must not trigger reconcile")
+	})
+}
+
 func TestHTTPRouteReconciler_FindRoutesForGateway_WrongType(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controller/mappers.go
+++ b/internal/controller/mappers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/api/v1alpha1"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/config"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/logging"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/routebinding"
 )
 
@@ -207,6 +208,40 @@ type Route interface {
 	// GetCrossNamespaceBackendNamespaces returns namespaces referenced by backends
 	// that differ from the route's own namespace.
 	GetCrossNamespaceBackendNamespaces() []string
+	// ReferencesService reports whether any backendRef on this route resolves
+	// to the Service identified by (namespace, name).
+	ReferencesService(namespace, name string) bool
+}
+
+// FindRoutesForService returns reconcile requests for routes that reference the
+// Service object in any of their backendRefs (across all rules). Used by both
+// HTTPRoute and GRPCRoute controllers to watch Service changes — a Service
+// appProtocol flip (e.g. enabling h2c) must enqueue all referencing routes.
+func FindRoutesForService(
+	obj client.Object,
+	routes []Route,
+) []reconcile.Request {
+	svc, ok := obj.(*corev1.Service)
+	if !ok {
+		return nil
+	}
+
+	var requests []reconcile.Request
+
+	for _, route := range routes {
+		if !route.ReferencesService(svc.Namespace, svc.Name) {
+			continue
+		}
+
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      route.GetName(),
+				Namespace: route.GetNamespace(),
+			},
+		})
+	}
+
+	return requests
 }
 
 // RouteFilterFunc determines if a route is relevant (e.g., managed by our Gateway).
@@ -243,6 +278,22 @@ func FindRoutesForReferenceGrant(
 	}
 
 	return requests
+}
+
+// backendRefMatchesService reports whether a Gateway API backendRef points at
+// the Service identified by (svcNamespace, svcName). routeNamespace is the
+// fallback used when the backendRef omits an explicit namespace.
+func backendRefMatchesService(ref *gatewayv1.BackendRef, routeNamespace, svcNamespace, svcName string) bool {
+	if !proxy.IsServiceBackendRef(ref.BackendObjectReference) {
+		return false
+	}
+
+	refNS := routeNamespace
+	if ref.Namespace != nil {
+		refNS = string(*ref.Namespace)
+	}
+
+	return refNS == svcNamespace && string(ref.Name) == svcName
 }
 
 // extractCrossNamespaceBackends returns unique namespaces from backend refs
@@ -288,6 +339,20 @@ func (w HTTPRouteWrapper) GetCrossNamespaceBackendNamespaces() []string {
 	return extractCrossNamespaceBackends(w.Namespace, refs)
 }
 
+// ReferencesService reports whether this HTTPRoute has any Service backendRef
+// matching (namespace, name).
+func (w HTTPRouteWrapper) ReferencesService(namespace, name string) bool {
+	for ruleIdx := range w.Spec.Rules {
+		for refIdx := range w.Spec.Rules[ruleIdx].BackendRefs {
+			if backendRefMatchesService(&w.Spec.Rules[ruleIdx].BackendRefs[refIdx].BackendRef, w.Namespace, namespace, name) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // GRPCRouteWrapper wraps GRPCRoute to implement Route.
 type GRPCRouteWrapper struct {
 	*gatewayv1.GRPCRoute
@@ -309,6 +374,20 @@ func (w GRPCRouteWrapper) GetCrossNamespaceBackendNamespaces() []string {
 	}
 
 	return extractCrossNamespaceBackends(w.Namespace, refs)
+}
+
+// ReferencesService reports whether this GRPCRoute has any Service backendRef
+// matching (namespace, name).
+func (w GRPCRouteWrapper) ReferencesService(namespace, name string) bool {
+	for ruleIdx := range w.Spec.Rules {
+		for refIdx := range w.Spec.Rules[ruleIdx].BackendRefs {
+			if backendRefMatchesService(&w.Spec.Rules[ruleIdx].BackendRefs[refIdx].BackendRef, w.Namespace, namespace, name) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // GetHostnames returns the hostnames from the HTTPRoute spec.

--- a/internal/controller/mappers_test.go
+++ b/internal/controller/mappers_test.go
@@ -1699,3 +1699,119 @@ func TestFindRoutesForGateway_MultipleClassesSameController(t *testing.T) {
 	require.Len(t, result, 1)
 	assert.Equal(t, "default/route-prod", result[0].String())
 }
+
+func TestFindRoutesForService_Direct(t *testing.T) {
+	t.Parallel()
+
+	port := gatewayv1.PortNumber(8081)
+
+	mkRoute := func(name string, refs ...gatewayv1.HTTPBackendRef) *gatewayv1.HTTPRoute {
+		return &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Rules: []gatewayv1.HTTPRouteRule{{BackendRefs: refs}},
+			},
+		}
+	}
+
+	ref := func(name string) gatewayv1.HTTPBackendRef {
+		return gatewayv1.HTTPBackendRef{
+			BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: gatewayv1.ObjectName(name),
+					Port: &port,
+				},
+			},
+		}
+	}
+
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc-x", Namespace: "default"}}
+
+	routes := []Route{
+		HTTPRouteWrapper{mkRoute("hit", ref("svc-x"))},
+		HTTPRouteWrapper{mkRoute("miss", ref("svc-other"))},
+	}
+
+	t.Run("matches routes referencing the Service", func(t *testing.T) {
+		t.Parallel()
+
+		got := FindRoutesForService(svc, routes)
+		require.Len(t, got, 1)
+		assert.Equal(t, "default/hit", got[0].String())
+	})
+
+	t.Run("non-Service object returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		got := FindRoutesForService(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "default"},
+		}, routes)
+		assert.Nil(t, got)
+	})
+
+	t.Run("empty route list returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		got := FindRoutesForService(svc, nil)
+		assert.Nil(t, got)
+	})
+}
+
+func TestGRPCRouteWrapper_ReferencesService(t *testing.T) {
+	t.Parallel()
+
+	port := gatewayv1.PortNumber(50051)
+	otherNS := gatewayv1.Namespace("other-ns")
+	notServiceKind := gatewayv1.Kind("Foo")
+
+	mk := func(refs ...gatewayv1.GRPCBackendRef) GRPCRouteWrapper {
+		return GRPCRouteWrapper{&gatewayv1.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+			Spec: gatewayv1.GRPCRouteSpec{
+				Rules: []gatewayv1.GRPCRouteRule{{BackendRefs: refs}},
+			},
+		}}
+	}
+
+	t.Run("same-namespace hit", func(t *testing.T) {
+		t.Parallel()
+
+		w := mk(gatewayv1.GRPCBackendRef{
+			BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: "svc-x", Port: &port,
+				},
+			},
+		})
+		assert.True(t, w.ReferencesService("default", "svc-x"))
+		assert.False(t, w.ReferencesService("default", "svc-other"))
+	})
+
+	t.Run("cross-namespace hit", func(t *testing.T) {
+		t.Parallel()
+
+		w := mk(gatewayv1.GRPCBackendRef{
+			BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: "svc-x", Namespace: &otherNS, Port: &port,
+				},
+			},
+		})
+		assert.True(t, w.ReferencesService("other-ns", "svc-x"))
+		assert.False(t, w.ReferencesService("default", "svc-x"),
+			"explicit ref.Namespace must override the route's namespace for matching")
+	})
+
+	t.Run("non-Service kind is ignored", func(t *testing.T) {
+		t.Parallel()
+
+		w := mk(gatewayv1.GRPCBackendRef{
+			BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: "svc-x", Kind: &notServiceKind, Port: &port,
+				},
+			},
+		})
+		assert.False(t, w.ReferencesService("default", "svc-x"))
+	})
+}

--- a/internal/controller/proxy_syncer.go
+++ b/internal/controller/proxy_syncer.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -20,6 +21,10 @@ import (
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/referencegrant"
 )
 
+// serviceKind is the default Kind a Gateway API BackendObjectReference falls
+// back to when Group/Kind are unset.
+const serviceKind = "Service"
+
 // ProxySyncer converts HTTPRoute resources to proxy config
 // and pushes it to enhanced-cloudflared replicas via HTTP API.
 type ProxySyncer struct {
@@ -27,6 +32,7 @@ type ProxySyncer struct {
 	logger           *slog.Logger
 	pusher           *proxy.ConfigPusher
 	backendValidator proxy.BackendRefValidator
+	protocolResolver proxy.BackendProtocolResolver
 	syncMu           sync.Mutex
 }
 
@@ -51,7 +57,35 @@ func NewProxySyncer(
 			Timeout: 10 * time.Second,
 		}, authToken),
 		backendValidator: newBackendRefValidator(refGrantValidator),
+		protocolResolver: newBackendProtocolResolver(k8sClient),
 	}
+}
+
+// newBackendProtocolResolver returns a resolver that reads a backend Service's
+// port appProtocol (e.g. kubernetes.io/h2c) so the proxy can pick the right
+// backend transport. Unknown services or ports resolve to "".
+func newBackendProtocolResolver(c client.Client) proxy.BackendProtocolResolver {
+	return func(ctx context.Context, namespace, serviceName string, port int32) string {
+		var svc corev1.Service
+
+		key := client.ObjectKey{Namespace: namespace, Name: serviceName}
+		if err := c.Get(ctx, key, &svc); err != nil {
+			return ""
+		}
+
+		return portAppProtocol(&svc, port)
+	}
+}
+
+// portAppProtocol returns the appProtocol of the Service port matching port, or "".
+func portAppProtocol(svc *corev1.Service, port int32) string {
+	for i := range svc.Spec.Ports {
+		if svc.Spec.Ports[i].Port == port && svc.Spec.Ports[i].AppProtocol != nil {
+			return *svc.Spec.Ports[i].AppProtocol
+		}
+	}
+
+	return ""
 }
 
 // newBackendRefValidator creates a BackendRefValidator from a referencegrant.Validator.
@@ -68,7 +102,7 @@ func newBackendRefValidator(validator *referencegrant.Validator) proxy.BackendRe
 			toGroup = string(*ref.Group)
 		}
 
-		toKind := "Service"
+		toKind := serviceKind
 		if ref.Kind != nil {
 			toKind = string(*ref.Kind)
 		}
@@ -125,8 +159,9 @@ func (s *ProxySyncer) SyncRoutes(
 
 	logger.Info("syncing proxy config", "routes", len(routes))
 
-	// Convert to proxy config with cross-namespace validation.
-	cfg := proxy.ConvertHTTPRoutes(ctx, routes, s.clusterDomain, s.backendValidator)
+	// Convert to proxy config with cross-namespace validation and backend
+	// protocol resolution (e.g. h2c) from Service appProtocol.
+	cfg := proxy.ConvertHTTPRoutes(ctx, routes, s.clusterDomain, s.backendValidator, s.protocolResolver)
 
 	// Clear backends for routes that have failed backend refs.
 	// This ensures the proxy returns 500 (no backend available) instead of

--- a/internal/controller/proxy_syncer_test.go
+++ b/internal/controller/proxy_syncer_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -122,6 +123,75 @@ func TestProxySyncer_NoRoutes_PushesEmptyConfig(t *testing.T) {
 	assert.Equal(t, int32(1), pushCount.Load())
 	assert.Empty(t, receivedConfig.Rules, "empty routes should produce empty rules")
 	assert.True(t, receivedConfig.Version > 0, "version should be positive even with no routes")
+}
+
+func TestProxySyncer_SyncRoutes_H2CBackend(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	var receivedConfig proxy.Config
+
+	var pushCount atomic.Int32
+
+	configServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodPut {
+			pushCount.Add(1)
+
+			if decodeErr := json.NewDecoder(req.Body).Decode(&receivedConfig); decodeErr != nil {
+				writer.WriteHeader(http.StatusBadRequest)
+
+				return
+			}
+		}
+
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer configServer.Close()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	h2cProto := "kubernetes.io/h2c"
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "grpc-svc", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "grpc", Port: 8081, AppProtocol: &h2cProto},
+				{Name: "http", Port: 80},
+			},
+		},
+	}
+
+	testClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc).Build()
+
+	syncer := controller.NewProxySyncer("cluster.local", "", testClient, slog.Default())
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "grpc-route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"grpc.example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{makeBackendRef("grpc-svc", 8081, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, routes, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), pushCount.Load())
+	require.Len(t, receivedConfig.Rules, 1)
+	require.Len(t, receivedConfig.Rules[0].Backends, 1)
+	assert.Equal(t, proxy.BackendProtocolH2C, receivedConfig.Rules[0].Backends[0].Protocol,
+		"backend on a Service port with appProtocol kubernetes.io/h2c must be marked h2c")
 }
 
 // Helper functions.

--- a/internal/controller/reconcile_route.go
+++ b/internal/controller/reconcile_route.go
@@ -81,6 +81,7 @@ type routeControllerSetupParams struct {
 	configResolver        *config.Resolver
 	findRoutesForGateway  handler.MapFunc
 	findRoutesForRefGrant handler.MapFunc
+	findRoutesForService  handler.MapFunc
 	getAllRelevantRoutes  RequestsFunc
 }
 
@@ -93,7 +94,7 @@ func setupRouteController(mgr ctrl.Manager, params *routeControllerSetupParams) 
 		ConfigResolver: params.configResolver,
 	}
 
-	err := ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		For(params.routeObject).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Watches(
@@ -111,8 +112,21 @@ func setupRouteController(mgr ctrl.Manager, params *routeControllerSetupParams) 
 		Watches(
 			&gatewayv1beta1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(params.findRoutesForRefGrant),
-		).
-		Complete(params.reconciler)
+		)
+
+	// A Service change can flip a backendRef's appProtocol (e.g. enable h2c)
+	// without touching any HTTPRoute. Only controllers that actually consume
+	// appProtocol (the L7 proxy, i.e. HTTPRoute) opt into this watch. GRPCRoute
+	// is tunnel-only and never reads appProtocol — leaving its findRoutesForService
+	// unset suppresses the watch and avoids needless reconcile churn.
+	if params.findRoutesForService != nil {
+		builder = builder.Watches(
+			&corev1.Service{},
+			handler.EnqueueRequestsFromMapFunc(params.findRoutesForService),
+		)
+	}
+
+	err := builder.Complete(params.reconciler)
 	if err != nil {
 		return errors.Wrap(err, "failed to setup route controller")
 	}

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -180,11 +180,36 @@ type MirrorConfig struct {
 	BackendURL string `json:"backendUrl"`
 }
 
+// BackendProtocol identifies the application protocol the proxy must speak to a
+// backend. It is derived from the Service port's appProtocol field.
+type BackendProtocol string
+
+const (
+	// BackendProtocolHTTP is the default: HTTP/1.1 (and TLS when the URL scheme is https).
+	BackendProtocolHTTP BackendProtocol = ""
+	// BackendProtocolH2C is HTTP/2 over cleartext (prior knowledge), selected by
+	// the Service port appProtocol kubernetes.io/h2c.
+	BackendProtocolH2C BackendProtocol = "h2c"
+)
+
+// isKnownBackendProtocol reports whether p is one of the protocols the proxy
+// recognises. Used by Config.Validate to reject pushed configs with unknown
+// values rather than silently falling through to the default-transport path.
+func isKnownBackendProtocol(p BackendProtocol) bool {
+	switch p {
+	case BackendProtocolHTTP, BackendProtocolH2C:
+		return true
+	default:
+		return false
+	}
+}
+
 // BackendRef identifies a backend service with a weight for traffic splitting.
 type BackendRef struct {
-	URL     string        `json:"url"`
-	Weight  int32         `json:"weight"`
-	Filters []RouteFilter `json:"filters,omitempty"`
+	URL      string          `json:"url"`
+	Weight   int32           `json:"weight"`
+	Protocol BackendProtocol `json:"protocol,omitempty"`
+	Filters  []RouteFilter   `json:"filters,omitempty"`
 }
 
 // RouteTimeouts configures timeout durations for proxied requests.
@@ -278,6 +303,10 @@ func (r *RouteRule) validate() error {
 
 		if backend.Weight < 0 {
 			return errors.Wrapf(errWeightNonNegative, "backend[%d]", idx)
+		}
+
+		if !isKnownBackendProtocol(backend.Protocol) {
+			return errors.Errorf("backend[%d]: unknown protocol %q", idx, string(backend.Protocol))
 		}
 
 		for filterIdx, filter := range backend.Filters {

--- a/internal/proxy/config_test.go
+++ b/internal/proxy/config_test.go
@@ -151,6 +151,26 @@ func TestProxyConfig_Validate(t *testing.T) {
 			wantErr: "rule[0]: backend[0]: weight must be non-negative",
 		},
 		{
+			name: "unknown backend protocol is rejected",
+			config: proxy.Config{
+				Version: 1,
+				Rules: []proxy.RouteRule{
+					{Backends: []proxy.BackendRef{{URL: "http://svc:80", Weight: 1, Protocol: "bogus"}}},
+				},
+			},
+			wantErr: "rule[0]: backend[0]: unknown protocol \"bogus\"",
+		},
+		{
+			name: "known backend protocol h2c is accepted",
+			config: proxy.Config{
+				Version: 1,
+				Rules: []proxy.RouteRule{
+					{Backends: []proxy.BackendRef{{URL: "http://svc:80", Weight: 1, Protocol: proxy.BackendProtocolH2C}}},
+				},
+			},
+			wantErr: "",
+		},
+		{
 			name: "unknown path match type",
 			config: proxy.Config{
 				Version: 1,

--- a/internal/proxy/converter.go
+++ b/internal/proxy/converter.go
@@ -34,6 +34,10 @@ const (
 
 	schemeHTTP  = "http"
 	schemeHTTPS = "https"
+
+	// appProtocolH2C is the Kubernetes Service appProtocol value selecting
+	// HTTP/2 cleartext to the backend.
+	appProtocolH2C = "kubernetes.io/h2c"
 )
 
 // BackendRefValidator checks whether a cross-namespace backend reference is allowed.
@@ -41,14 +45,23 @@ const (
 // Returns true if the reference is authorized (e.g., via ReferenceGrant).
 type BackendRefValidator func(ctx context.Context, fromNamespace string, ref gatewayv1.BackendObjectReference) bool
 
+// BackendProtocolResolver returns the Service port's appProtocol for a backend
+// (e.g. "kubernetes.io/h2c"), or "" when none is set or the Service is unknown.
+// It lets the converter pick the backend transport without itself reading the API.
+type BackendProtocolResolver func(ctx context.Context, namespace, serviceName string, port int32) string
+
 // ConvertHTTPRoutes converts Gateway API HTTPRoute resources into a proxy Config.
-// If validator is non-nil, cross-namespace backend refs are checked against it;
-// unauthorized refs are skipped with a warning log.
+//
+// validator and protocolResolver may both be nil:
+//   - nil validator: cross-namespace backend refs are accepted unconditionally
+//     (used by tests that don't model ReferenceGrant).
+//   - nil protocolResolver: backend protocol stays the default HTTP/1.1.
 func ConvertHTTPRoutes(
 	ctx context.Context,
 	routes []*gatewayv1.HTTPRoute,
 	clusterDomain string,
 	validator BackendRefValidator,
+	protocolResolver BackendProtocolResolver,
 ) *Config {
 	cfg := &Config{
 		Version: configVersionCounter.Add(1),
@@ -60,7 +73,7 @@ func ConvertHTTPRoutes(
 		for ruleIdx := range route.Spec.Rules {
 			proxyRule := convertHTTPRouteRule(
 				ctx, &route.Spec.Rules[ruleIdx], hostnames,
-				route.Namespace, clusterDomain, validator,
+				route.Namespace, clusterDomain, validator, protocolResolver,
 			)
 
 			// Rules with no backends and no redirect filter are kept —
@@ -91,6 +104,7 @@ func convertHTTPRouteRule(
 	namespace string,
 	clusterDomain string,
 	validator BackendRefValidator,
+	resolver BackendProtocolResolver,
 ) RouteRule {
 	proxyRule := RouteRule{
 		Hostnames: hostnames,
@@ -101,14 +115,14 @@ func convertHTTPRouteRule(
 	}
 
 	for filterIdx := range rule.Filters {
-		converted := convertFilter(&rule.Filters[filterIdx], namespace, clusterDomain)
+		converted := convertFilter(ctx, &rule.Filters[filterIdx], namespace, clusterDomain, validator)
 		if converted != nil {
 			proxyRule.Filters = append(proxyRule.Filters, *converted)
 		}
 	}
 
 	for backendIdx := range rule.BackendRefs {
-		backend, ok := convertBackendRef(ctx, &rule.BackendRefs[backendIdx], namespace, clusterDomain, validator)
+		backend, ok := convertBackendRef(ctx, &rule.BackendRefs[backendIdx], namespace, clusterDomain, validator, resolver)
 		if ok {
 			proxyRule.Backends = append(proxyRule.Backends, backend)
 		}
@@ -199,7 +213,12 @@ func convertQueryMatch(query gatewayv1.HTTPQueryParamMatch) QueryParamMatch {
 	return result
 }
 
-func convertFilter(filter *gatewayv1.HTTPRouteFilter, namespace, clusterDomain string) *RouteFilter {
+func convertFilter(
+	ctx context.Context,
+	filter *gatewayv1.HTTPRouteFilter,
+	namespace, clusterDomain string,
+	validator BackendRefValidator,
+) *RouteFilter {
 	switch filter.Type {
 	case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
 		return convertRequestHeaderFilter(filter.RequestHeaderModifier)
@@ -210,7 +229,7 @@ func convertFilter(filter *gatewayv1.HTTPRouteFilter, namespace, clusterDomain s
 	case gatewayv1.HTTPRouteFilterURLRewrite:
 		return convertURLRewriteFilter(filter.URLRewrite)
 	case gatewayv1.HTTPRouteFilterRequestMirror:
-		return convertMirrorFilter(filter.RequestMirror, namespace, clusterDomain)
+		return convertMirrorFilter(ctx, filter.RequestMirror, namespace, clusterDomain, validator)
 	case gatewayv1.HTTPRouteFilterExtensionRef,
 		gatewayv1.HTTPRouteFilterCORS,
 		gatewayv1.HTTPRouteFilterExternalAuth:
@@ -276,7 +295,10 @@ func convertURLRewriteFilter(rewrite *gatewayv1.HTTPURLRewriteFilter) *RouteFilt
 	}
 }
 
-func isServiceBackendRef(ref gatewayv1.BackendObjectReference) bool {
+// IsServiceBackendRef reports whether the BackendObjectReference points at a
+// core Service (the default Kind when Group/Kind are nil). Exported so the
+// controller package can reuse the same predicate without duplicating it.
+func IsServiceBackendRef(ref gatewayv1.BackendObjectReference) bool {
 	if ref.Group != nil && *ref.Group != "" && *ref.Group != "core" {
 		return false
 	}
@@ -288,12 +310,17 @@ func isServiceBackendRef(ref gatewayv1.BackendObjectReference) bool {
 	return true
 }
 
-func convertMirrorFilter(mirror *gatewayv1.HTTPRequestMirrorFilter, namespace, clusterDomain string) *RouteFilter {
+func convertMirrorFilter(
+	ctx context.Context,
+	mirror *gatewayv1.HTTPRequestMirrorFilter,
+	namespace, clusterDomain string,
+	validator BackendRefValidator,
+) *RouteFilter {
 	if mirror == nil {
 		return nil
 	}
 
-	if !isServiceBackendRef(mirror.BackendRef) {
+	if !IsServiceBackendRef(mirror.BackendRef) {
 		slog.Warn("skipping mirror with non-Service backend kind",
 			"kind", mirror.BackendRef.Kind,
 			"name", mirror.BackendRef.Name)
@@ -315,6 +342,10 @@ func convertMirrorFilter(mirror *gatewayv1.HTTPRequestMirrorFilter, namespace, c
 	mirrorNS := namespace
 	if mirror.BackendRef.Namespace != nil {
 		mirrorNS = string(*mirror.BackendRef.Namespace)
+	}
+
+	if !validateCrossNamespace(ctx, mirrorNS, namespace, string(mirror.BackendRef.Name), mirror.BackendRef, validator) {
+		return nil
 	}
 
 	mirrorURL := buildServiceURL(string(mirror.BackendRef.Name), mirrorNS, mirrorPort, clusterDomain)
@@ -438,8 +469,9 @@ func convertBackendRef(
 	namespace string,
 	clusterDomain string,
 	validator BackendRefValidator,
+	resolver BackendProtocolResolver,
 ) (BackendRef, bool) {
-	if !isServiceBackendRef(backend.BackendObjectReference) {
+	if !IsServiceBackendRef(backend.BackendObjectReference) {
 		slog.Warn("skipping non-Service backend kind",
 			"kind", backend.Kind,
 			"name", backend.Name)
@@ -485,14 +517,73 @@ func convertBackendRef(
 
 	result.URL = buildServiceURL(serviceName, svcNamespace, port, clusterDomain)
 
-	for filterIdx := range backend.Filters {
-		converted := convertFilter(&backend.Filters[filterIdx], namespace, clusterDomain)
+	result.Protocol, result.URL = resolveBackendProtocol(ctx, resolver, svcNamespace, serviceName, port, result.URL)
+
+	result.Filters = convertBackendFilters(ctx, backend.Filters, namespace, clusterDomain, validator)
+
+	return result, true
+}
+
+// resolveBackendProtocol applies the protocol resolver to a backend reference
+// and adjusts the URL scheme accordingly. h2c is cleartext, so an https://
+// scheme (which buildServiceURL emits for port 443) is rewritten to http://
+// to avoid a silent TLS-vs-plaintext mismatch.
+//
+// Unrecognised appProtocol values (e.g. kubernetes.io/ws, kubernetes.io/wss)
+// log a warning and fall back to the default HTTP/1.1 transport rather than
+// silently dropping the signal.
+func resolveBackendProtocol(
+	ctx context.Context,
+	resolver BackendProtocolResolver,
+	namespace, serviceName string,
+	port int32,
+	rawURL string,
+) (BackendProtocol, string) {
+	if resolver == nil {
+		return BackendProtocolHTTP, rawURL
+	}
+
+	appProto := resolver(ctx, namespace, serviceName, port)
+
+	switch appProto {
+	case "":
+		return BackendProtocolHTTP, rawURL
+	case appProtocolH2C:
+		return BackendProtocolH2C, strings.Replace(rawURL, schemeHTTPS+"://", schemeHTTP+"://", 1)
+	default:
+		slog.Warn("unsupported backend appProtocol; falling back to HTTP/1.1",
+			"namespace", namespace,
+			"service", serviceName,
+			"port", port,
+			"appProtocol", appProto,
+		)
+
+		return BackendProtocolHTTP, rawURL
+	}
+}
+
+// convertBackendFilters converts the per-backend HTTPRouteFilters into proxy
+// RouteFilters, skipping any that aren't supported or have nil config.
+func convertBackendFilters(
+	ctx context.Context,
+	filters []gatewayv1.HTTPRouteFilter,
+	namespace, clusterDomain string,
+	validator BackendRefValidator,
+) []RouteFilter {
+	if len(filters) == 0 {
+		return nil
+	}
+
+	result := make([]RouteFilter, 0, len(filters))
+
+	for filterIdx := range filters {
+		converted := convertFilter(ctx, &filters[filterIdx], namespace, clusterDomain, validator)
 		if converted != nil {
-			result.Filters = append(result.Filters, *converted)
+			result = append(result, *converted)
 		}
 	}
 
-	return result, true
+	return result
 }
 
 func resolveBackendNamespace(backend *gatewayv1.HTTPBackendRef, fallback string) string {

--- a/internal/proxy/converter_test.go
+++ b/internal/proxy/converter_test.go
@@ -1,7 +1,10 @@
 package proxy_test
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,11 +67,338 @@ func TestConvertHTTPRoutes_Basic(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 2)
 	assert.Contains(t, cfg.Rules[0].Hostnames, "example.com")
 	assert.Contains(t, cfg.Rules[1].Hostnames, "example.com")
+}
+
+func TestConvertHTTPRoutes_BackendProtocolH2C(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "h2c", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							backendRef("grpc-svc", 8081, 1),
+							backendRef("plain-svc", 80, 1),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Resolver mimics reading Service port appProtocol: grpc-svc:8081 is h2c,
+	// everything else has no appProtocol.
+	resolver := func(_ context.Context, namespace, name string, port int32) string {
+		if namespace == "default" && name == "grpc-svc" && port == 8081 {
+			return "kubernetes.io/h2c"
+		}
+
+		return ""
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 2)
+	assert.Equal(t, proxy.BackendProtocolH2C, cfg.Rules[0].Backends[0].Protocol, "grpc-svc:8081 should be h2c")
+	assert.Equal(t, proxy.BackendProtocolHTTP, cfg.Rules[0].Backends[1].Protocol, "plain-svc:80 should default to http")
+}
+
+func TestConvertHTTPRoutes_UnknownAppProtocol_LogsAndDefaults(t *testing.T) {
+	// Sequential test: swaps the default slog logger so we can capture the
+	// warning. t.Parallel() would race with other tests using slog.Default().
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "wss", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("ws-svc", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	resolver := func(_ context.Context, _, _ string, _ int32) string {
+		return "kubernetes.io/wss"
+	}
+
+	var logs bytes.Buffer
+
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Equal(t, proxy.BackendProtocolHTTP, cfg.Rules[0].Backends[0].Protocol,
+		"unknown appProtocol must fall back to default HTTP/1.1")
+	assert.Contains(t, logs.String(), "unsupported backend appProtocol",
+		"unknown appProtocol must surface a warning, not silently disappear")
+	assert.Contains(t, logs.String(), "kubernetes.io/wss",
+		"warning must name the offending appProtocol")
+}
+
+func TestConvertHTTPRoutes_RuleMirror_CrossNamespaceRejectedWithoutGrant(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	mirrorNS := gatewayv1.Namespace("other-ns")
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "mirror", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						Filters: []gatewayv1.HTTPRouteFilter{
+							{
+								Type: gatewayv1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+									BackendRef: gatewayv1.BackendObjectReference{
+										Name:      "shadow",
+										Namespace: &mirrorNS,
+										Port:      new(gatewayv1.PortNumber(8080)),
+									},
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("primary", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	// Validator that denies every cross-namespace reference — mimics absence
+	// of a ReferenceGrant.
+	rejectAll := func(_ context.Context, _ string, _ gatewayv1.BackendObjectReference) bool {
+		return false
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", rejectAll, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	assert.Empty(t, cfg.Rules[0].Filters,
+		"rule-level mirror to a cross-namespace Service without ReferenceGrant must be dropped, not silently forwarded")
+}
+
+func TestConvertHTTPRoutes_PerBackendMirror_CrossNamespaceRejectedWithoutGrant(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	mirrorNS := gatewayv1.Namespace("other-ns")
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "perbackendmirror", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "primary",
+										Port: new(gatewayv1.PortNumber(80)),
+									},
+									Weight: new(int32(1)),
+								},
+								Filters: []gatewayv1.HTTPRouteFilter{
+									{
+										Type: gatewayv1.HTTPRouteFilterRequestMirror,
+										RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+											BackendRef: gatewayv1.BackendObjectReference{
+												Name:      "shadow",
+												Namespace: &mirrorNS,
+												Port:      new(gatewayv1.PortNumber(8080)),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rejectAll := func(_ context.Context, _ string, _ gatewayv1.BackendObjectReference) bool {
+		return false
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", rejectAll, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Empty(t, cfg.Rules[0].Backends[0].Filters,
+		"per-backend mirror to a cross-namespace Service without ReferenceGrant must be dropped")
+}
+
+func TestConvertHTTPRoutes_PerBackendFilters(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	port := gatewayv1.PortNumber(80)
+	weight := int32(1)
+
+	// Backend-scoped filters are part of the Gateway API HTTPRoute spec
+	// (distinct from rule-level filters). The converter must carry them onto
+	// BackendRef.Filters; otherwise per-backend tweaks silently no-op.
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "per-backend", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "v1",
+										Port: &port,
+									},
+									Weight: &weight,
+								},
+								Filters: []gatewayv1.HTTPRouteFilter{
+									{
+										Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+										RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+											Set: []gatewayv1.HTTPHeader{
+												{Name: "X-Backend-Version", Value: "v1"},
+											},
+										},
+									},
+								},
+							},
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "v2",
+										Port: &port,
+									},
+									Weight: &weight,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 2)
+	require.Len(t, cfg.Rules[0].Backends[0].Filters, 1, "v1 backend must have its per-backend filter converted")
+	assert.Equal(t, proxy.FilterRequestHeaderModifier, cfg.Rules[0].Backends[0].Filters[0].Type)
+	require.NotNil(t, cfg.Rules[0].Backends[0].Filters[0].RequestHeaderModifier)
+	require.Len(t, cfg.Rules[0].Backends[0].Filters[0].RequestHeaderModifier.Set, 1)
+	assert.Equal(t, "X-Backend-Version", cfg.Rules[0].Backends[0].Filters[0].RequestHeaderModifier.Set[0].Name)
+	assert.Equal(t, "v1", cfg.Rules[0].Backends[0].Filters[0].RequestHeaderModifier.Set[0].Value)
+	assert.Empty(t, cfg.Rules[0].Backends[1].Filters, "v2 backend declares no per-backend filters")
+}
+
+func TestConvertHTTPRoutes_BackendProtocolH2C_OnPort443_UsesHTTPScheme(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	// Port 443 normally produces an https:// backend URL. h2c is cleartext —
+	// dialing plaintext against an https-scheme URL silently misbehaves.
+	// The converter must force http:// when the backend is marked h2c.
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "h2c-443", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("grpc-svc", 443, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	resolver := func(_ context.Context, _, _ string, _ int32) string { return "kubernetes.io/h2c" }
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Equal(t, proxy.BackendProtocolH2C, cfg.Rules[0].Backends[0].Protocol)
+	assert.True(t, strings.HasPrefix(cfg.Rules[0].Backends[0].URL, "http://"),
+		"h2c backend on port 443 must use http:// scheme, got %q", cfg.Rules[0].Backends[0].URL)
+}
+
+func TestConvertHTTPRoutes_NoProtocolResolver_DefaultsHTTP(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "plain", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("web-svc", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Equal(t, proxy.BackendProtocolHTTP, cfg.Rules[0].Backends[0].Protocol)
 }
 
 func TestConvertHTTPRoutes_MultipleHostnames(t *testing.T) {
@@ -95,7 +425,7 @@ func TestConvertHTTPRoutes_MultipleHostnames(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Equal(t, []string{"app.example.com", "app.example.org"}, cfg.Rules[0].Hostnames)
@@ -136,7 +466,7 @@ func TestConvertHTTPRoutes_Filters(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -181,7 +511,7 @@ func TestConvertHTTPRoutes_HeaderMatch(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Matches, 1)
@@ -218,7 +548,7 @@ func TestConvertHTTPRoutes_WeightedBackends(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 2)
@@ -249,7 +579,7 @@ func TestConvertHTTPRoutes_NoHostnames(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Hostnames, "no hostnames means catch-all")
@@ -258,7 +588,7 @@ func TestConvertHTTPRoutes_NoHostnames(t *testing.T) {
 func TestConvertHTTPRoutes_Empty(t *testing.T) {
 	t.Parallel()
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), nil, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), nil, "cluster.local", nil, nil)
 
 	assert.Empty(t, cfg.Rules)
 	assert.True(t, cfg.Version > 0, "version should be positive")
@@ -295,7 +625,7 @@ func TestConvertHTTPRoutes_NonServiceBackendSkipped(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1, "rule with unresolvable backend should still be present for 500 response")
 	assert.Empty(t, cfg.Rules[0].Backends, "non-Service backend should not be in backends list")
@@ -353,7 +683,7 @@ func TestConvertQueryMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{tt.route}, "cluster.local", nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{tt.route}, "cluster.local", nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Matches, 1)
@@ -379,7 +709,7 @@ func TestConvertFilter_RequestHeaderModifier(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -400,7 +730,7 @@ func TestConvertFilter_RequestHeaderModifier_NilBody(t *testing.T) {
 		RequestHeaderModifier: nil,
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters)
@@ -418,7 +748,7 @@ func TestConvertFilter_ResponseHeaderModifier(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -437,7 +767,7 @@ func TestConvertFilter_ResponseHeaderModifier_NilBody(t *testing.T) {
 		ResponseHeaderModifier: nil,
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters)
@@ -463,7 +793,7 @@ func TestConvertFilter_RequestRedirect_Full(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -488,7 +818,7 @@ func TestConvertFilter_RequestRedirect_NilBody(t *testing.T) {
 		RequestRedirect: nil,
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters)
@@ -565,7 +895,7 @@ func TestConvertFilter_URLRewrite(t *testing.T) {
 				URLRewrite: tt.rewrite,
 			})
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Filters, 1)
@@ -609,7 +939,7 @@ func TestConvertFilter_URLRewrite_NilBody(t *testing.T) {
 		URLRewrite: nil,
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters)
@@ -627,7 +957,7 @@ func TestConvertFilter_RequestMirror(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -646,7 +976,7 @@ func TestConvertFilter_RequestMirror_NilBody(t *testing.T) {
 		RequestMirror: nil,
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters)
@@ -667,7 +997,7 @@ func TestConvertFilter_UnsupportedTypes(t *testing.T) {
 				Type: filterType,
 			})
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			assert.Empty(t, cfg.Rules[0].Filters)
@@ -692,7 +1022,7 @@ func TestConvertHeaderModifier_AllOperations(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -715,7 +1045,7 @@ func TestConvertHeaderModifier_Empty(t *testing.T) {
 		RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -767,7 +1097,7 @@ func TestConvertRedirectPath(t *testing.T) {
 				},
 			})
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Filters, 1)
@@ -792,7 +1122,7 @@ func TestConvertRedirectPath_PrefixMatch(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -815,7 +1145,7 @@ func TestConvertRedirectPath_NilFields(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -869,7 +1199,7 @@ func TestConvertURLRewritePath(t *testing.T) {
 				},
 			})
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Filters, 1)
@@ -956,7 +1286,7 @@ func TestConvertTimeouts(t *testing.T) {
 
 			route := routeWithTimeouts(tt.timeouts)
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 
@@ -992,7 +1322,7 @@ func TestConvertTimeouts_Nil(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Nil(t, cfg.Rules[0].Timeouts)
@@ -1064,7 +1394,7 @@ func TestConvertHeaderMatch_EdgeCases(t *testing.T) {
 
 			route := routeWithHeaderMatch(tt.header)
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Matches, 1)
@@ -1113,7 +1443,7 @@ func TestConvertBackendRef_InvalidPort(t *testing.T) {
 				},
 			}
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 			if tt.expectSkipped {
 				require.Len(t, cfg.Rules, 1, "rule with invalid backend should still be present for 500 response")
@@ -1156,7 +1486,7 @@ func TestConvertMirrorFilter_InvalidPort(t *testing.T) {
 				},
 			})
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 
@@ -1206,7 +1536,7 @@ func TestConvertBackendRef_NonServiceKind(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1, "rule with unresolvable backend should still be present for 500 response")
 	assert.Empty(t, cfg.Rules[0].Backends, "non-Service backend should not be in backends list")
@@ -1229,7 +1559,7 @@ func TestConvertMirrorFilter_NonServiceKind(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters, "mirror filter with non-Service kind should be skipped")
@@ -1274,7 +1604,7 @@ func TestConvertBackendRef_CrossNamespaceRejected(t *testing.T) {
 		return false
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", rejectAll)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", rejectAll, nil)
 
 	require.Len(t, cfg.Rules, 1, "rule with rejected cross-namespace backend should still be present for 500 response")
 	assert.Empty(t, cfg.Rules[0].Backends, "rejected cross-namespace backend should not be in backends list")
@@ -1319,7 +1649,7 @@ func TestConvertBackendRef_CrossNamespaceAllowed(t *testing.T) {
 		return true
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", allowAll)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", allowAll, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 1, "cross-namespace backend should be allowed by validator")
@@ -1355,7 +1685,7 @@ func TestConvertBackendRef_SameNamespaceAlwaysAllowed(t *testing.T) {
 		return false
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", rejectAll)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", rejectAll, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 1, "same-namespace backend should always be allowed")
@@ -1404,7 +1734,7 @@ func TestBuildServiceURL_SchemeByPort(t *testing.T) {
 				},
 			}
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Backends, 1)
@@ -1435,7 +1765,7 @@ func TestConvertBackendRef_NegativeWeight(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
 
 	require.Len(t, cfg.Rules, 1, "rule with unresolvable backend should still be present for 500 response")
 	assert.Empty(t, cfg.Rules[0].Backends, "negative-weight backend should not be in backends list")

--- a/internal/proxy/export_test.go
+++ b/internal/proxy/export_test.go
@@ -1,8 +1,28 @@
 package proxy
 
-import "sync"
+import (
+	"net"
+	"net/http"
+	"sync"
+)
 
 // Transports returns the handler's internal transport pool for testing purposes.
 func (h *Handler) Transports() *sync.Map {
 	return &h.transports
+}
+
+// TransportKey exposes the per-host+protocol pool key for testing purposes.
+func TransportKey(host string, protocol BackendProtocol) string {
+	return transportKey(host, protocol)
+}
+
+// NewTransportForTest exposes newTransport for testing purposes.
+func NewTransportForTest(protocol BackendProtocol) http.RoundTripper {
+	return newTransport(protocol)
+}
+
+// NewH2CDialerForTest exposes newH2CDialer so tests can assert the dialer's
+// Timeout/KeepAlive fields without reaching inside the http2.Transport closure.
+func NewH2CDialerForTest() *net.Dialer {
+	return newH2CDialer()
 }

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -2,19 +2,37 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"slices"
 	"sync"
+	"time"
+
+	"golang.org/x/net/http2"
 )
 
 // Handler is the main HTTP handler for the L7 proxy.
 // It routes requests, applies filters, and proxies to backends.
 type Handler struct {
-	router     *Router
-	transports sync.Map // map[string]*http.Transport — per-backend transport pool
+	router *Router
+	// transports caches one http.RoundTripper per backend, keyed by
+	// host|protocol (see transportKey). Including the protocol in the key is
+	// what makes flipping a Service's appProtocol (e.g. http -> h2c) take effect
+	// without restarting the proxy: a stale HTTP/1.1 transport for the same
+	// host can no longer mask an h2c reconfiguration.
+	transports sync.Map // map[string]http.RoundTripper
+}
+
+// transportKey forms the cache key for a backend transport. The protocol is
+// part of the key so a protocol flip on the same host:port forces a fresh
+// transport.
+func transportKey(host string, protocol BackendProtocol) string {
+	return host + "|" + string(protocol)
 }
 
 // NewHandler creates a new proxy Handler backed by the given Router.
@@ -72,23 +90,25 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	h.proxyToBackend(writer, req, result)
 }
 
-// PruneTransports removes cached transports for hosts that are no longer active,
-// closing their idle connections to prevent resource leaks.
-func (h *Handler) PruneTransports(activeHosts map[string]bool) {
-	h.transports.Range(func(key, value any) bool {
-		host, ok := key.(string)
+// PruneTransports removes cached transports whose (host, protocol) key is no
+// longer present in activeKeys, closing their idle connections to prevent
+// resource leaks. Keys are formed by transportKey(host, protocol).
+func (h *Handler) PruneTransports(activeKeys map[string]bool) {
+	h.transports.Range(func(rawKey, value any) bool {
+		key, ok := rawKey.(string)
 		if !ok {
 			return true
 		}
 
-		if activeHosts[host] {
+		if activeKeys[key] {
 			return true
 		}
 
-		h.transports.Delete(host)
+		h.transports.Delete(key)
 
-		if transport, castOK := value.(*http.Transport); castOK {
-			transport.CloseIdleConnections()
+		// Both *http.Transport and *http2.Transport expose CloseIdleConnections.
+		if closer, castOK := value.(interface{ CloseIdleConnections() }); castOK {
+			closer.CloseIdleConnections()
 		}
 
 		return true
@@ -131,17 +151,17 @@ func (h *Handler) proxyToBackend(writer http.ResponseWriter, req *http.Request, 
 	}
 
 	// Merge rule-level and backend-specific filters for response processing.
-	allFilters := result.Filters
-	if len(result.BackendFilters) > 0 {
-		allFilters = append(allFilters, result.BackendFilters...)
-	}
+	// slices.Concat allocates a fresh slice; using append on result.Filters
+	// would alias its backing array if cap > len and races against concurrent
+	// requests reading the same compiled rule.
+	allFilters := slices.Concat(result.Filters, result.BackendFilters)
 
-	proxy := h.createReverseProxy(backendURL, allFilters)
+	proxy := h.createReverseProxy(backendURL, backend.Protocol, allFilters)
 	proxy.ServeHTTP(writer, req)
 }
 
 // createReverseProxy builds an httputil.ReverseProxy for the given backend.
-func (h *Handler) createReverseProxy(backendURL *url.URL, filters []Filter) *httputil.ReverseProxy {
+func (h *Handler) createReverseProxy(backendURL *url.URL, protocol BackendProtocol, filters []Filter) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.URL.Scheme = backendURL.Scheme
@@ -171,7 +191,7 @@ func (h *Handler) createReverseProxy(backendURL *url.URL, filters []Filter) *htt
 				req.Header.Set("User-Agent", "")
 			}
 		},
-		Transport:    h.getTransport(backendURL.Host),
+		Transport:    h.getTransport(backendURL.Host, protocol),
 		ErrorHandler: errorHandler,
 		ModifyResponse: func(resp *http.Response) error {
 			ApplyResponseFilters(filters, resp)
@@ -181,29 +201,78 @@ func (h *Handler) createReverseProxy(backendURL *url.URL, filters []Filter) *htt
 	}
 }
 
-// getTransport returns a shared transport for the given backend host.
-func (h *Handler) getTransport(host string) http.RoundTripper {
-	if transport, ok := h.transports.Load(host); ok {
-		loadedTransport, castOK := transport.(*http.Transport)
-		if castOK {
-			return loadedTransport
+// getTransport returns a shared transport for the given backend host/protocol.
+// The cache key includes the protocol so that flipping a Service's appProtocol
+// (e.g. http -> h2c) does not silently reuse a stale HTTP/1.1 transport.
+func (h *Handler) getTransport(host string, protocol BackendProtocol) http.RoundTripper {
+	key := transportKey(host, protocol)
+
+	if transport, ok := h.transports.Load(key); ok {
+		if rt, castOK := transport.(http.RoundTripper); castOK {
+			return rt
 		}
 	}
 
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		return http.DefaultTransport
+	transport := newTransport(protocol)
+	actual, _ := h.transports.LoadOrStore(key, transport)
+
+	if rt, ok := actual.(http.RoundTripper); ok {
+		return rt
 	}
 
-	transport := defaultTransport.Clone()
-	actual, _ := h.transports.LoadOrStore(host, transport)
+	return transport
+}
 
-	loadedTransport, ok := actual.(*http.Transport)
-	if !ok {
-		return http.DefaultTransport
+// h2cReadIdleTimeout sends an HTTP/2 PING on the multiplexed connection after
+// this much idle time so a dead TCP connection (NodePort flap, kube-proxy
+// churn, NAT timeout) gets evicted instead of blocking new requests.
+const h2cReadIdleTimeout = 30 * time.Second
+
+// h2cPingTimeout bounds how long the transport waits for a PING ACK before
+// declaring the connection dead and closing it.
+const h2cPingTimeout = 15 * time.Second
+
+// h2cDialTimeout caps the time spent on a single TCP SYN to an h2c backend.
+// Without this, a SYN against a gone pod hangs on kernel TCP defaults
+// (often >1 min), stalling the request goroutine well past any sensible
+// request budget. The value mirrors http.DefaultTransport's dialer.
+const h2cDialTimeout = 30 * time.Second
+
+// h2cDialKeepAlive matches http.DefaultTransport's dialer KeepAlive so TCP
+// keepalives evict half-closed connections from the pool.
+const h2cDialKeepAlive = 30 * time.Second
+
+// newH2CDialer constructs the net.Dialer used for h2c backend connections.
+// Exported indirectly via export_test.go so tests can assert the timeout fields.
+func newH2CDialer() *net.Dialer {
+	return &net.Dialer{
+		Timeout:   h2cDialTimeout,
+		KeepAlive: h2cDialKeepAlive,
+	}
+}
+
+// newTransport builds a backend transport for the given protocol. For h2c it
+// returns an HTTP/2 transport that negotiates cleartext via prior knowledge
+// (AllowHTTP with a plaintext dialer); otherwise a clone of the default transport.
+func newTransport(protocol BackendProtocol) http.RoundTripper {
+	if protocol == BackendProtocolH2C {
+		dialer := newH2CDialer()
+
+		return &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, addr)
+			},
+			ReadIdleTimeout: h2cReadIdleTimeout,
+			PingTimeout:     h2cPingTimeout,
+		}
 	}
 
-	return loadedTransport
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return defaultTransport.Clone()
+	}
+
+	return http.DefaultTransport
 }
 
 // errorHandler handles proxy errors with appropriate HTTP status codes.

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -441,7 +441,8 @@ func TestHandler_PruneTransportsRemovesStaleHostFromSyncMap(t *testing.T) {
 
 	// Verify transport for backend A was created.
 	hostA := backendA.Listener.Addr().String()
-	_, loaded := handler.Transports().Load(hostA)
+	keyA := proxy.TransportKey(hostA, proxy.BackendProtocolHTTP)
+	_, loaded := handler.Transports().Load(keyA)
 	require.True(t, loaded, "transport for backend A should exist after request")
 
 	// Push new config with only backend B, removing A.
@@ -459,7 +460,7 @@ func TestHandler_PruneTransportsRemovesStaleHostFromSyncMap(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify transport for backend A was pruned.
-	_, loaded = handler.Transports().Load(hostA)
+	_, loaded = handler.Transports().Load(keyA)
 	assert.False(t, loaded, "transport for backend A should be pruned after config update removed it")
 }
 

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
 
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
 )
@@ -48,6 +49,156 @@ func newEchoHeadersBackend(t *testing.T, headerNames ...string) *httptest.Server
 	t.Cleanup(server.Close)
 
 	return server
+}
+
+// newH2CBackend creates an httptest.Server that serves HTTP/2 cleartext (h2c)
+// via the stdlib's native UnencryptedHTTP2 protocol (Go 1.24+). It reports the
+// protocol it saw the request on via X-Backend-Proto so tests can assert the
+// proxy actually negotiated h2c. The server is closed on cleanup.
+func newH2CBackend(t *testing.T, name string) *httptest.Server {
+	t.Helper()
+
+	backend := http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("X-Backend", name)
+		writer.Header().Set("X-Backend-Proto", req.Proto)
+		writer.WriteHeader(http.StatusOK)
+	})
+
+	var protocols http.Protocols
+
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+
+	server := httptest.NewUnstartedServer(backend)
+	server.Config.Protocols = &protocols
+	server.Start()
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func TestHandler_BackendProtocolH2C(t *testing.T) {
+	t.Parallel()
+
+	backend := newH2CBackend(t, "h2c")
+
+	router := proxy.NewRouter()
+
+	cfg := &proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches: []proxy.RouteMatch{
+					{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}},
+				},
+				Backends: []proxy.BackendRef{
+					{URL: backend.URL, Weight: 1, Protocol: proxy.BackendProtocolH2C},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, router.UpdateConfig(cfg))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "h2c", resp.Header.Get("X-Backend"))
+	assert.Equal(t, "HTTP/2.0", resp.Header.Get("X-Backend-Proto"),
+		"proxy must speak HTTP/2 cleartext (h2c) to a backend with appProtocol kubernetes.io/h2c")
+}
+
+func TestNewTransport_H2C_HasLivenessDefaults(t *testing.T) {
+	t.Parallel()
+
+	rt := proxy.NewTransportForTest(proxy.BackendProtocolH2C)
+
+	tr, ok := rt.(*http2.Transport)
+	require.True(t, ok, "h2c transport must be *http2.Transport, got %T", rt)
+	assert.NotZero(t, tr.ReadIdleTimeout,
+		"h2c transport must set ReadIdleTimeout so dead TCP connections get evicted from the multiplexed pool")
+	assert.NotZero(t, tr.PingTimeout,
+		"h2c transport must set PingTimeout to bound how long a stuck PING blocks request progress")
+}
+
+func TestNewH2CDialer_HasTimeouts(t *testing.T) {
+	t.Parallel()
+
+	dialer := proxy.NewH2CDialerForTest()
+
+	// Without a Timeout the dialer would wait for kernel TCP defaults (often
+	// >1 minute) on a hung SYN, stalling the proxy request well past any
+	// sensible request budget. KeepAlive evicts half-closed connections from
+	// the pool. Both must mirror http.DefaultTransport's dialer config.
+	assert.NotZero(t, dialer.Timeout, "h2c dialer must set Timeout to bound TCP SYN waits")
+	assert.NotZero(t, dialer.KeepAlive, "h2c dialer must set KeepAlive to evict half-closed pool connections")
+}
+
+func TestHandler_BackendProtocolToggleSameHostPort(t *testing.T) {
+	t.Parallel()
+
+	// One backend server serving BOTH HTTP/1.1 and h2c on the same host:port —
+	// http.Protocols accepts both. This pins the scenario where the only thing
+	// that changes between configs is the Service appProtocol, not the address.
+	backend := newH2CBackend(t, "dualproto")
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends:  []proxy.BackendRef{{URL: backend.URL, Weight: 1, Protocol: proxy.BackendProtocolHTTP}},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	// Phase 1: HTTP/1.1 path primes the per-host transport cache.
+	req1 := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	resp1 := rec1.Result()
+	defer resp1.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp1.StatusCode)
+	require.Equal(t, "HTTP/1.1", resp1.Header.Get("X-Backend-Proto"),
+		"phase 1 must speak HTTP/1.1 to prime the wrong transport")
+
+	// Phase 2: same backend.URL, same host:port — only Protocol flipped to h2c.
+	// A cache keyed on host alone would reuse the HTTP/1.1 transport here.
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 2,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends:  []proxy.BackendRef{{URL: backend.URL, Weight: 1, Protocol: proxy.BackendProtocolH2C}},
+			},
+		},
+	}))
+
+	req2 := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	resp2 := rec2.Result()
+	defer resp2.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+	assert.Equal(t, "HTTP/2.0", resp2.Header.Get("X-Backend-Proto"),
+		"after the Protocol flip to h2c on the same host:port, the proxy must NOT reuse the cached HTTP/1.1 transport")
 }
 
 func TestHandler_PathMatchPrecedence(t *testing.T) {

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -54,8 +54,9 @@ type wildcardEntry struct {
 }
 
 // transportPruner is implemented by Handler to prune stale transport entries.
+// activeKeys are host|protocol keys produced by transportKey().
 type transportPruner interface {
-	PruneTransports(activeHosts map[string]bool)
+	PruneTransports(activeKeys map[string]bool)
 }
 
 // Router provides thread-safe HTTP request routing with atomic config updates.
@@ -150,15 +151,18 @@ func (r *Router) UpdateConfig(cfg *Config) error {
 	r.table.Store(table)
 
 	if r.pruner != nil {
-		r.pruner.PruneTransports(extractActiveHosts(cfg))
+		r.pruner.PruneTransports(extractActiveTransportKeys(cfg))
 	}
 
 	return nil
 }
 
-// extractActiveHosts collects all backend hosts from the config's rules.
-func extractActiveHosts(cfg *Config) map[string]bool {
-	hosts := make(map[string]bool)
+// extractActiveTransportKeys collects all backend transport-pool keys from the
+// config's rules. Keys are formed by transportKey(host, protocol) so
+// PruneTransports can evict stale entries when either changes (e.g. on a
+// Service appProtocol flip).
+func extractActiveTransportKeys(cfg *Config) map[string]bool {
+	keys := make(map[string]bool)
 
 	for _, rule := range cfg.Rules {
 		for _, backend := range rule.Backends {
@@ -167,11 +171,11 @@ func extractActiveHosts(cfg *Config) map[string]bool {
 				continue
 			}
 
-			hosts[parsed.Host] = true
+			keys[transportKey(parsed.Host, backend.Protocol)] = true
 		}
 	}
 
-	return hosts
+	return keys
 }
 
 // compileRoutingTable builds a routingTable from a Config.

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -50,6 +50,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		features.SupportHTTPRouteRequestTimeout,
 		features.SupportHTTPRouteBackendTimeout,
 		features.SupportHTTPRouteParentRefPort,
+		features.SupportHTTPRouteBackendProtocolH2C,
 		// NOTE: 303/307/308 redirect status codes work correctly in the proxy,
 		// but Cloudflare edge rewrites Location scheme to HTTPS, so conformance
 		// tests that verify http:// scheme in redirects will always fail.
@@ -83,7 +84,10 @@ func TestGatewayAPIConformance(t *testing.T) {
 		// HTTPRoute features not implemented
 		features.SupportHTTPRouteRequestMultipleMirrors,
 		features.SupportHTTPRouteRequestPercentageMirror,
-		features.SupportHTTPRouteBackendProtocolH2C,
+		// HTTPRouteBackendProtocolWebSocket: the proxy could implement it, but the
+		// conformance suite dials the Gateway address directly with a ws:// client
+		// (no custom dialer hook), and *.cfargotunnel.com is not routable — same
+		// structural limitation as the gRPC tests below. Left exempt.
 		features.SupportHTTPRouteBackendProtocolWebSocket,
 		features.SupportHTTPRouteCORS,
 		features.SupportHTTPRouteNamedRouteRule,
@@ -179,7 +183,6 @@ func TestGatewayAPIConformance(t *testing.T) {
 		"HTTPRouteRedirectPort",
 
 		// HTTPRoute features not implemented.
-		"HTTPRouteBackendProtocolH2C",
 		"HTTPRouteBackendProtocolWebSocket",
 		"HTTPRouteCORS",
 		"HTTPRouteCORSAllowCredentialsBehavior",

--- a/test/conformance/roundtripper.go
+++ b/test/conformance/roundtripper.go
@@ -44,6 +44,11 @@ func tunnelHostname() string {
 }
 
 // CaptureRoundTrip implements roundtripper.RoundTripper.
+//
+// Note: request.Protocol is intentionally ignored. Even if a test asks for
+// H2CPriorKnowledge, we always send HTTPS to the Cloudflare edge (the edge is
+// HTTPS-only). The backend-protocol features (h2c, etc.) are validated by what
+// the proxy-to-backend leg negotiates, not by the test client's wire format.
 func (t *TunnelRoundTripper) CaptureRoundTrip(request roundtripper.Request) (*roundtripper.CapturedRequest, *roundtripper.CapturedResponse, error) {
 	host := request.Host
 	if host == "" {


### PR DESCRIPTION
# Pull Request

## Summary

Implement HTTPRouteBackendProtocolH2C: when a backend Service port declares `appProtocol: kubernetes.io/h2c`, the v2 proxy now speaks HTTP/2 prior-knowledge cleartext to that backend. The conformance feature moves from `ExemptFeatures` into `SupportedFeatures`. WebSocket stays exempt — it is structurally blocked by the same direct-dial limitation as the gRPC conformance tests (`websocket.Dial` bypasses the configured roundtripper), documented in `limitations.md`.

## Changes

- New `BackendProtocol` type and `Protocol` field on `BackendRef` carry the resolved protocol from controller to data plane.
- `ConvertHTTPRoutes` takes a `BackendProtocolResolver` (nil-safe). The `ProxySyncer` wires one that reads `Service.Spec.Ports[].AppProtocol` via the manager's cached client.
- For h2c, the converter rewrites port-443 URLs from `https://` to `http://` so the cleartext dialer doesn't silently misbehave.
- New `http2.Transport` for h2c backends: `AllowHTTP: true`, plaintext `DialTLSContext` with explicit `Timeout`/`KeepAlive`, plus `ReadIdleTimeout` and `PingTimeout` so dead multiplexed connections get evicted.
- Per-host transport pool now keys by `host|protocol` — flipping a Service's `appProtocol` on the same host:port no longer reuses a stale HTTP/1.1 transport.
- `Config.Validate` rejects unknown `protocol` values on PUT so a bad config fails loud instead of silently degrading.
- HTTPRoute reconciler watches Services (filtered through `isRouteForOurGateway`) so an `appProtocol` change triggers a re-sync. GRPCRoute opts out — tunnel-only, doesn't consume `appProtocol`.
- Docs: `supported-resources.md` adds a backend-protocol matrix and fixes a long-standing `backendRefs[].filters: No` row (per-backend filters have actually worked since the rule-filter refactor); `limitations.md` adds a backend-protocol section covering h2c/ws/wss.
- `hack/conformance-setup.sh` bumps the experimental-CRD installer to v1.5.1 so it matches the vendored suite.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m`, 0 issues)
- [x] Markdown linting passes
- [x] `mkdocs build --strict` clean
- [x] h2c integration test pins both negotiation paths against a dual-protocol backend
- [x] Official Gateway API v1.5.1 conformance against a real Cloudflare Tunnel + homelab cluster: **40 passed, 0 failed, 90 skipped**, including `HTTPRouteBackendProtocolH2C`

## Documentation

- [x] `docs/gateway-api/supported-resources.md` updated
- [x] `docs/gateway-api/limitations.md` updated
- [x] Code comments added for the cache-key change, the h2c dialer config, and the roundtripper's deliberate `Protocol` skip
- [ ] CLAUDE.md updated — no workflow changes

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented — none; new `Protocol` field is `omitempty`, default behavior is unchanged for existing configs
