### PR TITLE
feat(proxy): support multiple request mirrors and percent/fraction sampling

### DIFF
--- a/docs/gateway-api/supported-resources.md
+++ b/docs/gateway-api/supported-resources.md
@@ -103,7 +103,7 @@ The following HTTPRoute filters are supported with the L7 proxy enabled:
 | `ResponseHeaderModifier` | Yes | Add, set, or remove response headers |
 | `RequestRedirect` | Yes | Redirect with scheme, hostname, port, path, status code |
 | `URLRewrite` | Yes | Rewrite hostname and/or path |
-| `RequestMirror` | Yes | Mirror traffic to a secondary backend |
+| `RequestMirror` | Yes | Mirror traffic to one or more secondary backends. Per Gateway API only one of `percent` or `fraction` may be set on a filter; `percent` takes precedence if both appear. |
 | `ExtensionRef` | No | Not implemented |
 
 ### Supported Service Types

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -175,9 +175,14 @@ type URLRewritePath struct {
 	ReplacePrefixMatch *string            `json:"replacePrefixMatch,omitempty"`
 }
 
-// MirrorConfig describes where to mirror requests.
+// MirrorConfig describes where to mirror requests and at what rate.
 type MirrorConfig struct {
 	BackendURL string `json:"backendUrl"`
+	// Percent is the percentage of requests to mirror to the backend
+	// (0-100 inclusive). nil means 100% (mirror every request). A Fraction
+	// on the Gateway API filter is normalized into Percent at conversion
+	// time so the proxy speaks one shape.
+	Percent *int32 `json:"percent,omitempty"`
 }
 
 // BackendProtocol identifies the application protocol the proxy must speak to a
@@ -398,6 +403,10 @@ func (f *RouteFilter) validate() error {
 	case FilterRequestMirror:
 		if f.RequestMirror == nil {
 			return errors.New("requestMirror config is required")
+		}
+
+		if pct := f.RequestMirror.Percent; pct != nil && (*pct < 0 || *pct > 100) {
+			return errors.Errorf("requestMirror percent must be in [0,100], got %d", *pct)
 		}
 	default:
 		return errors.Wrapf(errUnknownFilterType, "%q", f.Type)

--- a/internal/proxy/config_test.go
+++ b/internal/proxy/config_test.go
@@ -151,6 +151,40 @@ func TestProxyConfig_Validate(t *testing.T) {
 			wantErr: "rule[0]: backend[0]: weight must be non-negative",
 		},
 		{
+			name: "mirror percent out of range above is rejected",
+			config: proxy.Config{
+				Version: 1,
+				Rules: []proxy.RouteRule{
+					{
+						Filters: []proxy.RouteFilter{
+							{
+								Type:          proxy.FilterRequestMirror,
+								RequestMirror: &proxy.MirrorConfig{BackendURL: "http://mirror:80", Percent: new(int32(101))},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "rule[0]: filter[0]: requestMirror percent must be in [0,100], got 101",
+		},
+		{
+			name: "mirror percent out of range below is rejected",
+			config: proxy.Config{
+				Version: 1,
+				Rules: []proxy.RouteRule{
+					{
+						Filters: []proxy.RouteFilter{
+							{
+								Type:          proxy.FilterRequestMirror,
+								RequestMirror: &proxy.MirrorConfig{BackendURL: "http://mirror:80", Percent: new(int32(-1))},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "rule[0]: filter[0]: requestMirror percent must be in [0,100], got -1",
+		},
+		{
 			name: "unknown backend protocol is rejected",
 			config: proxy.Config{
 				Version: 1,

--- a/internal/proxy/converter.go
+++ b/internal/proxy/converter.go
@@ -351,9 +351,70 @@ func convertMirrorFilter(
 	mirrorURL := buildServiceURL(string(mirror.BackendRef.Name), mirrorNS, mirrorPort, clusterDomain)
 
 	return &RouteFilter{
-		Type:          FilterRequestMirror,
-		RequestMirror: &MirrorConfig{BackendURL: mirrorURL},
+		Type: FilterRequestMirror,
+		RequestMirror: &MirrorConfig{
+			BackendURL: mirrorURL,
+			Percent:    mirrorPercent(mirror),
+		},
 	}
+}
+
+// mirrorPercent normalises HTTPRequestMirrorFilter.Percent and Fraction into a
+// single 0-100 value. Returns nil when neither is set (i.e. mirror everything).
+// Per Gateway API only one of Percent or Fraction may be specified.
+//
+// Always returns a freshly allocated pointer so the proxy config is fully
+// detached from the HTTPRoute object's storage. Arithmetic uses int64 to avoid
+// overflow when a Fraction uses large numerator/denominator values that are
+// individually valid int32 but whose product overflows. The result is clamped
+// to [0, 100] defensively, even though the CRD already enforces this — the
+// proxy data plane treats out-of-range as a programming error and snapping to
+// the nearest legal value is safer than producing UB in shouldMirror.
+func mirrorPercent(mirror *gatewayv1.HTTPRequestMirrorFilter) *int32 {
+	if mirror.Percent != nil {
+		clamped := clampPercent(int64(*mirror.Percent))
+
+		return &clamped
+	}
+
+	if mirror.Fraction == nil {
+		return nil
+	}
+
+	denominator := int32(100)
+	if mirror.Fraction.Denominator != nil {
+		denominator = *mirror.Fraction.Denominator
+	}
+
+	if denominator <= 0 {
+		slog.Warn("skipping mirror Fraction with non-positive denominator",
+			"numerator", mirror.Fraction.Numerator,
+			"denominator", denominator,
+		)
+
+		return nil
+	}
+
+	// int64 arithmetic prevents Numerator*100 from wrapping on large
+	// Numerators (CRD validation only requires Numerator <= Denominator,
+	// not a Maximum cap, so values in the billions are legal input).
+	resolved := clampPercent(int64(mirror.Fraction.Numerator) * 100 / int64(denominator))
+
+	return &resolved
+}
+
+// clampPercent snaps an arbitrary integer to the [0, 100] range and narrows
+// the type to int32 (the wire format used by MirrorConfig.Percent).
+func clampPercent(value int64) int32 {
+	if value < 0 {
+		return 0
+	}
+
+	if value > 100 {
+		return 100
+	}
+
+	return int32(value)
 }
 
 func convertHeaderModifier(modifier *gatewayv1.HTTPHeaderFilter) *HeaderModifier {

--- a/internal/proxy/converter_test.go
+++ b/internal/proxy/converter_test.go
@@ -336,6 +336,326 @@ func TestConvertHTTPRoutes_PerBackendFilters(t *testing.T) {
 	assert.Empty(t, cfg.Rules[0].Backends[1].Filters, "v2 backend declares no per-backend filters")
 }
 
+func TestConvertHTTPRoutes_MultipleMirrors(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	port := gatewayv1.PortNumber(80)
+
+	// Two RequestMirror filters in the same rule must yield two distinct
+	// mirror RouteFilters (one per target). Gateway API 1.5 standard channel
+	// removed the previous "at most one mirror filter per rule" restriction.
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "multi-mirror", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						Filters: []gatewayv1.HTTPRouteFilter{
+							{
+								Type: gatewayv1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+									BackendRef: gatewayv1.BackendObjectReference{Name: "mirror-a", Port: &port},
+								},
+							},
+							{
+								Type: gatewayv1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+									BackendRef: gatewayv1.BackendObjectReference{Name: "mirror-b", Port: &port},
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("primary", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Filters, 2, "both mirror filters must be carried into the rule")
+	assert.Equal(t, proxy.FilterRequestMirror, cfg.Rules[0].Filters[0].Type)
+	assert.Equal(t, proxy.FilterRequestMirror, cfg.Rules[0].Filters[1].Type)
+	require.NotNil(t, cfg.Rules[0].Filters[0].RequestMirror)
+	require.NotNil(t, cfg.Rules[0].Filters[1].RequestMirror)
+	assert.Contains(t, cfg.Rules[0].Filters[0].RequestMirror.BackendURL, "mirror-a")
+	assert.Contains(t, cfg.Rules[0].Filters[1].RequestMirror.BackendURL, "mirror-b")
+}
+
+func TestConvertHTTPRoutes_MirrorWithPercent(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	port := gatewayv1.PortNumber(80)
+	percent := int32(20)
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "percent-mirror", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						Filters: []gatewayv1.HTTPRouteFilter{
+							{
+								Type: gatewayv1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+									BackendRef: gatewayv1.BackendObjectReference{Name: "mirror", Port: &port},
+									Percent:    &percent,
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("primary", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Filters, 1)
+	require.NotNil(t, cfg.Rules[0].Filters[0].RequestMirror)
+	require.NotNil(t, cfg.Rules[0].Filters[0].RequestMirror.Percent, "Percent field must propagate from HTTPRequestMirrorFilter")
+	assert.Equal(t, int32(20), *cfg.Rules[0].Filters[0].RequestMirror.Percent)
+}
+
+func TestConvertHTTPRoutes_MirrorFractionLargeDenominatorNoOverflow(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	port := gatewayv1.PortNumber(80)
+
+	// Numerator=30_000_000 and Denominator=100_000_000 encode 30% sampling at
+	// high resolution. The CRD validation does not cap either value.
+	// Numerator*100 = 3_000_000_000 overflows int32; int64 arithmetic must be
+	// used to land on 30, not on a wrapped negative.
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "fraction-big", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						Filters: []gatewayv1.HTTPRouteFilter{
+							{
+								Type: gatewayv1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+									BackendRef: gatewayv1.BackendObjectReference{Name: "mirror", Port: &port},
+									Fraction:   &gatewayv1.Fraction{Numerator: 30_000_000, Denominator: new(int32(100_000_000))},
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("primary", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.NotNil(t, cfg.Rules[0].Filters[0].RequestMirror.Percent)
+	assert.Equal(t, int32(30), *cfg.Rules[0].Filters[0].RequestMirror.Percent,
+		"large-denominator Fraction must use int64 arithmetic; got %d (likely int32 overflow)",
+		*cfg.Rules[0].Filters[0].RequestMirror.Percent)
+}
+
+func TestConvertHTTPRoutes_MirrorPercentDetachedFromSourcePointer(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	port := gatewayv1.PortNumber(80)
+	percent := int32(20)
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "alias", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Hostnames: []gatewayv1.Hostname{"example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+					},
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1.BackendObjectReference{Name: "mirror", Port: &port},
+								Percent:    &percent,
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("primary", 80, 1)},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+
+	// Mutate the source pointer after conversion. The proxy config must hold a
+	// snapshot, not a live alias — otherwise the filter goroutine could read
+	// changing values while serving requests.
+	*route.Spec.Rules[0].Filters[0].RequestMirror.Percent = 99
+	assert.Equal(t, int32(20), *cfg.Rules[0].Filters[0].RequestMirror.Percent,
+		"proxy config must own its own copy of Percent; source mutation leaked in")
+}
+
+func TestConvertHTTPRoutes_MirrorFractionNonPositiveDenominator_Skipped(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	port := gatewayv1.PortNumber(80)
+
+	// CRD validation requires Denominator>=1 but the proxy is permissive against
+	// malformed input that bypasses admission (e.g. a pushed config). A zero or
+	// negative denominator must not panic-divide; mirrorPercent returns nil and
+	// the filter falls back to default 100% sampling.
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "zero-denom", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						Filters: []gatewayv1.HTTPRouteFilter{
+							{
+								Type: gatewayv1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+									BackendRef: gatewayv1.BackendObjectReference{Name: "mirror", Port: &port},
+									Fraction:   &gatewayv1.Fraction{Numerator: 1, Denominator: new(int32(0))},
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("primary", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+		require.Len(t, cfg.Rules, 1)
+		require.Len(t, cfg.Rules[0].Filters, 1)
+		require.NotNil(t, cfg.Rules[0].Filters[0].RequestMirror)
+		assert.Nil(t, cfg.Rules[0].Filters[0].RequestMirror.Percent,
+			"non-positive denominator must drop the sampling rate (fall back to default 100%%)")
+	})
+}
+
+func TestShouldMirror_Contract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		percent *int32
+		want    bool // either deterministic, or "expected steady-state" for stochastic cases
+		isProb  bool // when true, want is the steady-state and we sample
+	}{
+		{name: "nil percent mirrors every request", percent: nil, want: true},
+		{name: "negative percent never mirrors (clamped)", percent: new(int32(-1)), want: false},
+		{name: "zero percent never mirrors", percent: new(int32(0)), want: false},
+		{name: "one hundred always mirrors", percent: new(int32(100)), want: true},
+		{name: "above one hundred always mirrors (clamped)", percent: new(int32(101)), want: true},
+		{name: "fifty mirrors stochastically", percent: new(int32(50)), want: true, isProb: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if !tt.isProb {
+				// Deterministic case: a single call must produce the expected verdict.
+				assert.Equal(t, tt.want, proxy.ShouldMirrorForTest(tt.percent))
+
+				return
+			}
+
+			// Stochastic case: across many calls the function must return both
+			// true and false at least once (it isn't stuck on one branch).
+			sawTrue := false
+			sawFalse := false
+
+			for range 1000 {
+				if proxy.ShouldMirrorForTest(tt.percent) {
+					sawTrue = true
+				} else {
+					sawFalse = true
+				}
+				if sawTrue && sawFalse {
+					break
+				}
+			}
+
+			assert.True(t, sawTrue, "percent=50 must produce true at least once over 1000 calls")
+			assert.True(t, sawFalse, "percent=50 must produce false at least once over 1000 calls")
+		})
+	}
+}
+
+func TestConvertHTTPRoutes_MirrorWithFractionResolvesToPercent(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	port := gatewayv1.PortNumber(80)
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "fraction-mirror", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						Filters: []gatewayv1.HTTPRouteFilter{
+							{
+								Type: gatewayv1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+									BackendRef: gatewayv1.BackendObjectReference{Name: "mirror", Port: &port},
+									// 25/50 = 50%
+									Fraction: &gatewayv1.Fraction{Numerator: 25, Denominator: new(int32(50))},
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("primary", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Filters, 1)
+	require.NotNil(t, cfg.Rules[0].Filters[0].RequestMirror)
+	require.NotNil(t, cfg.Rules[0].Filters[0].RequestMirror.Percent,
+		"Fraction must be normalized to Percent at conversion time")
+	assert.Equal(t, int32(50), *cfg.Rules[0].Filters[0].RequestMirror.Percent,
+		"25/50 must resolve to 50%%")
+}
+
 func TestConvertHTTPRoutes_BackendProtocolH2C_OnPort443_UsesHTTPScheme(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proxy/export_test.go
+++ b/internal/proxy/export_test.go
@@ -21,6 +21,13 @@ func NewTransportForTest(protocol BackendProtocol) http.RoundTripper {
 	return newTransport(protocol)
 }
 
+// ShouldMirrorForTest exposes the unexported requestMirror.shouldMirror
+// decision so its contract can be pinned by direct unit tests rather than the
+// statistical integration test.
+func ShouldMirrorForTest(percent *int32) bool {
+	return (&requestMirror{percent: percent}).shouldMirror()
+}
+
 // NewH2CDialerForTest exposes newH2CDialer so tests can assert the dialer's
 // Timeout/KeepAlive fields without reaching inside the http2.Transport closure.
 func NewH2CDialerForTest() *net.Dialer {

--- a/internal/proxy/filter.go
+++ b/internal/proxy/filter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"path"
@@ -285,19 +286,28 @@ func (f *urlRewriter) rewritePath(req *http.Request) {
 }
 
 // requestMirror sends a copy of the request to a mirror backend asynchronously.
+// percent is nil for unconditional mirroring (100%), otherwise an integer in
+// 0..100 that gates whether a given request is mirrored.
 type requestMirror struct {
 	backendURL string
+	percent    *int32
 }
 
 // NewRequestMirror creates a filter that mirrors requests to a backend URL.
 // All mirror instances share a single HTTP client for connection pooling.
-func NewRequestMirror(backendURL string) Filter {
+// percent (0-100) controls the fraction of requests mirrored; nil means 100%.
+func NewRequestMirror(backendURL string, percent *int32) Filter {
 	return &requestMirror{
 		backendURL: backendURL,
+		percent:    percent,
 	}
 }
 
 func (f *requestMirror) ProcessRequest(req *http.Request) *http.Response {
+	if !f.shouldMirror() {
+		return nil
+	}
+
 	mirrorURL, err := req.URL.Parse(f.backendURL + req.URL.Path)
 	if err != nil {
 		slog.Warn("mirror: failed to parse backend URL", "error", err)
@@ -392,6 +402,26 @@ func bufferMirrorBody(req *http.Request) ([]byte, bool) {
 
 func (f *requestMirror) ProcessResponse(_ *http.Response) {}
 
+// shouldMirror returns true when the configured percent admits the current
+// request. nil percent means mirror every request. 0 means never. Otherwise
+// flip a fair coin biased by percent.
+func (f *requestMirror) shouldMirror() bool {
+	if f.percent == nil {
+		return true
+	}
+
+	pct := *f.percent
+	if pct <= 0 {
+		return false
+	}
+
+	if pct >= 100 {
+		return true
+	}
+	//nolint:gosec // math/rand is fine for traffic mirroring sampling
+	return rand.Int32N(100) < pct
+}
+
 // CompileFilters converts RouteFilter specs into executable Filter instances.
 func CompileFilters(filters []RouteFilter) ([]Filter, error) {
 	compiled := make([]Filter, 0, len(filters))
@@ -419,7 +449,7 @@ func compileFilter(filter RouteFilter) (Filter, error) {
 	case FilterURLRewrite:
 		return NewURLRewriter(filter.URLRewrite), nil
 	case FilterRequestMirror:
-		return NewRequestMirror(filter.RequestMirror.BackendURL), nil
+		return NewRequestMirror(filter.RequestMirror.BackendURL, filter.RequestMirror.Percent), nil
 	default:
 		return nil, errors.Wrapf(errUnknownFilterType, "%q", filter.Type)
 	}

--- a/internal/proxy/filter_test.go
+++ b/internal/proxy/filter_test.go
@@ -474,7 +474,7 @@ func TestRequestMirror(t *testing.T) {
 	}))
 	defer mirror.Close()
 
-	filter := proxy.NewRequestMirror(mirror.URL)
+	filter := proxy.NewRequestMirror(mirror.URL, nil)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/test", nil)
 
@@ -488,7 +488,7 @@ func TestRequestMirror(t *testing.T) {
 func TestRequestMirror_InvalidBackendURL(t *testing.T) {
 	t.Parallel()
 
-	filter := proxy.NewRequestMirror("://invalid\x00url")
+	filter := proxy.NewRequestMirror("://invalid\x00url", nil)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/test", nil)
 
@@ -517,7 +517,7 @@ func TestRequestMirror_PostBody(t *testing.T) {
 	}))
 	defer mirror.Close()
 
-	filter := proxy.NewRequestMirror(mirror.URL)
+	filter := proxy.NewRequestMirror(mirror.URL, nil)
 
 	req := httptest.NewRequestWithContext(
 		context.Background(),
@@ -709,7 +709,7 @@ func TestRequestMirror_BodyReadError_RestoresPartialBody(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com/test", failingBody)
 
-	filter := proxy.NewRequestMirror("http://mirror-backend:8080")
+	filter := proxy.NewRequestMirror("http://mirror-backend:8080", nil)
 	resp := filter.ProcessRequest(req)
 
 	if resp != nil {
@@ -736,7 +736,7 @@ func TestRequestMirror_OversizeBody_SetsUnknownContentLength(t *testing.T) {
 	)
 	req.ContentLength = int64(len(oversizeBody))
 
-	filter := proxy.NewRequestMirror("http://mirror-backend:8080")
+	filter := proxy.NewRequestMirror("http://mirror-backend:8080", nil)
 	resp := filter.ProcessRequest(req)
 
 	if resp != nil {

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -140,6 +141,253 @@ func TestNewH2CDialer_HasTimeouts(t *testing.T) {
 	// the pool. Both must mirror http.DefaultTransport's dialer config.
 	assert.NotZero(t, dialer.Timeout, "h2c dialer must set Timeout to bound TCP SYN waits")
 	assert.NotZero(t, dialer.KeepAlive, "h2c dialer must set KeepAlive to evict half-closed pool connections")
+}
+
+// countingMirrorBackend records the number of received requests on an atomic
+// counter and 200s every one. Used to assert mirror filter behavior.
+func countingMirrorBackend(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+
+	var hits atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	return server, &hits
+}
+
+func TestHandler_MultipleMirrors_AllBackendsHit(t *testing.T) {
+	t.Parallel()
+
+	primary := newBackend(t, "primary")
+	mirrorA, hitsA := countingMirrorBackend(t)
+	mirrorB, hitsB := countingMirrorBackend(t)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Filters: []proxy.RouteFilter{
+					{Type: proxy.FilterRequestMirror, RequestMirror: &proxy.MirrorConfig{BackendURL: mirrorA.URL}},
+					{Type: proxy.FilterRequestMirror, RequestMirror: &proxy.MirrorConfig{BackendURL: mirrorB.URL}},
+				},
+				Backends: []proxy.BackendRef{{URL: primary.URL, Weight: 1}},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+
+	// Mirror requests are fire-and-forget goroutines; give them a moment.
+	require.Eventually(t, func() bool {
+		return hitsA.Load() == 1 && hitsB.Load() == 1
+	}, 3*time.Second, 20*time.Millisecond,
+		"both mirror backends must receive exactly one mirrored request (got A=%d B=%d)", hitsA.Load(), hitsB.Load())
+}
+
+// bodyEchoBackend captures the full request body of each request so tests can
+// assert mirror filters didn't truncate or share the body reader.
+func bodyEchoBackend(t *testing.T) (*httptest.Server, *atomic.Value) {
+	t.Helper()
+
+	var last atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		last.Store(string(body))
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	return server, &last
+}
+
+func TestHandler_MultipleMirrors_PostBody_BothReceiveFullBody(t *testing.T) {
+	t.Parallel()
+
+	primary := newBackend(t, "primary")
+	mirrorA, lastA := bodyEchoBackend(t)
+	mirrorB, lastB := bodyEchoBackend(t)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Filters: []proxy.RouteFilter{
+					{Type: proxy.FilterRequestMirror, RequestMirror: &proxy.MirrorConfig{BackendURL: mirrorA.URL}},
+					{Type: proxy.FilterRequestMirror, RequestMirror: &proxy.MirrorConfig{BackendURL: mirrorB.URL}},
+				},
+				Backends: []proxy.BackendRef{{URL: primary.URL, Weight: 1}},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	const payload = "this body must reach every mirror identically"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://app.example.com/", strings.NewReader(payload))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+
+	require.Eventually(t, func() bool {
+		a, _ := lastA.Load().(string)
+		b, _ := lastB.Load().(string)
+
+		return a == payload && b == payload
+	}, 3*time.Second, 20*time.Millisecond,
+		"both mirror backends must receive the full unmodified body via independent readers")
+}
+
+func TestHandler_MultipleMirrors_OversizeBody_PrimaryStillSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// 1 MiB + 1 byte: deliberately just past maxMirrorBodySize (1 << 20) so
+	// every mirror's bufferMirrorBody hits the oversize branch.
+	const oversize = (1 << 20) + 1
+
+	primary, primaryLast := bodyEchoBackend(t)
+	mirrorA, hitsA := countingMirrorBackend(t)
+	mirrorB, hitsB := countingMirrorBackend(t)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Filters: []proxy.RouteFilter{
+					{Type: proxy.FilterRequestMirror, RequestMirror: &proxy.MirrorConfig{BackendURL: mirrorA.URL}},
+					{Type: proxy.FilterRequestMirror, RequestMirror: &proxy.MirrorConfig{BackendURL: mirrorB.URL}},
+				},
+				Backends: []proxy.BackendRef{{URL: primary.URL, Weight: 1}},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	body := strings.Repeat("a", oversize)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://app.example.com/", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode,
+		"primary must still succeed even when both mirrors skip on oversize body")
+
+	// Give any spurious mirror goroutines a chance to run before asserting zero.
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Zero(t, hitsA.Load(), "first mirror must skip on oversize body, got %d hits", hitsA.Load())
+	assert.Zero(t, hitsB.Load(), "second mirror must skip on oversize body, got %d hits", hitsB.Load())
+
+	got, _ := primaryLast.Load().(string)
+	assert.Len(t, got, oversize, "primary must receive the full body despite mirror skips")
+}
+
+func TestHandler_MirrorPercentZero_NeverMirrors(t *testing.T) {
+	t.Parallel()
+
+	primary := newBackend(t, "primary")
+	mirror, hits := countingMirrorBackend(t)
+	zero := int32(0)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Filters: []proxy.RouteFilter{
+					{Type: proxy.FilterRequestMirror, RequestMirror: &proxy.MirrorConfig{BackendURL: mirror.URL, Percent: &zero}},
+				},
+				Backends: []proxy.BackendRef{{URL: primary.URL, Weight: 1}},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	for range 100 {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	// Allow goroutines a moment in case any leaked through.
+	time.Sleep(200 * time.Millisecond)
+	assert.Zero(t, hits.Load(), "Percent=0 must never mirror; got %d requests", hits.Load())
+}
+
+func TestHandler_MirrorPercentDistribution(t *testing.T) {
+	t.Parallel()
+
+	primary := newBackend(t, "primary")
+	mirror, hits := countingMirrorBackend(t)
+	twenty := int32(20)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Filters: []proxy.RouteFilter{
+					{Type: proxy.FilterRequestMirror, RequestMirror: &proxy.MirrorConfig{BackendURL: mirror.URL, Percent: &twenty}},
+				},
+				Backends: []proxy.BackendRef{{URL: primary.URL, Weight: 1}},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	const totalRequests = 500
+	for range totalRequests {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	// Wait for fire-and-forget goroutines to drain. Require at least one
+	// hit before declaring "stable", otherwise the initial poll fires before
+	// any mirror goroutine has had a chance to run (hits==0, sleep, hits==0,
+	// "stable") and the assertion below evaluates a falsely-empty counter.
+	require.Eventually(t, func() bool {
+		first := hits.Load()
+		if first == 0 {
+			return false
+		}
+
+		time.Sleep(100 * time.Millisecond)
+
+		return hits.Load() == first
+	}, 10*time.Second, 200*time.Millisecond)
+
+	got := int(hits.Load())
+	// Upstream conformance uses ±15% tolerance over 500 requests; mirror that.
+	// 20% expected → ~100 mirrored; allow [50, 150].
+	const expected = totalRequests * 20 / 100
+	const tolerance = totalRequests * 15 / 100
+	assert.GreaterOrEqual(t, got, expected-tolerance,
+		"mirrored request count %d below 20%% expected ±15%% tolerance", got)
+	assert.LessOrEqual(t, got, expected+tolerance,
+		"mirrored request count %d above 20%% expected ±15%% tolerance", got)
 }
 
 func TestHandler_BackendProtocolToggleSameHostPort(t *testing.T) {

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -51,6 +51,8 @@ func TestGatewayAPIConformance(t *testing.T) {
 		features.SupportHTTPRouteBackendTimeout,
 		features.SupportHTTPRouteParentRefPort,
 		features.SupportHTTPRouteBackendProtocolH2C,
+		features.SupportHTTPRouteRequestMultipleMirrors,
+		features.SupportHTTPRouteRequestPercentageMirror,
 		// NOTE: 303/307/308 redirect status codes work correctly in the proxy,
 		// but Cloudflare edge rewrites Location scheme to HTTPS, so conformance
 		// tests that verify http:// scheme in redirects will always fail.
@@ -82,8 +84,6 @@ func TestGatewayAPIConformance(t *testing.T) {
 		features.SupportMesh,
 
 		// HTTPRoute features not implemented
-		features.SupportHTTPRouteRequestMultipleMirrors,
-		features.SupportHTTPRouteRequestPercentageMirror,
 		// HTTPRouteBackendProtocolWebSocket: the proxy could implement it, but the
 		// conformance suite dials the Gateway address directly with a ws:// client
 		// (no custom dialer hook), and *.cfargotunnel.com is not routable — same


### PR DESCRIPTION
# Pull Request

## Summary

Implement two more standard-channel HTTPRoute conformance features:

- `HTTPRouteRequestMultipleMirrors` — multiple `RequestMirror` filters per rule (Gateway API 1.5 relaxed the previous one-mirror cardinality).
- `HTTPRouteRequestPercentageMirror` — `percent` / `fraction` sampling on a mirror filter.

## Changes

- `MirrorConfig` gains an optional `Percent *int32`. `nil` keeps the previous "mirror every request" behaviour.
- Converter normalises `HTTPRequestMirrorFilter.Fraction` into `Percent` at conversion time (`numerator * 100 / denominator` in `int64` to defeat the `int32` overflow trap on large-denominator fractions), and `clampPercent` snaps to `[0, 100]`. The result is always a freshly allocated pointer — never an alias into the HTTPRoute storage.
- Mirror filter gates each request on a fair coin biased by `Percent` (`rand.Int32N(100) < pct`, via `math/rand/v2` which is goroutine-safe).
- `Config.Validate` rejects out-of-range `Percent` at the API boundary so misconfigurations surface as a 400 instead of silent zero-mirror.
- Multiple mirrors per rule already produced one `RouteFilter` per filter — pinned by new converter and integration tests, including a POST-body case asserting both mirrors receive the full unmodified payload.
- Conformance: `SupportHTTPRouteRequestMultipleMirrors` and `SupportHTTPRouteRequestPercentageMirror` move out of `ExemptFeatures` into `SupportedFeatures`.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m`, 0 issues)
- [x] Markdown linting passes
- [x] `mkdocs build --strict` clean
- [x] Direct unit tests for `shouldMirror` (nil / -1 / 0 / 1 / 50 / 100 / 101)
- [x] Converter tests for overflow, pointer aliasing, non-positive denominator, fraction normalization
- [x] Integration tests for: both mirrors receiving a GET; both mirrors receiving a POST body identically; `Percent=0` never mirrors; statistical distribution over 500 requests (15% tolerance); oversize body skip leaves primary intact
- [ ] Official Gateway API v1.5.1 conformance against the real Cloudflare Tunnel + homelab — will be run before merge

## Documentation

- [x] `docs/gateway-api/supported-resources.md` `RequestMirror` row updated to mention multiple backends and the `percent` / `fraction` precedence rule

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes — none; new `Percent` field is `omitempty`, default behaviour unchanged for existing configs
