### PR TITLE
feat: support BackendTLSPolicy with SAN validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,15 @@ Cloudflare Tunnel has path matching behavior that differs from Gateway API:
 
 **Workaround:** Use distinct path prefixes (e.g., `/alpha`, `/beta`, `/gamma`), or enable the L7 proxy.
 
-See [Path Matching Limitations](https://cf.k8s.lex.la/gateway-api/limitations/#cloudflare-tunnel-path-matching-limitations) for details.
+`BackendTLSPolicy` (proxy → backend TLS) is supported at minimum-viable scope:
+
+- Hostname-type `SubjectAltNames` only — URI/SPIFFE SANs are rejected with `Accepted=False, Reason=Invalid`
+- `WellKnownCACertificates: System` is not honoured — only explicit `CACertificateRefs`
+- Multi-policy conflicts resolve by oldest-creationTimestamp (then alphabetical), but losing policies are not yet stamped `Accepted=False, Reason=Conflicted`
+- HTTPS-listener Re-encrypt is not supported (Cloudflare terminates frontend TLS at the edge)
+- `RequestMirror` filter does NOT route mirrored traffic through the TLS-aware transport pool — when a `BackendTLSPolicy` targets a mirror destination the mirrored copy is sent in plaintext (the converter logs a WARN to surface this; tracked as a follow-up)
+
+See [Path Matching Limitations](https://cf.k8s.lex.la/gateway-api/limitations/#cloudflare-tunnel-path-matching-limitations) and [Backend mTLS](https://cf.k8s.lex.la/gateway-api/limitations/#backend-mtls-backendtlspolicy) for details.
 
 See [Gateway API documentation](https://cf.k8s.lex.la/gateway-api/) for full details and examples.
 

--- a/charts/cloudflare-tunnel-gateway-controller/templates/clusterrole.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/templates/clusterrole.yaml
@@ -21,9 +21,12 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["referencegrants"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["backendtlspolicies"]
+    verbs: ["get", "list", "watch"]
   # Gateway API status subresources - write access for status updates only
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status"]
+    resources: ["gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status", "backendtlspolicies/status"]
     verbs: ["get", "update", "patch"]
   - apiGroups: [""]
     resources: ["services", "namespaces"]

--- a/charts/cloudflare-tunnel-gateway-controller/tests/rbac_test.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/tests/rbac_test.yaml
@@ -74,6 +74,25 @@ tests:
             resources: ["referencegrants"]
             verbs: ["get", "list", "watch"]
 
+  - it: should have read-only permissions for BackendTLSPolicy
+    set:
+      cloudflare:
+        tunnelId: "test-tunnel-id"
+        apiToken: "test-api-token"
+    asserts:
+      - template: clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["backendtlspolicies"]
+            verbs: ["get", "list", "watch"]
+      # The strict `contains` above already pins the verb list — any addition
+      # of a write verb to the BackendTLSPolicy rule mutates the structure and
+      # makes the assertion fail. A separate `notContains` per write verb
+      # would be cosmetic (helm-unittest matches the whole content object, so
+      # a single-verb negative check can never trigger on a mixed-verb rule).
+
   - it: should have write permissions for Gateways (for finalizers)
     set:
       cloudflare:
@@ -113,7 +132,7 @@ tests:
           path: rules
           content:
             apiGroups: ["gateway.networking.k8s.io"]
-            resources: ["gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status"]
+            resources: ["gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status", "backendtlspolicies/status"]
             verbs: ["get", "update", "patch"]
 
   - it: should have full CRUD permissions for secrets (Helm SDK)

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -70,6 +70,22 @@ rules:
       - list
       - watch
   - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - backendtlspolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - backendtlspolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
       - ""
     resources:
       - services

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -219,6 +219,83 @@ test's `websocket.Dial` connects directly to the Gateway address
 tests documented above. WebSocket backends may be supported separately via
 e2e validation in a future change.
 
+## Backend mTLS (BackendTLSPolicy)
+
+The L7 proxy supports Gateway API `BackendTLSPolicy` for proxy → backend TLS,
+with the following minimum-viable scope:
+
+| Behaviour | Status | Notes |
+| --- | --- | --- |
+| CA via same-namespace `ConfigMap` ref with `ca.crt` | Yes | Core support level. The CA bundle is parsed as PEM and rejected with `Accepted=False, Reason=NoValidCACertificate` if it contains no `CERTIFICATE` blocks |
+| Multiple `CACertificateRefs` per policy | Yes | All bundles are concatenated into the trust pool |
+| `Hostname` as TLS SNI + authentication (when no SANs) | Yes | Required field; matches stdlib RFC 6125 hostname verification |
+| `SubjectAltNames` of type `Hostname` (OR-matching) | Yes | Cert must match at least one entry. Wildcards in the cert SAN list are honoured via `x509.Certificate.VerifyHostname`. When `SubjectAltNames` is set, `Hostname` is used for SNI only and NOT for authentication, per Gateway API spec |
+| `SubjectAltNames` of type `URI` (e.g. SPIFFE) | No | The policy is stamped `Accepted=False, Reason=Invalid` rather than silently dropping the URI entries — operators see a clear failure instead of a weaker-than-requested enforcement |
+| `WellKnownCACertificates: System` | No | Only explicit `CACertificateRefs` are honoured |
+| Multiple `targetRefs` per policy | Yes | All targeted Services share the same TLS config |
+| `SectionName` per-port targeting | Yes | When a `TargetRef` carries `sectionName`, only the matching named Service port receives TLS; siblings on the same Service stay plaintext |
+| Conflict resolution across multiple policies on the same target | Partial | Oldest-creationTimestamp wins, alphabetical name on tie. Losers are NOT yet stamped `Accepted=False, Reason=Conflicted` — they share the winner's `Accepted=True`. The upstream `BackendTLSPolicyConflictResolution` conformance subtest is skipped pending that work |
+| Cross-namespace CA refs | No | Same-namespace only |
+| `GatewayBackendClientCertificate` (mutual TLS) | No | Requires the experimental Gateway API CRD channel; homelab ships the standard channel |
+| HTTPS-listener Re-encrypt (frontend TLS termination + backend TLS) | No | Cloudflare terminates TLS at the edge, so HTTPS listeners aren't supported (see the HTTPRoute HTTPS Listener limitation). The upstream `BackendTLSPolicy` parent test is skipped for the same reason |
+
+Policy status (`Accepted` / `ResolvedRefs`) is maintained per-Gateway-ancestor.
+Edits to the CA `ConfigMap` (creation, content patch, or deletion) re-trigger
+status reconciliation. The `Status.Ancestors` slice is capped at the spec's
+limit of 16 entries; entries are sorted deterministically by
+`{namespace, name}` so the truncated set stays stable across reconciles.
+`LastTransitionTime` is maintained via `meta.SetStatusCondition`, so it
+only flips when `Status`, `Reason`, or `Message` actually changes.
+
+### Fail-closed enforcement
+
+When a `BackendTLSPolicy` targets a Service but cannot be enforced (CA
+`ConfigMap` missing or unreadable, `ca.crt` empty or malformed PEM,
+unsupported `SubjectAltName` type), the proxy receives a poisoned TLS config
+(empty CA pool) and the next request to that Service fails with HTTP 502 — it
+is NOT silently downgraded to plaintext. The operator's stated intent ("this
+hop MUST be authenticated TLS") is preserved. Monitor the policy's
+`Accepted` condition to detect the failure mode (`Reason=NoValidCACertificate`
+or `Reason=Invalid`).
+
+### Interaction with `appProtocol: kubernetes.io/h2c`
+
+When a backend Service carries both `appProtocol: kubernetes.io/h2c` AND a
+`BackendTLSPolicy` targets it, the policy wins: the proxy dials TLS (HTTPS,
+with HTTP/2 negotiated via ALPN). h2c is by definition cleartext HTTP/2 and
+cannot coexist with backend TLS; the h2c marker is silently ignored on that
+hop. If you genuinely want HTTP/2 over TLS, omit the `appProtocol` hint and
+let ALPN negotiate it during the handshake.
+
+### RequestMirror filter does not honour BackendTLSPolicy
+
+The Gateway API `RequestMirror` filter sends a fire-and-forget copy of the
+request to a secondary backend through a side-channel HTTP client that does
+NOT share the proxy's TLS-aware transport pool. If a `BackendTLSPolicy`
+targets the mirror destination Service, the mirrored copy is sent in
+plaintext — the primary leg still respects the policy, but the mirror leg
+silently bypasses it.
+
+The converter surfaces a WARN log when a mirror destination has a matching
+policy so operators don't ship a silent bypass. A TLS-aware mirror dial path
+is a tracked follow-up; until then, if the mirror destination MUST receive
+TLS, route mirror traffic through a separate Service without a policy or use
+weighted `backendRefs` instead of the mirror filter.
+
+### Interaction with `appProtocol: https` / `HTTPS`
+
+`appProtocol: https` (or `HTTPS`) is treated as a hint that the backend
+expects TLS — but the proxy cannot dial TLS on its own without a CA to
+verify against. The behaviour:
+
+- With a matching `BackendTLSPolicy`: the policy provides the CA, the proxy
+  dials TLS, and the request goes through normally. The `appProtocol` hint
+  is redundant but accepted silently.
+- Without a matching `BackendTLSPolicy`: the proxy logs a WARN and falls
+  back to plaintext HTTP/1.1. The misconfiguration is visible in logs so
+  operators don't ship a broken TLS expectation. Attach a `BackendTLSPolicy`
+  to upgrade the hop to authenticated TLS.
+
 ## Route Types Not Supported
 
 | Route Type | Status | Reason |

--- a/internal/controller/backendtlspolicy_controller.go
+++ b/internal/controller/backendtlspolicy_controller.go
@@ -1,0 +1,714 @@
+package controller
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"sort"
+
+	"github.com/cockroachdb/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// configMapCAKey is the well-known key inside a ConfigMap that holds the PEM
+// CA bundle, per Gateway API Core support level for BackendTLSPolicy.
+const configMapCAKey = "ca.crt"
+
+// policyAncestorStatusMaxCount caps Status.Ancestors per Gateway API spec
+// (MaxItems=16 on PolicyStatus.Ancestors). The API server would otherwise
+// reject status updates on policies that front more than 16 Gateways. Per
+// spec we MUST NOT add further entries when full; this implementation
+// preserves every other controller's entry fully and only truncates OUR
+// entries (sorted by {namespace, name} for determinism) to fit within the
+// remaining slots. Operators of co-installed Gateway implementations never
+// have their claims clobbered by ours.
+const policyAncestorStatusMaxCount = 16
+
+// Sentinel errors for BackendTLSPolicy CA validation so wrappers can be matched.
+var (
+	errBackendTLSNoCARef            = errors.New("BackendTLSPolicy has no CACertificateRefs (WellKnownCACertificates not supported)")
+	errBackendTLSUnsupportedGroup   = errors.New("BackendTLSPolicy CACertificateRef group not supported (only core)")
+	errBackendTLSUnsupportedKind    = errors.New("BackendTLSPolicy CACertificateRef kind not supported (only ConfigMap)")
+	errBackendTLSCAKeyMissing       = errors.New("BackendTLSPolicy CA ConfigMap is missing the ca.crt key")
+	errBackendTLSCABundleMalformed  = errors.New("BackendTLSPolicy CA bundle is not valid PEM")
+	errBackendTLSCABundleNoCerts    = errors.New("BackendTLSPolicy CA bundle contains no CERTIFICATE blocks")
+	errBackendTLSUnsupportedSANType = errors.New("BackendTLSPolicy SubjectAltName type not supported (only Hostname)")
+)
+
+// parseCABundle decodes every PEM block in the supplied bundle and verifies
+// that at least one of them is a parseable CERTIFICATE. It is intentionally
+// strict: a bundle containing exclusively non-CERTIFICATE blocks (or no PEM
+// blocks at all) is rejected so the operator sees Accepted=False rather than
+// silently shipping an empty trust pool to the proxy.
+func parseCABundle(bundle string) (int, error) {
+	rest := []byte(bundle)
+	parsed := 0
+
+	for {
+		var block *pem.Block
+
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+
+		if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+			return parsed, fmt.Errorf("%w (block %d): %w", errBackendTLSCABundleMalformed, parsed, err)
+		}
+
+		parsed++
+	}
+
+	if parsed == 0 {
+		return 0, errBackendTLSCABundleNoCerts
+	}
+
+	return parsed, nil
+}
+
+// getConfigMap fetches a ConfigMap by namespaced key. Returns the wrapped
+// apierror unchanged so callers can switch on apierrors.IsNotFound.
+func getConfigMap(ctx context.Context, c client.Client, key client.ObjectKey) (*corev1.ConfigMap, error) {
+	var configMap corev1.ConfigMap
+	if err := c.Get(ctx, key, &configMap); err != nil {
+		return nil, fmt.Errorf("get configmap %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	return &configMap, nil
+}
+
+// routeReferencesAnyService reports whether the HTTPRoute references any of
+// the named Services as a backend. Service-only refs are considered (group
+// "" or "core", kind "" or "Service").
+func routeReferencesAnyService(route *gatewayv1.HTTPRoute, targets map[string]struct{}) bool {
+	if len(targets) == 0 {
+		return false
+	}
+
+	for ruleIdx := range route.Spec.Rules {
+		for refIdx := range route.Spec.Rules[ruleIdx].BackendRefs {
+			ref := &route.Spec.Rules[ruleIdx].BackendRefs[refIdx].BackendRef
+			if !proxy.IsServiceBackendRef(ref.BackendObjectReference) {
+				continue
+			}
+
+			if _, hit := targets[string(ref.Name)]; hit {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// parentReferenceToKey resolves an HTTPRoute parentRef into a ClusterObjectKey,
+// using the route's own namespace when the ref omits the namespace field.
+func parentReferenceToKey(parentRef gatewayv1.ParentReference, routeNamespace string) client.ObjectKey {
+	namespace := routeNamespace
+	if parentRef.Namespace != nil {
+		namespace = string(*parentRef.Namespace)
+	}
+
+	return client.ObjectKey{Namespace: namespace, Name: string(parentRef.Name)}
+}
+
+// BackendTLSPolicyReconciler maintains the status of BackendTLSPolicy
+// resources: validates the CA references, computes Accepted and ResolvedRefs
+// conditions, and writes them under each affected Gateway as a policy ancestor.
+type BackendTLSPolicyReconciler struct {
+	client.Client
+
+	Scheme         *runtime.Scheme
+	ControllerName string
+}
+
+// Reconcile validates a BackendTLSPolicy against the cluster's current state
+// and refreshes its status conditions for every Gateway that fronts a route to
+// the policy's target Service. Resources we do not manage are ignored.
+func (r *BackendTLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var policy gatewayv1.BackendTLSPolicy
+	if err := r.Get(ctx, req.NamespacedName, &policy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, errors.Wrap(err, "failed to get BackendTLSPolicy")
+	}
+
+	gateways, err := r.gatewaysForPolicy(ctx, &policy)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to enumerate ancestor gateways")
+	}
+
+	if len(gateways) == 0 {
+		// No Gateway from our class references the target — nothing to claim.
+		return ctrl.Result{}, nil
+	}
+
+	conditions := r.computeConditions(ctx, &policy)
+	logger.Info("reconciling BackendTLSPolicy",
+		"name", policy.Name,
+		"namespace", policy.Namespace,
+		"gateways", len(gateways),
+	)
+
+	if err := r.updateStatus(ctx, req.NamespacedName, gateways, conditions); err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to update BackendTLSPolicy status")
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// computeConditions evaluates the policy spec and returns the two conditions
+// to expose (Accepted and ResolvedRefs) per Gateway API semantics.
+//
+//   - Unsupported SubjectAltName type (URI etc.): Accepted=False, Reason=Invalid;
+//     ResolvedRefs is reported True because CA refs themselves resolved cleanly.
+//   - CA reference invalid or unresolvable: Accepted=False, Reason=NoValidCACertificate;
+//     ResolvedRefs=False, Reason=InvalidCACertificateRef.
+//   - All happy: both True.
+//
+// LastTransitionTime is left zero; callers route through meta.SetStatusCondition
+// in updateStatus so the timestamp reflects an actual transition rather than
+// flapping on every reconcile.
+func (r *BackendTLSPolicyReconciler) computeConditions(
+	ctx context.Context,
+	policy *gatewayv1.BackendTLSPolicy,
+) []metav1.Condition {
+	if err := r.validateSANs(policy); err != nil {
+		return sanInvalidConditions(policy.Generation, err)
+	}
+
+	if err := r.validateCARefs(ctx, policy); err != nil {
+		return caInvalidConditions(policy.Generation, err)
+	}
+
+	return acceptedConditions(policy.Generation)
+}
+
+// sanInvalidConditions returns Accepted=False/Invalid + ResolvedRefs=True for
+// the URI-SAN-not-supported case: CA refs themselves resolved fine but the
+// policy is rejected by the controller for an unsupported SubjectAltName type.
+func sanInvalidConditions(generation int64, err error) []metav1.Condition {
+	return []metav1.Condition{
+		{
+			Type:               string(gatewayv1.PolicyConditionAccepted),
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: generation,
+			Reason:             string(gatewayv1.PolicyReasonInvalid),
+			Message:            err.Error(),
+		},
+		{
+			Type:               string(gatewayv1.BackendTLSPolicyConditionResolvedRefs),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: generation,
+			Reason:             string(gatewayv1.BackendTLSPolicyReasonResolvedRefs),
+			Message:            "CA references resolved; SAN validation rejected the policy",
+		},
+	}
+}
+
+// caInvalidConditions returns the Accepted=False/NoValidCACertificate +
+// ResolvedRefs=False conditions, picking the most specific ResolvedRefs Reason
+// from the underlying validation error. Group/Kind mismatches map to
+// InvalidKind per the conformance suite; everything else (missing CM, missing
+// or empty ca.crt, malformed PEM) falls back to InvalidCACertificateRef.
+func caInvalidConditions(generation int64, err error) []metav1.Condition {
+	resolvedRefsReason := gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef
+	if errors.Is(err, errBackendTLSUnsupportedKind) || errors.Is(err, errBackendTLSUnsupportedGroup) {
+		resolvedRefsReason = gatewayv1.BackendTLSPolicyReasonInvalidKind
+	}
+
+	return []metav1.Condition{
+		{
+			Type:               string(gatewayv1.PolicyConditionAccepted),
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: generation,
+			Reason:             string(gatewayv1.BackendTLSPolicyReasonNoValidCACertificate),
+			Message:            err.Error(),
+		},
+		{
+			Type:               string(gatewayv1.BackendTLSPolicyConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: generation,
+			Reason:             string(resolvedRefsReason),
+			Message:            err.Error(),
+		},
+	}
+}
+
+// acceptedConditions returns the happy-path Accepted=True + ResolvedRefs=True pair.
+func acceptedConditions(generation int64) []metav1.Condition {
+	return []metav1.Condition{
+		{
+			Type:               string(gatewayv1.PolicyConditionAccepted),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: generation,
+			Reason:             string(gatewayv1.PolicyReasonAccepted),
+			Message:            "BackendTLSPolicy CA references resolved",
+		},
+		{
+			Type:               string(gatewayv1.BackendTLSPolicyConditionResolvedRefs),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: generation,
+			Reason:             string(gatewayv1.BackendTLSPolicyReasonResolvedRefs),
+			Message:            "All CA certificate references resolved",
+		},
+	}
+}
+
+// validateSANs rejects any SubjectAltName whose type is not Hostname. URI-type
+// SANs (SPIFFE etc.) are not yet implemented end-to-end and silently dropping
+// them would weaken the policy below what the operator requested.
+func (r *BackendTLSPolicyReconciler) validateSANs(policy *gatewayv1.BackendTLSPolicy) error {
+	for _, san := range policy.Spec.Validation.SubjectAltNames {
+		if san.Type != gatewayv1.HostnameSubjectAltNameType {
+			return fmt.Errorf("%w: %q", errBackendTLSUnsupportedSANType, san.Type)
+		}
+	}
+
+	return nil
+}
+
+// validateCARefs returns an error describing the first invalid CA reference,
+// or nil when every reference resolves to a ConfigMap whose "ca.crt" key
+// contains at least one parseable PEM CERTIFICATE block. Only same-namespace
+// ConfigMap refs are supported (Core).
+func (r *BackendTLSPolicyReconciler) validateCARefs(
+	ctx context.Context,
+	policy *gatewayv1.BackendTLSPolicy,
+) error {
+	refs := policy.Spec.Validation.CACertificateRefs
+	if len(refs) == 0 {
+		return errBackendTLSNoCARef
+	}
+
+	for _, ref := range refs {
+		group := string(ref.Group)
+		if group != "" && group != coreGroup {
+			return fmt.Errorf("%w: %q", errBackendTLSUnsupportedGroup, group)
+		}
+
+		if string(ref.Kind) != configMapKind {
+			return fmt.Errorf("%w: %q", errBackendTLSUnsupportedKind, ref.Kind)
+		}
+
+		key := client.ObjectKey{Namespace: policy.Namespace, Name: string(ref.Name)}
+
+		configMap, err := getConfigMap(ctx, r.Client, key)
+		if err != nil {
+			return err
+		}
+
+		bundle := configMap.Data[configMapCAKey]
+		if bundle == "" {
+			return fmt.Errorf("%w: %s/%s key %q is empty or missing",
+				errBackendTLSCAKeyMissing, key.Namespace, key.Name, configMapCAKey)
+		}
+
+		if _, err := parseCABundle(bundle); err != nil {
+			return fmt.Errorf("ConfigMap %s/%s: %w", key.Namespace, key.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// gatewaysForPolicy returns the Gateways managed by this controller that
+// front any HTTPRoute referencing the policy's target Service. We carry that
+// list into Status.Ancestors as the policy's parent context.
+func (r *BackendTLSPolicyReconciler) gatewaysForPolicy(
+	ctx context.Context,
+	policy *gatewayv1.BackendTLSPolicy,
+) ([]gatewayv1.Gateway, error) {
+	if len(policy.Spec.TargetRefs) == 0 {
+		return nil, nil
+	}
+
+	targetServices := make(map[string]struct{}, len(policy.Spec.TargetRefs))
+
+	for _, target := range policy.Spec.TargetRefs {
+		kind := string(target.Kind)
+		if kind != "" && kind != serviceKind {
+			continue
+		}
+
+		targetServices[string(target.Name)] = struct{}{}
+	}
+
+	var routes gatewayv1.HTTPRouteList
+	if err := r.List(ctx, &routes, client.InNamespace(policy.Namespace)); err != nil {
+		return nil, fmt.Errorf("list httproutes: %w", err)
+	}
+
+	gatewayKeys := collectGatewayKeys(routes.Items, targetServices)
+
+	gateways := make([]gatewayv1.Gateway, 0, len(gatewayKeys))
+
+	for _, key := range gatewayKeys {
+		var gateway gatewayv1.Gateway
+		if err := r.Get(ctx, key, &gateway); err != nil {
+			continue
+		}
+
+		managed, err := r.gatewayManagedByUs(ctx, &gateway)
+		if err != nil || !managed {
+			continue
+		}
+
+		gateways = append(gateways, gateway)
+	}
+
+	return gateways, nil
+}
+
+// collectGatewayKeys returns the deterministic, sorted set of Gateway keys
+// reached by HTTPRoutes that reference any of the target services. Sorting by
+// {namespace, name} keeps Status.Ancestors stable across reconciles, which
+// matters once a policy fronts more than 16 Gateways and updateStatus has to
+// truncate.
+func collectGatewayKeys(
+	routes []gatewayv1.HTTPRoute,
+	targetServices map[string]struct{},
+) []client.ObjectKey {
+	gatewayKeySet := map[client.ObjectKey]struct{}{}
+
+	for routeIdx := range routes {
+		route := &routes[routeIdx]
+		if !routeReferencesAnyService(route, targetServices) {
+			continue
+		}
+
+		for _, parentRef := range route.Spec.ParentRefs {
+			gatewayKeySet[parentReferenceToKey(parentRef, route.Namespace)] = struct{}{}
+		}
+	}
+
+	gatewayKeys := make([]client.ObjectKey, 0, len(gatewayKeySet))
+	for key := range gatewayKeySet {
+		gatewayKeys = append(gatewayKeys, key)
+	}
+
+	sort.Slice(gatewayKeys, func(left, right int) bool {
+		if gatewayKeys[left].Namespace != gatewayKeys[right].Namespace {
+			return gatewayKeys[left].Namespace < gatewayKeys[right].Namespace
+		}
+
+		return gatewayKeys[left].Name < gatewayKeys[right].Name
+	})
+
+	return gatewayKeys
+}
+
+// gatewayManagedByUs reports whether the Gateway's GatewayClass binds to this
+// controller. Matches the existing pattern used by mappers and reconcilers.
+func (r *BackendTLSPolicyReconciler) gatewayManagedByUs(ctx context.Context, gateway *gatewayv1.Gateway) (bool, error) {
+	var gatewayClass gatewayv1.GatewayClass
+
+	key := client.ObjectKey{Name: string(gateway.Spec.GatewayClassName)}
+	if err := r.Get(ctx, key, &gatewayClass); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("get GatewayClass %s: %w", key.Name, err)
+	}
+
+	return string(gatewayClass.Spec.ControllerName) == r.ControllerName, nil
+}
+
+// updateStatus replaces this controller's entries in Status.Ancestors with one
+// entry per managed Gateway, carrying the supplied conditions. Other
+// controllers' entries are preserved. meta.SetStatusCondition is used to
+// merge each condition into the existing ancestor (when present), preserving
+// LastTransitionTime when neither Status, Reason, nor Message changed.
+func (r *BackendTLSPolicyReconciler) updateStatus(
+	ctx context.Context,
+	policyKey client.ObjectKey,
+	gateways []gatewayv1.Gateway,
+	conditions []metav1.Condition,
+) error {
+	//nolint:wrapcheck // retry wrapper handles errors internally
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var fresh gatewayv1.BackendTLSPolicy
+		if err := r.Get(ctx, policyKey, &fresh); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+
+			return err //nolint:wrapcheck // unwrapped to participate in retry
+		}
+
+		existing := map[client.ObjectKey][]metav1.Condition{}
+		otherControllerEntries := make([]gatewayv1.PolicyAncestorStatus, 0, len(fresh.Status.Ancestors))
+
+		for _, ancestor := range fresh.Status.Ancestors {
+			if string(ancestor.ControllerName) != r.ControllerName {
+				otherControllerEntries = append(otherControllerEntries, ancestor)
+
+				continue
+			}
+
+			// Remember our previous conditions per Gateway so SetStatusCondition
+			// can decide whether LastTransitionTime needs to flip.
+			key := ancestorRefKey(ancestor.AncestorRef, fresh.Namespace)
+			existing[key] = ancestor.Conditions
+		}
+
+		ourEntries := make([]gatewayv1.PolicyAncestorStatus, 0, len(gateways))
+
+		for gwIdx := range gateways {
+			gateway := &gateways[gwIdx]
+			ancestorRef := gatewayAncestorRef(gateway)
+
+			key := client.ObjectKey{Namespace: gateway.Namespace, Name: gateway.Name}
+			merged := append([]metav1.Condition(nil), existing[key]...)
+
+			for _, condition := range conditions {
+				meta.SetStatusCondition(&merged, condition)
+			}
+
+			ourEntries = append(ourEntries, gatewayv1.PolicyAncestorStatus{
+				AncestorRef:    ancestorRef,
+				ControllerName: gatewayv1.GatewayController(r.ControllerName),
+				Conditions:     merged,
+			})
+		}
+
+		// Reserve the full slot count for other controllers' entries first;
+		// only OUR entries get truncated when the combined set exceeds the
+		// spec's 16-entry cap. Other controllers' status MUST NOT be dropped
+		// by our reconciler.
+		available := max(policyAncestorStatusMaxCount-len(otherControllerEntries), 0)
+
+		if len(ourEntries) > available {
+			ourEntries = ourEntries[:available]
+		}
+
+		combined := otherControllerEntries
+		combined = append(combined, ourEntries...)
+		fresh.Status.Ancestors = combined
+
+		return r.Status().Update(ctx, &fresh) //nolint:wrapcheck // unwrapped to participate in retry
+	})
+}
+
+// gatewayAncestorRef returns the ParentReference identifying the supplied
+// Gateway as a BackendTLSPolicy ancestor.
+func gatewayAncestorRef(gateway *gatewayv1.Gateway) gatewayv1.ParentReference {
+	gatewayGroup := gatewayv1.GroupName
+	gatewayKind := gatewayv1.Kind("Gateway")
+	gatewayNamespace := gatewayv1.Namespace(gateway.Namespace)
+
+	return gatewayv1.ParentReference{
+		Group:     (*gatewayv1.Group)(&gatewayGroup),
+		Kind:      &gatewayKind,
+		Namespace: &gatewayNamespace,
+		Name:      gatewayv1.ObjectName(gateway.Name),
+	}
+}
+
+// ancestorRefKey resolves an AncestorRef back to a {Namespace, Name} key.
+// Falls back to the policy's own namespace when the ref omits Namespace.
+func ancestorRefKey(ref gatewayv1.ParentReference, policyNamespace string) client.ObjectKey {
+	namespace := policyNamespace
+	if ref.Namespace != nil {
+		namespace = string(*ref.Namespace)
+	}
+
+	return client.ObjectKey{Namespace: namespace, Name: string(ref.Name)}
+}
+
+// setupStatusReconcilers builds and registers the reconcilers responsible only
+// for updating status conditions on Gateway API resources we don't otherwise
+// drive (GatewayClass acceptance, BackendTLSPolicy ancestry). Extracted from
+// the top-level Run() to keep its cyclomatic complexity within budget.
+func setupStatusReconcilers(mgr ctrl.Manager, controllerName string) error {
+	gatewayClassReconciler := &GatewayClassReconciler{
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		ControllerName: controllerName,
+	}
+
+	if err := gatewayClassReconciler.SetupWithManager(mgr); err != nil {
+		return errors.Wrap(err, "failed to setup gatewayclass controller")
+	}
+
+	backendTLSPolicyReconciler := &BackendTLSPolicyReconciler{
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		ControllerName: controllerName,
+	}
+
+	if err := backendTLSPolicyReconciler.SetupWithManager(mgr); err != nil {
+		return errors.Wrap(err, "failed to setup BackendTLSPolicy controller")
+	}
+
+	return nil
+}
+
+// SetupWithManager wires the reconciler with watches for BackendTLSPolicy,
+// HTTPRoutes (target-service membership), and ConfigMaps (CA bundle source).
+// The ConfigMap watch is what lets policy status flip from
+// NoValidCACertificate to Accepted when an absent CA ConfigMap is later
+// created (or back, when its ca.crt key is emptied).
+func (r *BackendTLSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&gatewayv1.BackendTLSPolicy{}).
+		Watches(
+			&gatewayv1.HTTPRoute{},
+			handler.EnqueueRequestsFromMapFunc(r.policiesForRouteChange),
+		).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.policiesForConfigMapChange),
+		).
+		Complete(r)
+	if err != nil {
+		return errors.Wrap(err, "failed to setup BackendTLSPolicy controller")
+	}
+
+	return nil
+}
+
+// policiesForConfigMapChange enqueues every BackendTLSPolicy in the changed
+// ConfigMap's namespace that references the ConfigMap by name as a CA source.
+// Per Gateway API Core, only same-namespace ConfigMap refs are supported, so
+// the namespace check matches the reconciler's own validateCARefs scope.
+func (r *BackendTLSPolicyReconciler) policiesForConfigMapChange(ctx context.Context, obj client.Object) []reconcile.Request {
+	configMap, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		return nil
+	}
+
+	var policies gatewayv1.BackendTLSPolicyList
+	if err := r.List(ctx, &policies, client.InNamespace(configMap.Namespace)); err != nil {
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0)
+
+	for policyIdx := range policies.Items {
+		policy := &policies.Items[policyIdx]
+		if !policyReferencesConfigMap(policy, configMap.Name) {
+			continue
+		}
+
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKey{Namespace: policy.Namespace, Name: policy.Name},
+		})
+	}
+
+	return requests
+}
+
+// isConfigMapReferencedByBackendTLSPolicy reports whether the supplied
+// ConfigMap is referenced as a CA bundle source by any BackendTLSPolicy in
+// the same namespace. Used by the route reconciler's ConfigMap watch
+// predicate to suppress kube-root-ca, leader-election, and other unrelated
+// ConfigMap events that would otherwise trigger a full proxy resync.
+func isConfigMapReferencedByBackendTLSPolicy(ctx context.Context, c client.Client, configMap *corev1.ConfigMap) bool {
+	var policies gatewayv1.BackendTLSPolicyList
+	if err := c.List(ctx, &policies, client.InNamespace(configMap.Namespace)); err != nil {
+		return false
+	}
+
+	for policyIdx := range policies.Items {
+		if policyReferencesConfigMap(&policies.Items[policyIdx], configMap.Name) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// policyReferencesConfigMap reports whether the policy lists the named
+// ConfigMap among its CACertificateRefs (group ""/"core", kind "ConfigMap").
+func policyReferencesConfigMap(policy *gatewayv1.BackendTLSPolicy, configMapName string) bool {
+	for _, ref := range policy.Spec.Validation.CACertificateRefs {
+		group := string(ref.Group)
+		if group != "" && group != coreGroup {
+			continue
+		}
+
+		if string(ref.Kind) != configMapKind {
+			continue
+		}
+
+		if string(ref.Name) == configMapName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// policiesForRouteChange enqueues only the BackendTLSPolicies in the route's
+// namespace whose TargetRefs intersect the route's backendRefs. A change to a
+// route that doesn't touch a policy's target Service should not bump that
+// policy's status (saves the reconciler from doing full work on every
+// unrelated route edit in busy namespaces).
+func (r *BackendTLSPolicyReconciler) policiesForRouteChange(ctx context.Context, obj client.Object) []reconcile.Request {
+	route, ok := obj.(*gatewayv1.HTTPRoute)
+	if !ok {
+		return nil
+	}
+
+	var policies gatewayv1.BackendTLSPolicyList
+	if err := r.List(ctx, &policies, client.InNamespace(route.Namespace)); err != nil {
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(policies.Items))
+
+	for policyIdx := range policies.Items {
+		policy := &policies.Items[policyIdx]
+		if !policyTargetsAnyRouteBackend(policy, route) {
+			continue
+		}
+
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKey{Namespace: policy.Namespace, Name: policy.Name},
+		})
+	}
+
+	return requests
+}
+
+// policyTargetsAnyRouteBackend reports whether the policy's TargetRefs include
+// at least one Service that the route also references as a backend. Used by
+// policiesForRouteChange to skip irrelevant policies on every HTTPRoute edit.
+func policyTargetsAnyRouteBackend(policy *gatewayv1.BackendTLSPolicy, route *gatewayv1.HTTPRoute) bool {
+	targets := map[string]struct{}{}
+
+	for _, target := range policy.Spec.TargetRefs {
+		kind := string(target.Kind)
+		if kind != "" && kind != serviceKind {
+			continue
+		}
+
+		targets[string(target.Name)] = struct{}{}
+	}
+
+	return routeReferencesAnyService(route, targets)
+}

--- a/internal/controller/backendtlspolicy_controller_test.go
+++ b/internal/controller/backendtlspolicy_controller_test.go
@@ -1,0 +1,1232 @@
+package controller
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// errSimulatedCacheMiss is reused by tests that need an interceptor to fail
+// a cache List call deterministically.
+var errSimulatedCacheMiss = errors.New("simulated cache miss")
+
+// generateSelfSignedCAPEM produces a tiny self-signed CA cert and returns it
+// as a PEM string. Used so tests exercise the same parseCABundle path that
+// production controllers run.
+func generateSelfSignedCAPEM(t *testing.T) string {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageCertSign,
+		IsCA:         true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	return string(pemBytes)
+}
+
+// gatewayClassFor builds a GatewayClass tied to the given controllerName.
+func gatewayClassFor(name, controllerName string) *gatewayv1.GatewayClass {
+	return &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: gatewayv1.GatewayController(controllerName)},
+	}
+}
+
+// gatewayFor builds a Gateway in ns with the given GatewayClass reference.
+func gatewayFor(namespace, name, gatewayClassName string) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName(gatewayClassName)},
+	}
+}
+
+// httpRouteFor builds an HTTPRoute with one rule pointing at the given backend
+// Service. parentGwName is recorded as the only parentRef in the same namespace.
+func httpRouteFor(namespace, name, parentGwName, backendServiceName string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(parentGwName)},
+				},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(backendServiceName),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// caConfigMap builds a ConfigMap in ns/name holding the supplied PEM bundle
+// under the "ca.crt" key.
+func caConfigMap(namespace, name, pemBundle string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Data:       map[string]string{configMapCAKey: pemBundle},
+	}
+}
+
+// backendTLSPolicyFor builds a BackendTLSPolicy targeting the named Service
+// with the given CA-cert ConfigMap reference. Optional creationTimestamp lets
+// tests model precedence ordering.
+func backendTLSPolicyFor(
+	namespace, name, serviceName, configMapName string,
+	creationTimestamp time.Time,
+) *gatewayv1.BackendTLSPolicy {
+	kindService := gatewayv1.Kind(serviceKind)
+	kindConfigMap := gatewayv1.Kind(configMapKind)
+
+	policy := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  namespace,
+			Name:       name,
+			Generation: 1,
+		},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				{
+					LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+						Kind: kindService,
+						Name: gatewayv1.ObjectName(serviceName),
+					},
+				},
+			},
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				CACertificateRefs: []gatewayv1.LocalObjectReference{
+					{
+						Kind: kindConfigMap,
+						Name: gatewayv1.ObjectName(configMapName),
+					},
+				},
+				Hostname: "test.example.com",
+			},
+		},
+	}
+
+	if !creationTimestamp.IsZero() {
+		policy.CreationTimestamp = metav1.NewTime(creationTimestamp)
+	}
+
+	return policy
+}
+
+func newBackendTLSPolicyScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	return scheme
+}
+
+// ---- parseCABundle ----
+
+func TestParseCABundle_AcceptsValidCert(t *testing.T) {
+	t.Parallel()
+
+	pemString := generateSelfSignedCAPEM(t)
+
+	count, err := parseCABundle(pemString)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestParseCABundle_RejectsNoCertificateBlocks(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseCABundle("not a pem block at all")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errBackendTLSCABundleNoCerts))
+}
+
+func TestParseCABundle_RejectsMalformedCert(t *testing.T) {
+	t.Parallel()
+
+	garbagePEM := "-----BEGIN CERTIFICATE-----\nQUFBQQ==\n-----END CERTIFICATE-----\n"
+
+	_, err := parseCABundle(garbagePEM)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errBackendTLSCABundleMalformed))
+}
+
+// ---- validateCARefs ----
+
+func TestValidateCARefs_NoRefs(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	policy := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p"},
+	}
+
+	err := r.validateCARefs(context.Background(), policy)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errBackendTLSNoCARef))
+}
+
+func TestValidateCARefs_UnsupportedGroup(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	badGroup := gatewayv1.Group("apps")
+	policy := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p"},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				CACertificateRefs: []gatewayv1.LocalObjectReference{
+					{Group: badGroup, Kind: configMapKind, Name: "x"},
+				},
+			},
+		},
+	}
+
+	err := r.validateCARefs(context.Background(), policy)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errBackendTLSUnsupportedGroup))
+}
+
+func TestValidateCARefs_UnsupportedKind(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	policy := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p"},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				CACertificateRefs: []gatewayv1.LocalObjectReference{
+					{Kind: "Secret", Name: "x"},
+				},
+			},
+		},
+	}
+
+	err := r.validateCARefs(context.Background(), policy)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errBackendTLSUnsupportedKind))
+}
+
+func TestValidateCARefs_ConfigMapNotFound(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "missing-cm", time.Time{})
+
+	err := r.validateCARefs(context.Background(), policy)
+	require.Error(t, err)
+	// Not-found errors aren't wrapped by a sentinel — only verify it errors.
+}
+
+func TestValidateCARefs_EmptyCAKey(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	configMap := caConfigMap("ns", "cm", "")
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+
+	err := r.validateCARefs(context.Background(), policy)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errBackendTLSCAKeyMissing))
+}
+
+func TestValidateCARefs_MalformedPEM(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	configMap := caConfigMap("ns", "cm", "not actually pem")
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+
+	err := r.validateCARefs(context.Background(), policy)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errBackendTLSCABundleNoCerts))
+}
+
+func TestValidateCARefs_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	configMap := caConfigMap("ns", "cm", generateSelfSignedCAPEM(t))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+
+	err := r.validateCARefs(context.Background(), policy)
+	require.NoError(t, err)
+}
+
+// ---- validateSANs ----
+
+func TestValidateSANs_AcceptsHostnameOnly(t *testing.T) {
+	t.Parallel()
+
+	r := &BackendTLSPolicyReconciler{ControllerName: "test"}
+
+	policy := &gatewayv1.BackendTLSPolicy{
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				SubjectAltNames: []gatewayv1.SubjectAltName{
+					{Type: gatewayv1.HostnameSubjectAltNameType, Hostname: "alt.example.com"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, r.validateSANs(policy))
+}
+
+func TestValidateSANs_RejectsURIType(t *testing.T) {
+	t.Parallel()
+
+	r := &BackendTLSPolicyReconciler{ControllerName: "test"}
+
+	uriType := gatewayv1.URISubjectAltNameType
+	policy := &gatewayv1.BackendTLSPolicy{
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				SubjectAltNames: []gatewayv1.SubjectAltName{
+					{Type: uriType},
+				},
+			},
+		},
+	}
+
+	err := r.validateSANs(policy)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errBackendTLSUnsupportedSANType))
+}
+
+// ---- computeConditions ----
+
+func TestComputeConditions_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	configMap := caConfigMap("ns", "cm", generateSelfSignedCAPEM(t))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	policy.Generation = 5
+
+	conditions := r.computeConditions(context.Background(), policy)
+
+	require.Len(t, conditions, 2)
+	assert.Equal(t, string(gatewayv1.PolicyConditionAccepted), conditions[0].Type)
+	assert.Equal(t, metav1.ConditionTrue, conditions[0].Status)
+	assert.Equal(t, string(gatewayv1.PolicyReasonAccepted), conditions[0].Reason)
+	assert.Equal(t, int64(5), conditions[0].ObservedGeneration)
+	assert.Equal(t, string(gatewayv1.BackendTLSPolicyConditionResolvedRefs), conditions[1].Type)
+	assert.Equal(t, metav1.ConditionTrue, conditions[1].Status)
+}
+
+func TestComputeConditions_InvalidKind(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	policy := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p", Generation: 3},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				CACertificateRefs: []gatewayv1.LocalObjectReference{
+					{Kind: "Secret", Name: "secret-as-ca"},
+				},
+			},
+		},
+	}
+
+	conditions := r.computeConditions(context.Background(), policy)
+
+	require.Len(t, conditions, 2)
+	assert.Equal(t, metav1.ConditionFalse, conditions[0].Status)
+	assert.Equal(t, string(gatewayv1.BackendTLSPolicyReasonNoValidCACertificate), conditions[0].Reason)
+	assert.Equal(t, string(gatewayv1.BackendTLSPolicyReasonInvalidKind), conditions[1].Reason)
+	assert.Equal(t, int64(3), conditions[0].ObservedGeneration)
+	assert.Equal(t, int64(3), conditions[1].ObservedGeneration)
+}
+
+func TestComputeConditions_InvalidCACertificateRef(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "nonexistent-cm", time.Time{})
+
+	conditions := r.computeConditions(context.Background(), policy)
+
+	require.Len(t, conditions, 2)
+	assert.Equal(t, metav1.ConditionFalse, conditions[0].Status)
+	assert.Equal(t, string(gatewayv1.BackendTLSPolicyReasonNoValidCACertificate), conditions[0].Reason)
+	assert.Equal(t, string(gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef), conditions[1].Reason)
+}
+
+func TestComputeConditions_URISANRejected(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	uriType := gatewayv1.URISubjectAltNameType
+	policy := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p", Generation: 7},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				SubjectAltNames: []gatewayv1.SubjectAltName{{Type: uriType}},
+			},
+		},
+	}
+
+	conditions := r.computeConditions(context.Background(), policy)
+
+	require.Len(t, conditions, 2)
+	assert.Equal(t, metav1.ConditionFalse, conditions[0].Status)
+	assert.Equal(t, string(gatewayv1.PolicyReasonInvalid), conditions[0].Reason)
+	// SAN failure does not invalidate the CA refs themselves.
+	assert.Equal(t, metav1.ConditionTrue, conditions[1].Status)
+	assert.Equal(t, string(gatewayv1.BackendTLSPolicyReasonResolvedRefs), conditions[1].Reason)
+	assert.Equal(t, int64(7), conditions[0].ObservedGeneration)
+}
+
+// ---- selectPolicyForService / isPolicyOlder / policyTargetsService ----
+
+// alwaysEmptyPortName is a resolvePortName stub for tests where SectionName
+// is not expected to matter (no SectionName on the policies under test).
+func alwaysEmptyPortName() string { return "" }
+
+// TestUpdateStatus_ConflictResolution_LoserSharesAcceptedTrue pins the
+// current gap from Gateway API's GEP-713 conflict-resolution semantics: when
+// two policies target the same Service, this controller picks the older one
+// as the "winner" (correctly) but does NOT stamp the loser with
+// `Accepted=False, Reason=Conflicted`. The loser shares the winner's
+// `Accepted=True` status, which is observable to clients reading either
+// policy's Status.Ancestors.
+//
+// When the conflict-resolution logic lands (loser stamped with Conflicted
+// reason), flip this test to assert `Accepted=False, Reason=Conflicted` on
+// the losing policy and unskip BackendTLSPolicyConflictResolution in the
+// conformance suite (test/conformance/conformance_test.go).
+func TestUpdateStatus_ConflictResolution_LoserSharesAcceptedTrue(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	// Two policies, same target Service, distinct creationTimestamps. Older
+	// wins; without conflict tracking the loser also gets Accepted=True from
+	// its own reconcile (it doesn't see the winner).
+	winner := backendTLSPolicyFor("ns", "winner", "svc", "cm", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	loser := backendTLSPolicyFor("ns", "loser", "svc", "cm", time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(winner, loser).
+		WithStatusSubresource(winner, loser).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test-controller"}
+
+	gateway := *gatewayFor("ns", "gw", "cf-class")
+	conditions := acceptedConditions(loser.Generation)
+
+	// Reconcile the loser as if no conflict exists — it gets Accepted=True.
+	require.NoError(t, r.updateStatus(context.Background(),
+		client.ObjectKey{Namespace: "ns", Name: "loser"},
+		[]gatewayv1.Gateway{gateway}, conditions))
+
+	var refreshed gatewayv1.BackendTLSPolicy
+	require.NoError(t, fakeClient.Get(context.Background(),
+		client.ObjectKey{Namespace: "ns", Name: "loser"}, &refreshed))
+	require.Len(t, refreshed.Status.Ancestors, 1)
+
+	// Pending follow-up: when conflict resolution lands the loser MUST be
+	// Accepted=False, Reason=Conflicted. Pinning the current gap here.
+	accepted := false
+
+	for _, condition := range refreshed.Status.Ancestors[0].Conditions {
+		if condition.Type == string(gatewayv1.PolicyConditionAccepted) && condition.Status == metav1.ConditionTrue {
+			accepted = true
+		}
+	}
+
+	assert.True(t, accepted,
+		"FIXME: currently the losing policy shares the winner's Accepted=True. "+
+			"When conflict tracking lands, flip this assertion to expect "+
+			"Accepted=False, Reason=Conflicted, and unskip BackendTLSPolicyConflictResolution "+
+			"in test/conformance/conformance_test.go.")
+}
+
+func TestSelectPolicyForServicePort_OlderWins(t *testing.T) {
+	t.Parallel()
+
+	older := *backendTLSPolicyFor("ns", "policy-z", "svc", "cm", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	newer := *backendTLSPolicyFor("ns", "policy-a", "svc", "cm", time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	winner := selectPolicyForServicePort(context.Background(), fakeClient,
+		[]gatewayv1.BackendTLSPolicy{newer, older}, "ns", "svc", 443)
+	require.NotNil(t, winner)
+	assert.Equal(t, "policy-z", winner.Name)
+}
+
+func TestSelectPolicyForServicePort_TieBreaksAlphabetically(t *testing.T) {
+	t.Parallel()
+
+	sameTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	policyA := *backendTLSPolicyFor("ns", "alpha", "svc", "cm", sameTime)
+	policyB := *backendTLSPolicyFor("ns", "beta", "svc", "cm", sameTime)
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	winner := selectPolicyForServicePort(context.Background(), fakeClient,
+		[]gatewayv1.BackendTLSPolicy{policyB, policyA}, "ns", "svc", 443)
+	require.NotNil(t, winner)
+	assert.Equal(t, "alpha", winner.Name)
+}
+
+func TestSelectPolicyForServicePort_NoMatchReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	policy := *backendTLSPolicyFor("ns", "p", "other-svc", "cm", time.Time{})
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	winner := selectPolicyForServicePort(context.Background(), fakeClient,
+		[]gatewayv1.BackendTLSPolicy{policy}, "ns", "svc", 443)
+	assert.Nil(t, winner)
+}
+
+func TestSelectPolicyForServicePort_SectionNameMatchesNamedPort(t *testing.T) {
+	t.Parallel()
+
+	policy := *backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	sectionName := gatewayv1.SectionName("https")
+	policy.Spec.TargetRefs[0].SectionName = &sectionName
+
+	scheme := newBackendTLSPolicyScheme(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "svc"},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: 80},
+				{Name: "https", Port: 8443},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc).Build()
+
+	// Matching named port → policy applies.
+	winner := selectPolicyForServicePort(context.Background(), fakeClient,
+		[]gatewayv1.BackendTLSPolicy{policy}, "ns", "svc", 8443)
+	require.NotNil(t, winner, "SectionName 'https' matches port 8443 (named 'https') → policy applies")
+
+	// Different port on the same Service → policy must NOT apply.
+	winner = selectPolicyForServicePort(context.Background(), fakeClient,
+		[]gatewayv1.BackendTLSPolicy{policy}, "ns", "svc", 80)
+	assert.Nil(t, winner, "SectionName 'https' must NOT match port 80 (named 'http') — multi-port spec invariant")
+}
+
+func TestPolicyTargetsServicePort_KindAliases(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		kind     string
+		expected bool
+	}{
+		{"Service", true},
+		{"", true},
+		{"Pod", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			t.Parallel()
+
+			policy := &gatewayv1.BackendTLSPolicy{
+				Spec: gatewayv1.BackendTLSPolicySpec{
+					TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+						{
+							LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+								Kind: gatewayv1.Kind(tc.kind),
+								Name: "svc",
+							},
+						},
+					},
+				},
+			}
+
+			assert.Equal(t, tc.expected, policyTargetsServicePort(policy, "svc", alwaysEmptyPortName))
+		})
+	}
+}
+
+// ---- routeReferencesAnyService ----
+
+func TestRouteReferencesAnyService_MatchesServiceBackend(t *testing.T) {
+	t.Parallel()
+
+	route := httpRouteFor("ns", "r", "gw", "target")
+	targets := map[string]struct{}{"target": {}}
+
+	assert.True(t, routeReferencesAnyService(route, targets))
+}
+
+func TestRouteReferencesAnyService_IgnoresNonServiceKind(t *testing.T) {
+	t.Parallel()
+
+	route := httpRouteFor("ns", "r", "gw", "target")
+	// Override the kind to a non-Service value.
+	nonService := gatewayv1.Kind("Pod")
+	route.Spec.Rules[0].BackendRefs[0].Kind = &nonService
+
+	targets := map[string]struct{}{"target": {}}
+	assert.False(t, routeReferencesAnyService(route, targets))
+}
+
+func TestRouteReferencesAnyService_EmptyTargets(t *testing.T) {
+	t.Parallel()
+
+	route := httpRouteFor("ns", "r", "gw", "target")
+	assert.False(t, routeReferencesAnyService(route, map[string]struct{}{}))
+}
+
+// ---- policyReferencesConfigMap / isConfigMapReferencedByBackendTLSPolicy ----
+
+func TestPolicyReferencesConfigMap_MatchesByName(t *testing.T) {
+	t.Parallel()
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "ca-cm", time.Time{})
+	assert.True(t, policyReferencesConfigMap(policy, "ca-cm"))
+	assert.False(t, policyReferencesConfigMap(policy, "other-cm"))
+}
+
+func TestPolicyReferencesConfigMap_IgnoresNonConfigMapKind(t *testing.T) {
+	t.Parallel()
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "ca-cm", time.Time{})
+	policy.Spec.Validation.CACertificateRefs[0].Kind = "Secret"
+	assert.False(t, policyReferencesConfigMap(policy, "ca-cm"))
+}
+
+func TestIsConfigMapReferencedByBackendTLSPolicy(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	policy := backendTLSPolicyFor("ns", "p", "svc", "ca-cm", time.Time{})
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy).
+		Build()
+
+	matching := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ca-cm"}}
+	other := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "unrelated"}}
+
+	assert.True(t, isConfigMapReferencedByBackendTLSPolicy(context.Background(), fakeClient, matching))
+	assert.False(t, isConfigMapReferencedByBackendTLSPolicy(context.Background(), fakeClient, other))
+}
+
+// ---- collectGatewayKeys ----
+
+func TestCollectGatewayKeys_DeterministicSort(t *testing.T) {
+	t.Parallel()
+
+	// Build several HTTPRoutes referencing the same Service, fanning out to
+	// Gateways named in non-alphabetical order, to confirm the result is
+	// alphabetised by {namespace, name}.
+	routes := []gatewayv1.HTTPRoute{
+		*httpRouteFor("ns", "r-zeta", "gw-z", "svc"),
+		*httpRouteFor("ns", "r-alpha", "gw-a", "svc"),
+		*httpRouteFor("ns", "r-mu", "gw-m", "svc"),
+	}
+
+	keys := collectGatewayKeys(routes, map[string]struct{}{"svc": {}})
+
+	require.Len(t, keys, 3)
+	assert.Equal(t, "gw-a", keys[0].Name)
+	assert.Equal(t, "gw-m", keys[1].Name)
+	assert.Equal(t, "gw-z", keys[2].Name)
+}
+
+func TestCollectGatewayKeys_SkipsUnrelatedRoutes(t *testing.T) {
+	t.Parallel()
+
+	routes := []gatewayv1.HTTPRoute{
+		*httpRouteFor("ns", "r-other", "gw", "different-svc"),
+	}
+	keys := collectGatewayKeys(routes, map[string]struct{}{"svc": {}})
+
+	assert.Empty(t, keys)
+}
+
+// ---- updateStatus ----
+
+func TestUpdateStatus_PreservesOtherControllers(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	other := gatewayv1.PolicyAncestorStatus{
+		AncestorRef:    gatewayv1.ParentReference{Name: "other-gw"},
+		ControllerName: gatewayv1.GatewayController("other-controller"),
+		Conditions: []metav1.Condition{
+			{Type: string(gatewayv1.PolicyConditionAccepted), Status: metav1.ConditionTrue},
+		},
+	}
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	policy.Status.Ancestors = []gatewayv1.PolicyAncestorStatus{other}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy).
+		WithStatusSubresource(policy).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test-controller"}
+
+	gateway := *gatewayFor("ns", "our-gw", "cf-class")
+	conditions := acceptedConditions(policy.Generation)
+
+	err := r.updateStatus(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, []gatewayv1.Gateway{gateway}, conditions)
+	require.NoError(t, err)
+
+	var refreshed gatewayv1.BackendTLSPolicy
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, &refreshed))
+	require.Len(t, refreshed.Status.Ancestors, 2)
+	// Other controller's entry preserved.
+	assert.Equal(t, gatewayv1.GatewayController("other-controller"), refreshed.Status.Ancestors[0].ControllerName)
+	assert.Equal(t, gatewayv1.GatewayController("test-controller"), refreshed.Status.Ancestors[1].ControllerName)
+	assert.Equal(t, gatewayv1.ObjectName("our-gw"), refreshed.Status.Ancestors[1].AncestorRef.Name)
+}
+
+func TestUpdateStatus_PreservesOtherControllersUnderCap(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	// Seed three other-controller ancestor claims so the policy starts with a
+	// non-trivial foreign footprint. With 20 incoming OUR-managed Gateways
+	// the truncation MUST drop OUR entries first, never the foreigners.
+	otherClaims := []gatewayv1.PolicyAncestorStatus{
+		{
+			AncestorRef:    gatewayv1.ParentReference{Name: "foreign-1"},
+			ControllerName: gatewayv1.GatewayController("foreign-controller-1"),
+			Conditions:     []metav1.Condition{{Type: "Accepted", Status: metav1.ConditionTrue}},
+		},
+		{
+			AncestorRef:    gatewayv1.ParentReference{Name: "foreign-2"},
+			ControllerName: gatewayv1.GatewayController("foreign-controller-2"),
+			Conditions:     []metav1.Condition{{Type: "Accepted", Status: metav1.ConditionTrue}},
+		},
+		{
+			AncestorRef:    gatewayv1.ParentReference{Name: "foreign-3"},
+			ControllerName: gatewayv1.GatewayController("foreign-controller-3"),
+			Conditions:     []metav1.Condition{{Type: "Accepted", Status: metav1.ConditionTrue}},
+		},
+	}
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	policy.Status.Ancestors = otherClaims
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy).
+		WithStatusSubresource(policy).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test-controller"}
+
+	gateways := make([]gatewayv1.Gateway, 0, 20)
+	for i := range 20 {
+		gateways = append(gateways, *gatewayFor("ns", "gw-"+zeroPadded(i), "cf-class"))
+	}
+
+	require.NoError(t, r.updateStatus(context.Background(),
+		client.ObjectKey{Namespace: "ns", Name: "p"},
+		gateways,
+		acceptedConditions(policy.Generation),
+	))
+
+	var refreshed gatewayv1.BackendTLSPolicy
+	require.NoError(t, fakeClient.Get(context.Background(),
+		client.ObjectKey{Namespace: "ns", Name: "p"}, &refreshed))
+	assert.Len(t, refreshed.Status.Ancestors, policyAncestorStatusMaxCount,
+		"combined set capped at 16")
+
+	// Every foreign claim must survive the truncation — count them up.
+	foreignSurvivors := 0
+
+	for _, ancestor := range refreshed.Status.Ancestors {
+		if string(ancestor.ControllerName) != r.ControllerName {
+			foreignSurvivors++
+		}
+	}
+
+	assert.Equal(t, len(otherClaims), foreignSurvivors,
+		"other controllers' ancestor entries MUST NOT be dropped by our truncation; "+
+			"only OUR entries shrink to fit within the cap")
+}
+
+func TestUpdateStatus_CapsAncestorsAt16(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy).
+		WithStatusSubresource(policy).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test-controller"}
+
+	// 20 ancestor gateways → updateStatus must truncate to 16.
+	gateways := make([]gatewayv1.Gateway, 0, 20)
+	for i := range 20 {
+		// Use zero-padded names so alphabetical truncation is well-defined.
+		name := "gw-" + zeroPadded(i)
+		gateways = append(gateways, *gatewayFor("ns", name, "cf-class"))
+	}
+
+	conditions := acceptedConditions(policy.Generation)
+
+	err := r.updateStatus(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, gateways, conditions)
+	require.NoError(t, err)
+
+	var refreshed gatewayv1.BackendTLSPolicy
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, &refreshed))
+	assert.Len(t, refreshed.Status.Ancestors, policyAncestorStatusMaxCount)
+}
+
+func zeroPadded(idx int) string {
+	letters := []byte{byte('0' + idx/10), byte('0' + idx%10)}
+
+	return string(letters)
+}
+
+func TestUpdateStatus_SetsLastTransitionTime(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy).
+		WithStatusSubresource(policy).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test-controller"}
+
+	gateway := *gatewayFor("ns", "gw", "cf-class")
+	conditions := acceptedConditions(policy.Generation)
+
+	require.NoError(t, r.updateStatus(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, []gatewayv1.Gateway{gateway}, conditions))
+
+	var refreshed gatewayv1.BackendTLSPolicy
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, &refreshed))
+	require.Len(t, refreshed.Status.Ancestors, 1)
+	require.NotEmpty(t, refreshed.Status.Ancestors[0].Conditions)
+	for _, condition := range refreshed.Status.Ancestors[0].Conditions {
+		assert.False(t, condition.LastTransitionTime.IsZero(),
+			"LastTransitionTime must be populated by meta.SetStatusCondition")
+	}
+}
+
+// ---- policiesForRouteChange ----
+
+func TestPoliciesForRouteChange_OnlyMatchingPolicy(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	matching := backendTLSPolicyFor("ns", "match", "svc", "cm", time.Time{})
+	unrelated := backendTLSPolicyFor("ns", "unrelated", "other-svc", "cm", time.Time{})
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(matching, unrelated).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	route := httpRouteFor("ns", "r", "gw", "svc")
+	requests := r.policiesForRouteChange(context.Background(), route)
+
+	require.Len(t, requests, 1)
+	assert.Equal(t, "match", requests[0].Name)
+}
+
+// ---- policiesForConfigMapChange ----
+
+func TestPoliciesForConfigMapChange_OnlyReferencingPolicies(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	referencing := backendTLSPolicyFor("ns", "ref", "svc", "ca-cm", time.Time{})
+	other := backendTLSPolicyFor("ns", "other", "svc-2", "different-cm", time.Time{})
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(referencing, other).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ca-cm"}}
+	requests := r.policiesForConfigMapChange(context.Background(), configMap)
+
+	require.Len(t, requests, 1)
+	assert.Equal(t, "ref", requests[0].Name)
+}
+
+// ---- newBackendTLSResolver: fail-closed semantics ----
+
+func TestBackendTLSResolver_NoPolicyReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	resolver := newBackendTLSResolver(fakeClient)
+
+	got := resolver(context.Background(), "ns", "svc", 443)
+	assert.Nil(t, got, "no matching policy → nil so the proxy uses plaintext")
+}
+
+func TestBackendTLSResolver_PolicyTargetsButCAMissing_ReturnsPoisonedConfig(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "missing-cm", time.Time{})
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy).
+		Build()
+
+	resolver := newBackendTLSResolver(fakeClient)
+
+	got := resolver(context.Background(), "ns", "svc", 443)
+	require.NotNil(t, got,
+		"policy targets the Service but CA cannot be resolved — resolver MUST NOT return nil "+
+			"(that would downgrade to plaintext). Return a poisoned config so the handshake fails.")
+	assert.Empty(t, got.CABundlePEM,
+		"poisoned config carries an empty CA bundle so x509 verification fails closed")
+}
+
+func TestBackendTLSResolver_PolicyTargetsButCAMalformed_ReturnsPoisonedConfig(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	configMap := caConfigMap("ns", "cm", "not actual pem")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy, configMap).
+		Build()
+
+	resolver := newBackendTLSResolver(fakeClient)
+
+	got := resolver(context.Background(), "ns", "svc", 443)
+	require.NotNil(t, got, "policy targets the Service — resolver must NOT return nil for malformed CA")
+	assert.Empty(t, got.CABundlePEM)
+}
+
+func TestBackendTLSResolver_URISubjectAltName_ReturnsPoisonedConfig(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	uriType := gatewayv1.URISubjectAltNameType
+	policy.Spec.Validation.SubjectAltNames = []gatewayv1.SubjectAltName{
+		{Type: uriType},
+	}
+
+	configMap := caConfigMap("ns", "cm", generateSelfSignedCAPEM(t))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy, configMap).
+		Build()
+
+	resolver := newBackendTLSResolver(fakeClient)
+
+	got := resolver(context.Background(), "ns", "svc", 443)
+	require.NotNil(t, got,
+		"URI-type SubjectAltName is not supported — resolver must NOT return nil (plaintext); "+
+			"must return a poisoned config so traffic fails closed")
+	assert.Empty(t, got.CABundlePEM)
+}
+
+// TestBackendTLSResolver_ListErrorFailsOpen pins the documented asymmetry
+// between cache errors (fail OPEN) and per-policy validation errors (fail
+// CLOSED). When `client.List` itself errors before the policy list can be
+// inspected, the resolver returns nil — the proxy dials plaintext for THIS
+// request rather than poisoning every route in the namespace. The decision
+// is documented in newBackendTLSResolver's godoc; this test pins it.
+func TestBackendTLSResolver_ListErrorFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*gatewayv1.BackendTLSPolicyList); ok {
+					return errSimulatedCacheMiss
+				}
+
+				return nil
+			},
+		}).
+		Build()
+
+	resolver := newBackendTLSResolver(fakeClient)
+
+	got := resolver(context.Background(), "ns", "svc", 443)
+	assert.Nil(t, got,
+		"List error → fail OPEN (nil → proxy dials plaintext). "+
+			"Poisoning every namespace on a transient cache miss would be a worse failure mode; "+
+			"the asymmetry is documented in newBackendTLSResolver's godoc and surfaced via a WARN log.")
+}
+
+func TestBackendTLSResolver_MultipleCARefs_Concatenates(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	caOne := generateSelfSignedCAPEM(t)
+	caTwo := generateSelfSignedCAPEM(t)
+
+	cmOne := caConfigMap("ns", "ca-one", caOne)
+	cmTwo := caConfigMap("ns", "ca-two", caTwo)
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "ca-one", time.Time{})
+	policy.Spec.Validation.CACertificateRefs = append(policy.Spec.Validation.CACertificateRefs,
+		gatewayv1.LocalObjectReference{
+			Kind: configMapKind,
+			Name: "ca-two",
+		},
+	)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy, cmOne, cmTwo).
+		Build()
+
+	resolver := newBackendTLSResolver(fakeClient)
+
+	got := resolver(context.Background(), "ns", "svc", 443)
+	require.NotNil(t, got, "two valid CACertificateRefs must produce a real (non-poisoned) config")
+	assert.Contains(t, got.CABundlePEM, caOne,
+		"first CA bundle must appear in the concatenated trust pool")
+	assert.Contains(t, got.CABundlePEM, caTwo,
+		"second CA bundle must appear in the concatenated trust pool — multiple refs cannot silently 'first-wins'")
+}
+
+func TestBackendTLSResolver_HappyPath_ReturnsRealConfig(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	policy.Spec.Validation.SubjectAltNames = []gatewayv1.SubjectAltName{
+		{Type: gatewayv1.HostnameSubjectAltNameType, Hostname: "alt.example.com"},
+	}
+	configMap := caConfigMap("ns", "cm", generateSelfSignedCAPEM(t))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy, configMap).
+		Build()
+
+	resolver := newBackendTLSResolver(fakeClient)
+
+	got := resolver(context.Background(), "ns", "svc", 443)
+	require.NotNil(t, got)
+	assert.NotEmpty(t, got.CABundlePEM, "valid policy + CA → real CA bundle")
+	assert.Equal(t, "test.example.com", got.ServerName)
+	assert.Equal(t, []string{"alt.example.com"}, got.SubjectAltNames)
+}
+
+// ---- ObservedGeneration ----
+
+func TestUpdateStatus_ObservedGenerationMatchesPolicyGeneration(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	policy.Generation = 42
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy).
+		WithStatusSubresource(policy).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test-controller"}
+
+	gateway := *gatewayFor("ns", "gw", "cf-class")
+	conditions := acceptedConditions(policy.Generation)
+
+	require.NoError(t, r.updateStatus(context.Background(),
+		client.ObjectKey{Namespace: "ns", Name: "p"},
+		[]gatewayv1.Gateway{gateway},
+		conditions,
+	))
+
+	var refreshed gatewayv1.BackendTLSPolicy
+	require.NoError(t, fakeClient.Get(context.Background(),
+		client.ObjectKey{Namespace: "ns", Name: "p"}, &refreshed))
+	require.Len(t, refreshed.Status.Ancestors, 1)
+	require.NotEmpty(t, refreshed.Status.Ancestors[0].Conditions)
+
+	for _, condition := range refreshed.Status.Ancestors[0].Conditions {
+		assert.Equal(t, int64(42), condition.ObservedGeneration,
+			"every condition must carry the current policy.Generation; "+
+				"the upstream BackendTLSPolicyObservedGenerationBump conformance test pins this")
+	}
+}
+
+// ---- Reconcile (integration of the pieces above) ----
+
+func TestReconcile_NotFound(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "missing", Namespace: "ns"}})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}
+
+func TestReconcile_NoMatchingGateway_IsNoop(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	// Policy targets a Service that no route under our managed Gateway references.
+	policy := backendTLSPolicyFor("ns", "p", "lonely-svc", "cm", time.Time{})
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy).
+		WithStatusSubresource(policy).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "p"}})
+	require.NoError(t, err)
+
+	var refreshed gatewayv1.BackendTLSPolicy
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, &refreshed))
+	assert.Empty(t, refreshed.Status.Ancestors)
+}
+
+func TestReconcile_HappyPath_StampsAcceptedAndResolvedRefs(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	const controllerName = "github.com/lexfrei/test"
+
+	gatewayClass := gatewayClassFor("cf-class", controllerName)
+	gateway := gatewayFor("ns", "gw", "cf-class")
+	route := httpRouteFor("ns", "r", "gw", "svc")
+	configMap := caConfigMap("ns", "cm", generateSelfSignedCAPEM(t))
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gatewayClass, gateway, route, configMap, policy).
+		WithStatusSubresource(policy).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: controllerName}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "p"}})
+	require.NoError(t, err)
+
+	var refreshed gatewayv1.BackendTLSPolicy
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, &refreshed))
+	require.Len(t, refreshed.Status.Ancestors, 1)
+	require.Len(t, refreshed.Status.Ancestors[0].Conditions, 2)
+
+	for _, condition := range refreshed.Status.Ancestors[0].Conditions {
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, refreshed.Generation, condition.ObservedGeneration)
+	}
+}

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -201,15 +201,8 @@ func Run(ctx context.Context, cfg *Config) error {
 		return errors.Wrap(err, "failed to setup gatewayclassconfig controller")
 	}
 
-	// Setup GatewayClass controller for status updates
-	gatewayClassReconciler := &GatewayClassReconciler{
-		Client:         mgr.GetClient(),
-		Scheme:         mgr.GetScheme(),
-		ControllerName: cfg.ControllerName,
-	}
-
-	if err := gatewayClassReconciler.SetupWithManager(mgr); err != nil {
-		return errors.Wrap(err, "failed to setup gatewayclass controller")
+	if err := setupStatusReconcilers(mgr, cfg.ControllerName); err != nil {
+		return err
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/internal/controller/proxy_syncer.go
+++ b/internal/controller/proxy_syncer.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,6 +26,14 @@ import (
 // back to when Group/Kind are unset.
 const serviceKind = "Service"
 
+// coreGroup is the implicit Group for Kubernetes core resources (Service,
+// ConfigMap). Gateway API treats "" and "core" as aliases.
+const coreGroup = "core"
+
+// configMapKind is the Kind value for ConfigMap references used by Gateway
+// API BackendTLSPolicy CACertificateRefs.
+const configMapKind = "ConfigMap"
+
 // ProxySyncer converts HTTPRoute resources to proxy config
 // and pushes it to enhanced-cloudflared replicas via HTTP API.
 type ProxySyncer struct {
@@ -33,6 +42,7 @@ type ProxySyncer struct {
 	pusher           *proxy.ConfigPusher
 	backendValidator proxy.BackendRefValidator
 	protocolResolver proxy.BackendProtocolResolver
+	tlsResolver      proxy.BackendTLSResolver
 	syncMu           sync.Mutex
 }
 
@@ -58,7 +68,277 @@ func NewProxySyncer(
 		}, authToken),
 		backendValidator: newBackendRefValidator(refGrantValidator),
 		protocolResolver: newBackendProtocolResolver(k8sClient),
+		tlsResolver:      newBackendTLSResolver(k8sClient),
 	}
+}
+
+// newBackendTLSResolver returns a resolver that looks up a BackendTLSPolicy
+// targeting the given Service+Port and returns the corresponding TLS
+// configuration (CA, hostname, SANs) for the proxy to apply on the backend
+// hop. SectionName on the policy's TargetRef is honoured per Gateway API:
+// when set, only the matching named port receives TLS — other ports of the
+// same Service are unaffected.
+//
+// One asymmetry worth calling out: when the cache-backed `client.List` call
+// itself errors (which only happens before the informer's initial sync or on
+// API server unavailability), the resolver fails OPEN — returns nil and the
+// proxy dials plaintext. Returning poisoned configs here would block every
+// route in the namespace whenever the BackendTLSPolicy cache hiccups, which
+// is a worse failure mode in practice. A WARN surfaces the event so the
+// asymmetry is observable in logs.
+//
+// Behaviour by case:
+//
+//   - List error or no policy targets the service: returns nil → the proxy
+//     dials the backend in plaintext (no policy applies, so there's no
+//     operator intent to enforce).
+//   - A policy targets the service BUT the CA cannot be resolved (missing
+//     ConfigMap, unsupported Group/Kind, empty ca.crt, malformed PEM) OR the
+//     policy carries a non-Hostname SubjectAltName type that this controller
+//     does not support: returns a *poisoned* config — an empty CA pool with
+//     the policy's Hostname. This causes the proxy's TLS handshake to fail
+//     and the request returns 502, NOT a silent plaintext downgrade. The
+//     operator's stated intent ("traffic to this Service MUST be
+//     authenticated TLS") is preserved.
+//
+// Precedence per Gateway API: oldest creationTimestamp wins; on tie,
+// alphabetical {namespace}/{name}.
+func newBackendTLSResolver(c client.Client) proxy.BackendTLSResolver {
+	return func(ctx context.Context, namespace, serviceName string, port int32) *proxy.BackendTLSConfig {
+		var policies gatewayv1.BackendTLSPolicyList
+		if err := c.List(ctx, &policies, client.InNamespace(namespace)); err != nil {
+			slog.Warn("failed to list BackendTLSPolicy — falling back to plaintext for this backend; "+
+				"policy enforcement will resume once the cache recovers",
+				"error", err,
+				"namespace", namespace,
+				"service", serviceName,
+				"port", port,
+			)
+
+			return nil
+		}
+
+		policy := selectPolicyForServicePort(ctx, c, policies.Items, namespace, serviceName, port)
+		if policy == nil {
+			return nil
+		}
+
+		// Fail closed for any unsupported SAN type — the operator asked for
+		// stricter identity than this controller can enforce.
+		if !hasOnlyHostnameSANs(policy) {
+			return poisonedBackendTLS(policy)
+		}
+
+		caBundle, ok := resolveCABundlePEM(ctx, c, policy)
+		if !ok {
+			return poisonedBackendTLS(policy)
+		}
+
+		sans := make([]string, 0, len(policy.Spec.Validation.SubjectAltNames))
+		for _, san := range policy.Spec.Validation.SubjectAltNames {
+			if san.Hostname != "" {
+				sans = append(sans, string(san.Hostname))
+			}
+		}
+
+		return &proxy.BackendTLSConfig{
+			CABundlePEM:     caBundle,
+			ServerName:      string(policy.Spec.Validation.Hostname),
+			SubjectAltNames: sans,
+		}
+	}
+}
+
+// hasOnlyHostnameSANs reports whether every SubjectAltName entry on the
+// policy is of the supported Hostname type. URI-type SANs (SPIFFE etc.) are
+// not yet implemented end-to-end and must not silently degrade enforcement.
+func hasOnlyHostnameSANs(policy *gatewayv1.BackendTLSPolicy) bool {
+	for _, san := range policy.Spec.Validation.SubjectAltNames {
+		if san.Type != gatewayv1.HostnameSubjectAltNameType {
+			return false
+		}
+	}
+
+	return true
+}
+
+// poisonedBackendTLS returns a TLS config that is guaranteed to fail handshake
+// (empty CA pool, no SAN list), used to short-circuit a request when a
+// BackendTLSPolicy targets the Service but cannot be enforced — strictly
+// preferred over silently downgrading to plaintext.
+func poisonedBackendTLS(policy *gatewayv1.BackendTLSPolicy) *proxy.BackendTLSConfig {
+	return &proxy.BackendTLSConfig{
+		CABundlePEM: "",
+		ServerName:  string(policy.Spec.Validation.Hostname),
+	}
+}
+
+// selectPolicyForServicePort picks the precedence-winner among policies that
+// target a Service+Port: TargetRefs without SectionName apply to every port;
+// TargetRefs with SectionName apply only when the named port matches `port`.
+// Older creationTimestamp wins; ties break alphabetically by name.
+//
+// `c`, `ctx`, and `namespace` enable the optional Service-port-name lookup —
+// when a policy carries a SectionName, the function maps the port number back
+// to the Service's port name and checks for a match.
+func selectPolicyForServicePort(
+	ctx context.Context,
+	c client.Client,
+	policies []gatewayv1.BackendTLSPolicy,
+	namespace, serviceName string,
+	port int32,
+) *gatewayv1.BackendTLSPolicy {
+	var portName string
+
+	// Defer the Service lookup until at least one policy carries a SectionName —
+	// most policies don't, so we avoid an extra Get for the common case.
+	portNameResolved := false
+	resolvePortName := func() string {
+		if portNameResolved {
+			return portName
+		}
+
+		portNameResolved = true
+		portName = lookupServicePortName(ctx, c, namespace, serviceName, port)
+
+		return portName
+	}
+
+	var best *gatewayv1.BackendTLSPolicy
+
+	for policyIdx := range policies {
+		policy := &policies[policyIdx]
+		if !policyTargetsServicePort(policy, serviceName, resolvePortName) {
+			continue
+		}
+
+		if best == nil || isPolicyOlder(policy, best) {
+			best = policy
+		}
+	}
+
+	return best
+}
+
+// policyTargetsServicePort reports whether any TargetRef in the policy points
+// at a Service with the given name AND, when SectionName is set, only when the
+// named port matches the resolved port name. resolvePortName is lazy — called
+// only when at least one TargetRef carries a SectionName.
+func policyTargetsServicePort(
+	policy *gatewayv1.BackendTLSPolicy,
+	serviceName string,
+	resolvePortName func() string,
+) bool {
+	for _, target := range policy.Spec.TargetRefs {
+		if string(target.Name) != serviceName {
+			continue
+		}
+
+		kind := string(target.Kind)
+		if kind != "" && kind != serviceKind {
+			continue
+		}
+
+		if target.SectionName == nil || *target.SectionName == "" {
+			return true
+		}
+
+		// SectionName set → only match when the actual backend port carries
+		// the same name. If the Service has no port with that name (or the
+		// Service can't be fetched), this policy does NOT apply to this port.
+		if string(*target.SectionName) == resolvePortName() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// lookupServicePortName returns the name of the Service port matching `port`,
+// or "" if the Service or port can't be resolved. Errors are swallowed
+// intentionally: a missing Service is treated as "no port name available",
+// which leads SectionName-bearing policies to be rejected for this port.
+func lookupServicePortName(ctx context.Context, c client.Client, namespace, serviceName string, port int32) string {
+	var svc corev1.Service
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: serviceName}, &svc); err != nil {
+		return ""
+	}
+
+	for portIdx := range svc.Spec.Ports {
+		if svc.Spec.Ports[portIdx].Port == port {
+			return svc.Spec.Ports[portIdx].Name
+		}
+	}
+
+	return ""
+}
+
+// isPolicyOlder reports whether candidate was created before incumbent, or
+// with the same timestamp and a smaller name (Gateway API precedence rule).
+func isPolicyOlder(candidate, incumbent *gatewayv1.BackendTLSPolicy) bool {
+	if candidate.CreationTimestamp.Before(&incumbent.CreationTimestamp) {
+		return true
+	}
+
+	if incumbent.CreationTimestamp.Before(&candidate.CreationTimestamp) {
+		return false
+	}
+
+	return candidate.Name < incumbent.Name
+}
+
+// resolveCABundlePEM returns the concatenated PEM-encoded CA certificate bundle
+// referenced by the BackendTLSPolicy, or ok=false if any reference fails to
+// resolve. Only same-namespace ConfigMap refs with a "ca.crt" key are
+// supported (Core in Gateway API v1). Returns ok=false on any of: unsupported
+// Group/Kind, missing ConfigMap, empty `ca.crt` key, or a `ca.crt` value that
+// does not contain at least one parseable PEM CERTIFICATE block — the proxy
+// then short-circuits the backend so traffic fails closed rather than
+// downgrading silently to plaintext when the policy can't be enforced.
+func resolveCABundlePEM(ctx context.Context, c client.Client, policy *gatewayv1.BackendTLSPolicy) (string, bool) {
+	if len(policy.Spec.Validation.CACertificateRefs) == 0 {
+		return "", false
+	}
+
+	var bundle strings.Builder
+
+	for _, ref := range policy.Spec.Validation.CACertificateRefs {
+		group := string(ref.Group)
+		if group != "" && group != coreGroup {
+			return "", false
+		}
+
+		if string(ref.Kind) != configMapKind {
+			return "", false
+		}
+
+		var caCM corev1.ConfigMap
+
+		key := client.ObjectKey{Namespace: policy.Namespace, Name: string(ref.Name)}
+		if err := c.Get(ctx, key, &caCM); err != nil {
+			return "", false
+		}
+
+		caPEM, hasKey := caCM.Data[configMapCAKey]
+		if !hasKey || caPEM == "" {
+			return "", false
+		}
+
+		// Mirror the reconciler's validateCARefs check — a ConfigMap with
+		// garbage content under ca.crt would otherwise be passed through to
+		// the proxy and silently fail every TLS handshake at runtime.
+		if _, err := parseCABundle(caPEM); err != nil {
+			return "", false
+		}
+
+		bundle.WriteString(caPEM)
+
+		if !strings.HasSuffix(caPEM, "\n") {
+			bundle.WriteByte('\n')
+		}
+	}
+
+	return bundle.String(), true
 }
 
 // newBackendProtocolResolver returns a resolver that reads a backend Service's
@@ -159,9 +439,10 @@ func (s *ProxySyncer) SyncRoutes(
 
 	logger.Info("syncing proxy config", "routes", len(routes))
 
-	// Convert to proxy config with cross-namespace validation and backend
-	// protocol resolution (e.g. h2c) from Service appProtocol.
-	cfg := proxy.ConvertHTTPRoutes(ctx, routes, s.clusterDomain, s.backendValidator, s.protocolResolver)
+	// Convert to proxy config with cross-namespace validation, backend
+	// protocol resolution (e.g. h2c from Service appProtocol), and
+	// BackendTLSPolicy lookup for the proxy → backend TLS hop.
+	cfg := proxy.ConvertHTTPRoutes(ctx, routes, s.clusterDomain, s.backendValidator, s.protocolResolver, s.tlsResolver)
 
 	// Clear backends for routes that have failed backend refs.
 	// This ensures the proxy returns 500 (no backend available) instead of

--- a/internal/controller/proxy_syncer_test.go
+++ b/internal/controller/proxy_syncer_test.go
@@ -194,6 +194,181 @@ func TestProxySyncer_SyncRoutes_H2CBackend(t *testing.T) {
 		"backend on a Service port with appProtocol kubernetes.io/h2c must be marked h2c")
 }
 
+// TestProxySyncer_SyncRoutes_BackendTLSPolicyMissingCA_FailsClosed verifies the
+// critical security contract that a BackendTLSPolicy targeting a Service with
+// an unresolvable CA bundle must NOT downgrade traffic to plaintext. The
+// pushed proxy config MUST include TLS config (with empty CA pool) so the
+// handler returns 502 — the operator's stated intent ("must be authenticated
+// TLS") is preserved even when enforcement is impossible.
+func TestProxySyncer_SyncRoutes_BackendTLSPolicyMissingCA_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	var receivedConfig proxy.Config
+
+	configServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodPut {
+			if decodeErr := json.NewDecoder(req.Body).Decode(&receivedConfig); decodeErr != nil {
+				writer.WriteHeader(http.StatusBadRequest)
+
+				return
+			}
+		}
+
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer configServer.Close()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	policy := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "secure-policy", Namespace: "default"},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				{
+					LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+						Kind: "Service",
+						Name: "secure-svc",
+					},
+				},
+			},
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				CACertificateRefs: []gatewayv1.LocalObjectReference{
+					{Kind: "ConfigMap", Name: "does-not-exist"},
+				},
+				Hostname: "secure.example.com",
+			},
+		},
+	}
+
+	testClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy).Build()
+
+	syncer := controller.NewProxySyncer("cluster.local", "", testClient, slog.Default())
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "secure-route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"secure.example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{makeBackendRef("secure-svc", 8080, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, routes, nil))
+
+	require.Len(t, receivedConfig.Rules, 1)
+	require.Len(t, receivedConfig.Rules[0].Backends, 1)
+	backend := receivedConfig.Rules[0].Backends[0]
+
+	require.NotNil(t, backend.TLS,
+		"BackendTLSPolicy targets the Service but CA can't be resolved — the proxy config MUST carry "+
+			"a (poisoned) TLS block so traffic fails closed, NOT nil which would downgrade to plaintext")
+	assert.Empty(t, backend.TLS.CABundlePEM,
+		"poisoned config has empty CA bundle → handshake fails closed at the proxy")
+}
+
+// TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesPoisonedConfig
+// verifies the URI-SAN fail-closed path end-to-end: when a BackendTLSPolicy
+// requires a URI-type SubjectAltName (SPIFFE etc.), the resolver MUST emit a
+// poisoned TLS config rather than silently dropping the SAN requirement.
+// This pairs with the integration handshake test
+// (TestHandler_BackendTLSPolicy_PoisonedConfig_HandshakeFails in
+// internal/proxy/integration_test.go) which confirms the proxy turns that
+// poisoned config into a 502 at handshake time.
+func TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesPoisonedConfig(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	var receivedConfig proxy.Config
+
+	configServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodPut {
+			if decodeErr := json.NewDecoder(req.Body).Decode(&receivedConfig); decodeErr != nil {
+				writer.WriteHeader(http.StatusBadRequest)
+
+				return
+			}
+		}
+
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer configServer.Close()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	policy := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "spiffe-policy", Namespace: "default"},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				{
+					LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+						Kind: "Service",
+						Name: "spiffe-svc",
+					},
+				},
+			},
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				// URI-type SAN — unsupported by this controller. The resolver
+				// MUST poison rather than fall back to plaintext.
+				SubjectAltNames: []gatewayv1.SubjectAltName{
+					{Type: gatewayv1.URISubjectAltNameType, URI: "spiffe://example.org/server"},
+				},
+				Hostname: "spiffe.example.com",
+			},
+		},
+	}
+
+	testClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy).Build()
+
+	syncer := controller.NewProxySyncer("cluster.local", "", testClient, slog.Default())
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "spiffe-route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"spiffe.example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{makeBackendRef("spiffe-svc", 8443, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, routes, nil))
+
+	require.Len(t, receivedConfig.Rules, 1)
+	require.Len(t, receivedConfig.Rules[0].Backends, 1)
+	backend := receivedConfig.Rules[0].Backends[0]
+
+	require.NotNil(t, backend.TLS,
+		"URI-type SAN is unsupported but the policy targets the Service — the resolver MUST emit "+
+			"a TLS block (poisoned) so traffic fails closed at handshake time. nil here would "+
+			"silently downgrade to plaintext.")
+	assert.Empty(t, backend.TLS.CABundlePEM,
+		"poisoned config carries an empty CA bundle so handshake fails closed")
+	assert.Empty(t, backend.TLS.SubjectAltNames,
+		"poisoned config drops SAN list — chain verification fails before SAN matching matters")
+}
+
 // Helper functions.
 
 func makeBackendRef(name string, port, weight int) gatewayv1.HTTPBackendRef {

--- a/internal/controller/reconcile_route.go
+++ b/internal/controller/reconcile_route.go
@@ -114,17 +114,7 @@ func setupRouteController(mgr ctrl.Manager, params *routeControllerSetupParams) 
 			handler.EnqueueRequestsFromMapFunc(params.findRoutesForRefGrant),
 		)
 
-	// A Service change can flip a backendRef's appProtocol (e.g. enable h2c)
-	// without touching any HTTPRoute. Only controllers that actually consume
-	// appProtocol (the L7 proxy, i.e. HTTPRoute) opt into this watch. GRPCRoute
-	// is tunnel-only and never reads appProtocol — leaving its findRoutesForService
-	// unset suppresses the watch and avoids needless reconcile churn.
-	if params.findRoutesForService != nil {
-		builder = builder.Watches(
-			&corev1.Service{},
-			handler.EnqueueRequestsFromMapFunc(params.findRoutesForService),
-		)
-	}
+	builder = addProxyOnlyWatches(builder, params)
 
 	err := builder.Complete(params.reconciler)
 	if err != nil {
@@ -136,4 +126,44 @@ func setupRouteController(mgr ctrl.Manager, params *routeControllerSetupParams) 
 	}
 
 	return nil
+}
+
+// addProxyOnlyWatches adds the watches that only the proxy-driving (HTTPRoute)
+// controller needs: Service for appProtocol changes, BackendTLSPolicy for TLS
+// config churn, and ConfigMap for CA bundle edits (filtered to ones actually
+// referenced by a policy). GRPCRoute opts out by leaving findRoutesForService
+// nil. Extracted from setupRouteController to keep its function length within
+// the linter budget.
+func addProxyOnlyWatches(
+	builder *ctrl.Builder,
+	params *routeControllerSetupParams,
+) *ctrl.Builder {
+	if params.findRoutesForService == nil {
+		return builder
+	}
+
+	enqueueAllRoutes := handler.EnqueueRequestsFromMapFunc(
+		func(ctx context.Context, _ client.Object) []reconcile.Request {
+			return params.getAllRelevantRoutes(ctx)
+		},
+	)
+	enqueueRoutesForCAConfigMap := handler.EnqueueRequestsFromMapFunc(
+		func(ctx context.Context, obj client.Object) []reconcile.Request {
+			configMap, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				return nil
+			}
+
+			if !isConfigMapReferencedByBackendTLSPolicy(ctx, params.k8sClient, configMap) {
+				return nil
+			}
+
+			return params.getAllRelevantRoutes(ctx)
+		},
+	)
+
+	return builder.
+		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(params.findRoutesForService)).
+		Watches(&gatewayv1.BackendTLSPolicy{}, enqueueAllRoutes).
+		Watches(&corev1.ConfigMap{}, enqueueRoutesForCAConfigMap)
 }

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -209,12 +209,30 @@ func isKnownBackendProtocol(p BackendProtocol) bool {
 	}
 }
 
+// BackendTLSConfig captures the per-backend TLS verification settings derived
+// from a Gateway API BackendTLSPolicy that targets the Service this BackendRef
+// points at. The proxy uses it to build a TLS transport that validates the
+// backend's server certificate against the supplied CA bundle and hostname.
+type BackendTLSConfig struct {
+	// CABundlePEM is the concatenated PEM-encoded CA certificate bundle the
+	// proxy uses as the trust anchor when verifying the backend's certificate.
+	CABundlePEM string `json:"caBundle,omitempty"`
+	// ServerName is used both as the TLS SNI value and as the expected
+	// hostname during certificate verification (DNS SAN match).
+	ServerName string `json:"serverName,omitempty"`
+	// SubjectAltNames lists additional hostnames that the backend cert may
+	// present in its SAN to satisfy this policy. ServerName is implied; this
+	// list is additive.
+	SubjectAltNames []string `json:"subjectAltNames,omitempty"`
+}
+
 // BackendRef identifies a backend service with a weight for traffic splitting.
 type BackendRef struct {
-	URL      string          `json:"url"`
-	Weight   int32           `json:"weight"`
-	Protocol BackendProtocol `json:"protocol,omitempty"`
-	Filters  []RouteFilter   `json:"filters,omitempty"`
+	URL      string            `json:"url"`
+	Weight   int32             `json:"weight"`
+	Protocol BackendProtocol   `json:"protocol,omitempty"`
+	TLS      *BackendTLSConfig `json:"tls,omitempty"`
+	Filters  []RouteFilter     `json:"filters,omitempty"`
 }
 
 // RouteTimeouts configures timeout durations for proxied requests.

--- a/internal/proxy/converter.go
+++ b/internal/proxy/converter.go
@@ -50,18 +50,25 @@ type BackendRefValidator func(ctx context.Context, fromNamespace string, ref gat
 // It lets the converter pick the backend transport without itself reading the API.
 type BackendProtocolResolver func(ctx context.Context, namespace, serviceName string, port int32) string
 
+// BackendTLSResolver returns the TLS config the proxy must apply when dialing
+// the given backend Service port, or nil when no BackendTLSPolicy targets it.
+// It lets the converter inject TLS settings without itself reading the API.
+type BackendTLSResolver func(ctx context.Context, namespace, serviceName string, port int32) *BackendTLSConfig
+
 // ConvertHTTPRoutes converts Gateway API HTTPRoute resources into a proxy Config.
 //
-// validator and protocolResolver may both be nil:
+// validator, protocolResolver, and tlsResolver may all be nil:
 //   - nil validator: cross-namespace backend refs are accepted unconditionally
 //     (used by tests that don't model ReferenceGrant).
 //   - nil protocolResolver: backend protocol stays the default HTTP/1.1.
+//   - nil tlsResolver: no BackendTLSPolicy is applied; plaintext to backends.
 func ConvertHTTPRoutes(
 	ctx context.Context,
 	routes []*gatewayv1.HTTPRoute,
 	clusterDomain string,
 	validator BackendRefValidator,
 	protocolResolver BackendProtocolResolver,
+	tlsResolver BackendTLSResolver,
 ) *Config {
 	cfg := &Config{
 		Version: configVersionCounter.Add(1),
@@ -73,7 +80,7 @@ func ConvertHTTPRoutes(
 		for ruleIdx := range route.Spec.Rules {
 			proxyRule := convertHTTPRouteRule(
 				ctx, &route.Spec.Rules[ruleIdx], hostnames,
-				route.Namespace, clusterDomain, validator, protocolResolver,
+				route.Namespace, clusterDomain, validator, protocolResolver, tlsResolver,
 			)
 
 			// Rules with no backends and no redirect filter are kept —
@@ -105,6 +112,7 @@ func convertHTTPRouteRule(
 	clusterDomain string,
 	validator BackendRefValidator,
 	resolver BackendProtocolResolver,
+	tlsResolver BackendTLSResolver,
 ) RouteRule {
 	proxyRule := RouteRule{
 		Hostnames: hostnames,
@@ -115,14 +123,14 @@ func convertHTTPRouteRule(
 	}
 
 	for filterIdx := range rule.Filters {
-		converted := convertFilter(ctx, &rule.Filters[filterIdx], namespace, clusterDomain, validator)
+		converted := convertFilter(ctx, &rule.Filters[filterIdx], namespace, clusterDomain, validator, tlsResolver)
 		if converted != nil {
 			proxyRule.Filters = append(proxyRule.Filters, *converted)
 		}
 	}
 
 	for backendIdx := range rule.BackendRefs {
-		backend, ok := convertBackendRef(ctx, &rule.BackendRefs[backendIdx], namespace, clusterDomain, validator, resolver)
+		backend, ok := convertBackendRef(ctx, &rule.BackendRefs[backendIdx], namespace, clusterDomain, validator, resolver, tlsResolver)
 		if ok {
 			proxyRule.Backends = append(proxyRule.Backends, backend)
 		}
@@ -218,6 +226,7 @@ func convertFilter(
 	filter *gatewayv1.HTTPRouteFilter,
 	namespace, clusterDomain string,
 	validator BackendRefValidator,
+	tlsResolver BackendTLSResolver,
 ) *RouteFilter {
 	switch filter.Type {
 	case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
@@ -229,7 +238,7 @@ func convertFilter(
 	case gatewayv1.HTTPRouteFilterURLRewrite:
 		return convertURLRewriteFilter(filter.URLRewrite)
 	case gatewayv1.HTTPRouteFilterRequestMirror:
-		return convertMirrorFilter(ctx, filter.RequestMirror, namespace, clusterDomain, validator)
+		return convertMirrorFilter(ctx, filter.RequestMirror, namespace, clusterDomain, validator, tlsResolver)
 	case gatewayv1.HTTPRouteFilterExtensionRef,
 		gatewayv1.HTTPRouteFilterCORS,
 		gatewayv1.HTTPRouteFilterExternalAuth:
@@ -315,6 +324,7 @@ func convertMirrorFilter(
 	mirror *gatewayv1.HTTPRequestMirrorFilter,
 	namespace, clusterDomain string,
 	validator BackendRefValidator,
+	tlsResolver BackendTLSResolver,
 ) *RouteFilter {
 	if mirror == nil {
 		return nil
@@ -349,6 +359,22 @@ func convertMirrorFilter(
 	}
 
 	mirrorURL := buildServiceURL(string(mirror.BackendRef.Name), mirrorNS, mirrorPort, clusterDomain)
+
+	// RequestMirror runs through a side-channel HTTP client that does NOT
+	// share the main proxy's TLS-aware transport pool. If a BackendTLSPolicy
+	// targets the mirror destination, the mirrored copy would be sent in
+	// plaintext, silently bypassing the operator's TLS intent. Document the
+	// gap loudly so operators see the silent downgrade; an actual TLS-aware
+	// mirror dial is tracked as a follow-up (see limitations.md).
+	if tlsResolver != nil {
+		if tls := tlsResolver(ctx, mirrorNS, string(mirror.BackendRef.Name), mirrorPort); tls != nil {
+			slog.Warn("RequestMirror target has a matching BackendTLSPolicy but the mirror filter dials plaintext — mirrored copy bypasses backend TLS enforcement",
+				"namespace", mirrorNS,
+				"service", string(mirror.BackendRef.Name),
+				"port", mirrorPort,
+			)
+		}
+	}
 
 	return &RouteFilter{
 		Type: FilterRequestMirror,
@@ -531,6 +557,7 @@ func convertBackendRef(
 	clusterDomain string,
 	validator BackendRefValidator,
 	resolver BackendProtocolResolver,
+	tlsResolver BackendTLSResolver,
 ) (BackendRef, bool) {
 	if !IsServiceBackendRef(backend.BackendObjectReference) {
 		slog.Warn("skipping non-Service backend kind",
@@ -578,11 +605,38 @@ func convertBackendRef(
 
 	result.URL = buildServiceURL(serviceName, svcNamespace, port, clusterDomain)
 
-	result.Protocol, result.URL = resolveBackendProtocol(ctx, resolver, svcNamespace, serviceName, port, result.URL)
+	// Resolve TLS first so the protocol resolver can know whether to silently
+	// pass through `appProtocol: https` (policy attached → suppressed) or warn
+	// (no policy → operator misconfigured a TLS hint with no actual TLS).
+	result.TLS, result.URL = resolveBackendTLS(ctx, tlsResolver, svcNamespace, serviceName, port, result.URL)
+	result.Protocol, result.URL = resolveBackendProtocol(ctx, resolver, svcNamespace, serviceName, port, result.URL, result.TLS != nil)
 
-	result.Filters = convertBackendFilters(ctx, backend.Filters, namespace, clusterDomain, validator)
+	result.Filters = convertBackendFilters(ctx, backend.Filters, namespace, clusterDomain, validator, tlsResolver)
 
 	return result, true
+}
+
+// resolveBackendTLS applies the BackendTLSPolicy resolver. When a policy
+// targets the backend, the returned TLS config is attached and the URL scheme
+// is forced to https (buildServiceURL's port-443 heuristic alone misses TLS on
+// non-standard ports).
+func resolveBackendTLS(
+	ctx context.Context,
+	resolver BackendTLSResolver,
+	namespace, serviceName string,
+	port int32,
+	rawURL string,
+) (*BackendTLSConfig, string) {
+	if resolver == nil {
+		return nil, rawURL
+	}
+
+	tls := resolver(ctx, namespace, serviceName, port)
+	if tls == nil {
+		return nil, rawURL
+	}
+
+	return tls, strings.Replace(rawURL, schemeHTTP+"://", schemeHTTPS+"://", 1)
 }
 
 // resolveBackendProtocol applies the protocol resolver to a backend reference
@@ -593,12 +647,19 @@ func convertBackendRef(
 // Unrecognised appProtocol values (e.g. kubernetes.io/ws, kubernetes.io/wss)
 // log a warning and fall back to the default HTTP/1.1 transport rather than
 // silently dropping the signal.
+//
+// `tlsAttached` reports whether a BackendTLSPolicy already applied a TLS config
+// to this backend. When the operator declared `appProtocol: https` (or
+// `HTTPS`) but no policy attached, the proxy would otherwise silently dial
+// plaintext — defeating the operator's stated TLS intent. In that case the
+// function logs a WARN so the misconfiguration is visible.
 func resolveBackendProtocol(
 	ctx context.Context,
 	resolver BackendProtocolResolver,
 	namespace, serviceName string,
 	port int32,
 	rawURL string,
+	tlsAttached bool,
 ) (BackendProtocol, string) {
 	if resolver == nil {
 		return BackendProtocolHTTP, rawURL
@@ -610,7 +671,41 @@ func resolveBackendProtocol(
 	case "":
 		return BackendProtocolHTTP, rawURL
 	case appProtocolH2C:
+		// h2c is plaintext HTTP/2 — but if a BackendTLSPolicy already
+		// attached, TLS wins (cleartext h2c cannot coexist with TLS).
+		// Leave the URL https:// so stdlib applies TLSClientConfig and
+		// HTTP/2 is negotiated via ALPN. A WARN surfaces the suppressed
+		// h2c hint so operators don't ship a confusing combo silently.
+		if tlsAttached {
+			slog.Warn("appProtocol kubernetes.io/h2c suppressed by BackendTLSPolicy on the same Service — HTTP/2 will be negotiated over TLS via ALPN",
+				"namespace", namespace,
+				"service", serviceName,
+				"port", port,
+			)
+
+			return BackendProtocolHTTP, rawURL
+		}
+
 		return BackendProtocolH2C, strings.Replace(rawURL, schemeHTTPS+"://", schemeHTTP+"://", 1)
+	case "http", "HTTP":
+		// Plaintext hint matches the default transport — silent.
+		return BackendProtocolHTTP, rawURL
+	case "https", "HTTPS":
+		// TLS hint. If a BackendTLSPolicy attached, resolveBackendTLS already
+		// rewrote the URL to https:// and built a real TLS config — the hint
+		// is redundant, no warning needed. If no policy attached, the proxy
+		// would dial in plaintext anyway (we have no CA to verify against);
+		// surface this so operators don't ship a broken TLS expectation.
+		if !tlsAttached {
+			slog.Warn("backend declares appProtocol https but no BackendTLSPolicy targets it — request will be sent in plaintext",
+				"namespace", namespace,
+				"service", serviceName,
+				"port", port,
+				"appProtocol", appProto,
+			)
+		}
+
+		return BackendProtocolHTTP, rawURL
 	default:
 		slog.Warn("unsupported backend appProtocol; falling back to HTTP/1.1",
 			"namespace", namespace,
@@ -630,6 +725,7 @@ func convertBackendFilters(
 	filters []gatewayv1.HTTPRouteFilter,
 	namespace, clusterDomain string,
 	validator BackendRefValidator,
+	tlsResolver BackendTLSResolver,
 ) []RouteFilter {
 	if len(filters) == 0 {
 		return nil
@@ -638,7 +734,7 @@ func convertBackendFilters(
 	result := make([]RouteFilter, 0, len(filters))
 
 	for filterIdx := range filters {
-		converted := convertFilter(ctx, &filters[filterIdx], namespace, clusterDomain, validator)
+		converted := convertFilter(ctx, &filters[filterIdx], namespace, clusterDomain, validator, tlsResolver)
 		if converted != nil {
 			result = append(result, *converted)
 		}

--- a/internal/proxy/converter_test.go
+++ b/internal/proxy/converter_test.go
@@ -67,7 +67,7 @@ func TestConvertHTTPRoutes_Basic(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 2)
 	assert.Contains(t, cfg.Rules[0].Hostnames, "example.com")
@@ -109,7 +109,7 @@ func TestConvertHTTPRoutes_BackendProtocolH2C(t *testing.T) {
 		return ""
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 2)
@@ -150,7 +150,7 @@ func TestConvertHTTPRoutes_UnknownAppProtocol_LogsAndDefaults(t *testing.T) {
 
 	t.Cleanup(func() { slog.SetDefault(previous) })
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 1)
@@ -160,6 +160,242 @@ func TestConvertHTTPRoutes_UnknownAppProtocol_LogsAndDefaults(t *testing.T) {
 		"unknown appProtocol must surface a warning, not silently disappear")
 	assert.Contains(t, logs.String(), "kubernetes.io/wss",
 		"warning must name the offending appProtocol")
+}
+
+// TestConvertHTTPRoutes_AppProtocolPlaintextPassThrough verifies that
+// `appProtocol: http`/`HTTP` flow through silently. They're transport-default
+// hints aligning with the proxy's default plaintext HTTP/1.1 transport.
+func TestConvertHTTPRoutes_AppProtocolPlaintextPassThrough(t *testing.T) {
+	cases := []struct {
+		name        string
+		appProtocol string
+	}{
+		{name: "lowercase http", appProtocol: "http"},
+		{name: "uppercase HTTP", appProtocol: "HTTP"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pathPrefix := gatewayv1.PathMatchPathPrefix
+			routes := []*gatewayv1.HTTPRoute{httpAppProtocolTestRoute(pathPrefix)}
+
+			resolver := func(_ context.Context, _, _ string, _ int32) string { return tc.appProtocol }
+			logs, cleanup := captureWarnLogs()
+			t.Cleanup(cleanup)
+
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver, nil)
+
+			require.Len(t, cfg.Rules, 1)
+			require.Len(t, cfg.Rules[0].Backends, 1)
+			assert.Equal(t, proxy.BackendProtocolHTTP, cfg.Rules[0].Backends[0].Protocol)
+			assert.NotContains(t, logs.String(), "unsupported backend appProtocol",
+				"http appProtocol must NOT log 'unsupported'")
+			assert.NotContains(t, logs.String(), "appProtocol https but no BackendTLSPolicy",
+				"plain http appProtocol must NOT log the no-policy warning")
+		})
+	}
+}
+
+// TestConvertHTTPRoutes_AppProtocolHTTPSWithoutPolicy_Warns confirms that
+// declaring `appProtocol: https` without a matching BackendTLSPolicy logs a
+// WARN — the proxy would otherwise dial in plaintext, silently violating the
+// operator's TLS intent.
+func TestConvertHTTPRoutes_AppProtocolHTTPSWithoutPolicy_Warns(t *testing.T) {
+	cases := []struct {
+		name        string
+		appProtocol string
+	}{
+		{name: "lowercase https", appProtocol: "https"},
+		{name: "uppercase HTTPS", appProtocol: "HTTPS"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pathPrefix := gatewayv1.PathMatchPathPrefix
+			routes := []*gatewayv1.HTTPRoute{httpAppProtocolTestRoute(pathPrefix)}
+
+			resolver := func(_ context.Context, _, _ string, _ int32) string { return tc.appProtocol }
+			logs, cleanup := captureWarnLogs()
+			t.Cleanup(cleanup)
+
+			// tlsResolver = nil → no BackendTLSPolicy applies → must warn.
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver, nil)
+
+			require.Len(t, cfg.Rules, 1)
+			require.Len(t, cfg.Rules[0].Backends, 1)
+			assert.Equal(t, proxy.BackendProtocolHTTP, cfg.Rules[0].Backends[0].Protocol)
+			assert.Nil(t, cfg.Rules[0].Backends[0].TLS, "no policy attached → no TLS config")
+			assert.Contains(t, logs.String(), "appProtocol https but no BackendTLSPolicy",
+				"appProtocol https without a policy MUST log a warning so the misconfiguration is visible")
+		})
+	}
+}
+
+// TestConvertHTTPRoutes_AppProtocolHTTPSWithPolicy_NoWarn confirms that
+// declaring `appProtocol: https` together with a BackendTLSPolicy is the
+// happy path: TLS is configured, no warning is logged.
+func TestConvertHTTPRoutes_AppProtocolHTTPSWithPolicy_NoWarn(t *testing.T) {
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	routes := []*gatewayv1.HTTPRoute{httpAppProtocolTestRoute(pathPrefix)}
+
+	protocolResolver := func(_ context.Context, _, _ string, _ int32) string { return "https" }
+	tlsResolver := func(_ context.Context, _, _ string, _ int32) *proxy.BackendTLSConfig {
+		return &proxy.BackendTLSConfig{
+			CABundlePEM: "-----BEGIN CERTIFICATE-----\nQUFBQQ==\n-----END CERTIFICATE-----\n",
+			ServerName:  "svc.default.svc.cluster.local",
+		}
+	}
+
+	logs, cleanup := captureWarnLogs()
+	t.Cleanup(cleanup)
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, protocolResolver, tlsResolver)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.NotNil(t, cfg.Rules[0].Backends[0].TLS, "policy attached → TLS config present")
+	assert.NotContains(t, logs.String(), "appProtocol https but no BackendTLSPolicy",
+		"appProtocol https WITH a BackendTLSPolicy must NOT warn — the operator did the right thing")
+}
+
+// TestConvertHTTPRoutes_Mirror_TargetHasBackendTLSPolicy_Warns pins the
+// known gap: the RequestMirror filter dials through a side-channel HTTP
+// client that does NOT share the proxy's TLS-aware transport pool, so a
+// mirror destination protected by BackendTLSPolicy would receive plaintext
+// instead of TLS. Until an actual TLS-aware mirror dial lands, the converter
+// surfaces a WARN so operators don't ship a silent policy bypass.
+func TestConvertHTTPRoutes_Mirror_TargetHasBackendTLSPolicy_Warns(t *testing.T) {
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	port := gatewayv1.PortNumber(443)
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "mirror-route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"app.example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						Filters: []gatewayv1.HTTPRouteFilter{
+							{
+								Type: gatewayv1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+									BackendRef: gatewayv1.BackendObjectReference{
+										Name: "mirror-target",
+										Port: &port,
+									},
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("primary", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	// tlsResolver returns a TLS config for mirror-target → warn must fire.
+	tlsResolver := func(_ context.Context, _, serviceName string, _ int32) *proxy.BackendTLSConfig {
+		if serviceName == "mirror-target" {
+			return &proxy.BackendTLSConfig{
+				CABundlePEM: "-----BEGIN CERTIFICATE-----\nQUFBQQ==\n-----END CERTIFICATE-----\n",
+				ServerName:  "mirror-target.default.svc.cluster.local",
+			}
+		}
+
+		return nil
+	}
+
+	logs, cleanup := captureWarnLogs()
+	t.Cleanup(cleanup)
+
+	proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, tlsResolver)
+
+	assert.Contains(t, logs.String(), "mirror filter dials plaintext",
+		"a BackendTLSPolicy protecting a mirror target MUST surface a WARN — "+
+			"the mirror leg currently bypasses TLS enforcement and operators must be told")
+}
+
+// TestConvertHTTPRoutes_BackendTLSPolicy_OverridesH2C verifies the docs claim
+// that when both `appProtocol: kubernetes.io/h2c` and a BackendTLSPolicy
+// target the same Service, TLS wins: the URL stays https://, the TLS config
+// is attached, and a WARN surfaces the suppressed h2c hint so operators
+// don't ship a confusing combo silently. Without this fix the h2c arm would
+// rewrite https:// → http://, defeating the TLS policy and silently routing
+// plaintext (a security regression).
+func TestConvertHTTPRoutes_BackendTLSPolicy_OverridesH2C(t *testing.T) {
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"app.example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("svc", 443, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	// Service signals h2c.
+	protocolResolver := func(_ context.Context, _, _ string, _ int32) string { return "kubernetes.io/h2c" }
+	// BackendTLSPolicy also targets the Service.
+	tlsResolver := func(_ context.Context, _, _ string, _ int32) *proxy.BackendTLSConfig {
+		return &proxy.BackendTLSConfig{
+			CABundlePEM: "-----BEGIN CERTIFICATE-----\nQUFBQQ==\n-----END CERTIFICATE-----\n",
+			ServerName:  "svc.default.svc.cluster.local",
+		}
+	}
+
+	logs, cleanup := captureWarnLogs()
+	t.Cleanup(cleanup)
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, protocolResolver, tlsResolver)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+
+	backend := cfg.Rules[0].Backends[0]
+	assert.NotNil(t, backend.TLS, "BackendTLSPolicy MUST stay attached even when h2c is also signalled")
+	assert.Contains(t, backend.URL, "https://",
+		"TLS policy MUST win — URL must remain https:// so stdlib applies TLSClientConfig. "+
+			"If the URL gets rewritten to http:// the proxy silently routes plaintext.")
+	assert.Equal(t, proxy.BackendProtocolHTTP, backend.Protocol,
+		"with TLS attached the protocol marker drops back to HTTP — HTTP/2 is negotiated via ALPN on the TLS handshake")
+	assert.Contains(t, logs.String(), "h2c suppressed by BackendTLSPolicy",
+		"the h2c-suppressed warning must surface so operators see the conflict")
+}
+
+func httpAppProtocolTestRoute(pathPrefix gatewayv1.PathMatchType) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Hostnames: []gatewayv1.Hostname{"example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("svc", 80, 1)},
+				},
+			},
+		},
+	}
+}
+
+func captureWarnLogs() (*bytes.Buffer, func()) {
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	return &logs, func() { slog.SetDefault(previous) }
 }
 
 func TestConvertHTTPRoutes_RuleMirror_CrossNamespaceRejectedWithoutGrant(t *testing.T) {
@@ -203,7 +439,7 @@ func TestConvertHTTPRoutes_RuleMirror_CrossNamespaceRejectedWithoutGrant(t *test
 		return false
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", rejectAll, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", rejectAll, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters,
@@ -259,7 +495,7 @@ func TestConvertHTTPRoutes_PerBackendMirror_CrossNamespaceRejectedWithoutGrant(t
 		return false
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", rejectAll, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", rejectAll, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 1)
@@ -323,7 +559,7 @@ func TestConvertHTTPRoutes_PerBackendFilters(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 2)
@@ -376,7 +612,7 @@ func TestConvertHTTPRoutes_MultipleMirrors(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 2, "both mirror filters must be carried into the rule")
@@ -421,7 +657,7 @@ func TestConvertHTTPRoutes_MirrorWithPercent(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -466,7 +702,7 @@ func TestConvertHTTPRoutes_MirrorFractionLargeDenominatorNoOverflow(t *testing.T
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.NotNil(t, cfg.Rules[0].Filters[0].RequestMirror.Percent)
@@ -506,7 +742,7 @@ func TestConvertHTTPRoutes_MirrorPercentDetachedFromSourcePointer(t *testing.T) 
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	// Mutate the source pointer after conversion. The proxy config must hold a
 	// snapshot, not a live alias — otherwise the filter goroutine could read
@@ -553,7 +789,7 @@ func TestConvertHTTPRoutes_MirrorFractionNonPositiveDenominator_Skipped(t *testi
 	}
 
 	require.NotPanics(t, func() {
-		cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+		cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 		require.Len(t, cfg.Rules, 1)
 		require.Len(t, cfg.Rules[0].Filters, 1)
 		require.NotNil(t, cfg.Rules[0].Filters[0].RequestMirror)
@@ -645,7 +881,7 @@ func TestConvertHTTPRoutes_MirrorWithFractionResolvesToPercent(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -654,6 +890,90 @@ func TestConvertHTTPRoutes_MirrorWithFractionResolvesToPercent(t *testing.T) {
 		"Fraction must be normalized to Percent at conversion time")
 	assert.Equal(t, int32(50), *cfg.Rules[0].Filters[0].RequestMirror.Percent,
 		"25/50 must resolve to 50%%")
+}
+
+func TestConvertHTTPRoutes_BackendTLSPolicy_AttachesTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "tls", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							backendRef("tls-svc", 8443, 1),
+							backendRef("plain-svc", 80, 1),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	caPEM := "-----BEGIN CERTIFICATE-----\nFAKE CA PEM FOR TEST\n-----END CERTIFICATE-----\n"
+	tlsResolver := func(_ context.Context, namespace, name string, port int32) *proxy.BackendTLSConfig {
+		if namespace == "default" && name == "tls-svc" && port == 8443 {
+			return &proxy.BackendTLSConfig{
+				CABundlePEM:     caPEM,
+				ServerName:      "tls-svc.example.com",
+				SubjectAltNames: []string{"alt.example.com"},
+			}
+		}
+
+		return nil
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, tlsResolver)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 2)
+
+	require.NotNil(t, cfg.Rules[0].Backends[0].TLS, "BackendTLSPolicy targeting tls-svc must attach TLS config")
+	assert.Equal(t, caPEM, cfg.Rules[0].Backends[0].TLS.CABundlePEM)
+	assert.Equal(t, "tls-svc.example.com", cfg.Rules[0].Backends[0].TLS.ServerName)
+	assert.Equal(t, []string{"alt.example.com"}, cfg.Rules[0].Backends[0].TLS.SubjectAltNames)
+	assert.True(t, strings.HasPrefix(cfg.Rules[0].Backends[0].URL, "https://"),
+		"backend with TLS policy must use https:// scheme regardless of port, got %q", cfg.Rules[0].Backends[0].URL)
+
+	assert.Nil(t, cfg.Rules[0].Backends[1].TLS, "plain-svc has no BackendTLSPolicy")
+	assert.True(t, strings.HasPrefix(cfg.Rules[0].Backends[1].URL, "http://"),
+		"plain backend on port 80 keeps http:// scheme")
+}
+
+func TestConvertHTTPRoutes_BackendTLSPolicy_NoResolverLeavesTLSNil(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "default-tls", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("svc", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Nil(t, cfg.Rules[0].Backends[0].TLS, "no resolver means no TLS attached")
 }
 
 func TestConvertHTTPRoutes_BackendProtocolH2C_OnPort443_UsesHTTPScheme(t *testing.T) {
@@ -683,7 +1003,7 @@ func TestConvertHTTPRoutes_BackendProtocolH2C_OnPort443_UsesHTTPScheme(t *testin
 
 	resolver := func(_ context.Context, _, _ string, _ int32) string { return "kubernetes.io/h2c" }
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 1)
@@ -714,7 +1034,7 @@ func TestConvertHTTPRoutes_NoProtocolResolver_DefaultsHTTP(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 1)
@@ -745,7 +1065,7 @@ func TestConvertHTTPRoutes_MultipleHostnames(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Equal(t, []string{"app.example.com", "app.example.org"}, cfg.Rules[0].Hostnames)
@@ -786,7 +1106,7 @@ func TestConvertHTTPRoutes_Filters(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -831,7 +1151,7 @@ func TestConvertHTTPRoutes_HeaderMatch(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Matches, 1)
@@ -868,7 +1188,7 @@ func TestConvertHTTPRoutes_WeightedBackends(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 2)
@@ -899,7 +1219,7 @@ func TestConvertHTTPRoutes_NoHostnames(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Hostnames, "no hostnames means catch-all")
@@ -908,7 +1228,7 @@ func TestConvertHTTPRoutes_NoHostnames(t *testing.T) {
 func TestConvertHTTPRoutes_Empty(t *testing.T) {
 	t.Parallel()
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), nil, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), nil, "cluster.local", nil, nil, nil)
 
 	assert.Empty(t, cfg.Rules)
 	assert.True(t, cfg.Version > 0, "version should be positive")
@@ -945,7 +1265,7 @@ func TestConvertHTTPRoutes_NonServiceBackendSkipped(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1, "rule with unresolvable backend should still be present for 500 response")
 	assert.Empty(t, cfg.Rules[0].Backends, "non-Service backend should not be in backends list")
@@ -1003,7 +1323,7 @@ func TestConvertQueryMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{tt.route}, "cluster.local", nil, nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{tt.route}, "cluster.local", nil, nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Matches, 1)
@@ -1029,7 +1349,7 @@ func TestConvertFilter_RequestHeaderModifier(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1050,7 +1370,7 @@ func TestConvertFilter_RequestHeaderModifier_NilBody(t *testing.T) {
 		RequestHeaderModifier: nil,
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters)
@@ -1068,7 +1388,7 @@ func TestConvertFilter_ResponseHeaderModifier(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1087,7 +1407,7 @@ func TestConvertFilter_ResponseHeaderModifier_NilBody(t *testing.T) {
 		ResponseHeaderModifier: nil,
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters)
@@ -1113,7 +1433,7 @@ func TestConvertFilter_RequestRedirect_Full(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1138,7 +1458,7 @@ func TestConvertFilter_RequestRedirect_NilBody(t *testing.T) {
 		RequestRedirect: nil,
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters)
@@ -1215,7 +1535,7 @@ func TestConvertFilter_URLRewrite(t *testing.T) {
 				URLRewrite: tt.rewrite,
 			})
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1259,7 +1579,7 @@ func TestConvertFilter_URLRewrite_NilBody(t *testing.T) {
 		URLRewrite: nil,
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters)
@@ -1277,7 +1597,7 @@ func TestConvertFilter_RequestMirror(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1296,7 +1616,7 @@ func TestConvertFilter_RequestMirror_NilBody(t *testing.T) {
 		RequestMirror: nil,
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters)
@@ -1317,7 +1637,7 @@ func TestConvertFilter_UnsupportedTypes(t *testing.T) {
 				Type: filterType,
 			})
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			assert.Empty(t, cfg.Rules[0].Filters)
@@ -1342,7 +1662,7 @@ func TestConvertHeaderModifier_AllOperations(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1365,7 +1685,7 @@ func TestConvertHeaderModifier_Empty(t *testing.T) {
 		RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1417,7 +1737,7 @@ func TestConvertRedirectPath(t *testing.T) {
 				},
 			})
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1442,7 +1762,7 @@ func TestConvertRedirectPath_PrefixMatch(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1465,7 +1785,7 @@ func TestConvertRedirectPath_NilFields(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1519,7 +1839,7 @@ func TestConvertURLRewritePath(t *testing.T) {
 				},
 			})
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Filters, 1)
@@ -1606,7 +1926,7 @@ func TestConvertTimeouts(t *testing.T) {
 
 			route := routeWithTimeouts(tt.timeouts)
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 
@@ -1642,7 +1962,7 @@ func TestConvertTimeouts_Nil(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Nil(t, cfg.Rules[0].Timeouts)
@@ -1714,7 +2034,7 @@ func TestConvertHeaderMatch_EdgeCases(t *testing.T) {
 
 			route := routeWithHeaderMatch(tt.header)
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Matches, 1)
@@ -1763,7 +2083,7 @@ func TestConvertBackendRef_InvalidPort(t *testing.T) {
 				},
 			}
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 			if tt.expectSkipped {
 				require.Len(t, cfg.Rules, 1, "rule with invalid backend should still be present for 500 response")
@@ -1806,7 +2126,7 @@ func TestConvertMirrorFilter_InvalidPort(t *testing.T) {
 				},
 			})
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 
@@ -1856,7 +2176,7 @@ func TestConvertBackendRef_NonServiceKind(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1, "rule with unresolvable backend should still be present for 500 response")
 	assert.Empty(t, cfg.Rules[0].Backends, "non-Service backend should not be in backends list")
@@ -1879,7 +2199,7 @@ func TestConvertMirrorFilter_NonServiceKind(t *testing.T) {
 		},
 	})
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	assert.Empty(t, cfg.Rules[0].Filters, "mirror filter with non-Service kind should be skipped")
@@ -1924,7 +2244,7 @@ func TestConvertBackendRef_CrossNamespaceRejected(t *testing.T) {
 		return false
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", rejectAll, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", rejectAll, nil, nil)
 
 	require.Len(t, cfg.Rules, 1, "rule with rejected cross-namespace backend should still be present for 500 response")
 	assert.Empty(t, cfg.Rules[0].Backends, "rejected cross-namespace backend should not be in backends list")
@@ -1969,7 +2289,7 @@ func TestConvertBackendRef_CrossNamespaceAllowed(t *testing.T) {
 		return true
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", allowAll, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", allowAll, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 1, "cross-namespace backend should be allowed by validator")
@@ -2005,7 +2325,7 @@ func TestConvertBackendRef_SameNamespaceAlwaysAllowed(t *testing.T) {
 		return false
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", rejectAll, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", rejectAll, nil, nil)
 
 	require.Len(t, cfg.Rules, 1)
 	require.Len(t, cfg.Rules[0].Backends, 1, "same-namespace backend should always be allowed")
@@ -2054,7 +2374,7 @@ func TestBuildServiceURL_SchemeByPort(t *testing.T) {
 				},
 			}
 
-			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 			require.Len(t, cfg.Rules, 1)
 			require.Len(t, cfg.Rules[0].Backends, 1)
@@ -2085,7 +2405,7 @@ func TestConvertBackendRef_NegativeWeight(t *testing.T) {
 		},
 	}
 
-	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil)
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{route}, "cluster.local", nil, nil, nil)
 
 	require.Len(t, cfg.Rules, 1, "rule with unresolvable backend should still be present for 500 response")
 	assert.Empty(t, cfg.Rules[0].Backends, "negative-weight backend should not be in backends list")

--- a/internal/proxy/export_test.go
+++ b/internal/proxy/export_test.go
@@ -11,14 +11,14 @@ func (h *Handler) Transports() *sync.Map {
 	return &h.transports
 }
 
-// TransportKey exposes the per-host+protocol pool key for testing purposes.
-func TransportKey(host string, protocol BackendProtocol) string {
-	return transportKey(host, protocol)
+// TransportKey exposes the per-host+protocol+tls pool key for testing purposes.
+func TransportKey(host string, protocol BackendProtocol, backendTLS *BackendTLSConfig) string {
+	return transportKey(host, protocol, backendTLS)
 }
 
 // NewTransportForTest exposes newTransport for testing purposes.
-func NewTransportForTest(protocol BackendProtocol) http.RoundTripper {
-	return newTransport(protocol)
+func NewTransportForTest(protocol BackendProtocol, backendTLS *BackendTLSConfig) http.RoundTripper {
+	return newTransport(protocol, backendTLS)
 }
 
 // ShouldMirrorForTest exposes the unexported requestMirror.shouldMirror

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -2,8 +2,12 @@ package proxy
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -28,11 +32,35 @@ type Handler struct {
 	transports sync.Map // map[string]http.RoundTripper
 }
 
-// transportKey forms the cache key for a backend transport. The protocol is
-// part of the key so a protocol flip on the same host:port forces a fresh
-// transport.
-func transportKey(host string, protocol BackendProtocol) string {
-	return host + "|" + string(protocol)
+// transportKey forms the cache key for a backend transport. Host, protocol
+// AND TLS identity all participate so that a config push which adds, removes,
+// or re-anchors a BackendTLSPolicy forces a fresh transport instead of reusing
+// a stale one. tlsFingerprint hashes the CA + ServerName + SANs into a short
+// stable string.
+func transportKey(host string, protocol BackendProtocol, backendTLS *BackendTLSConfig) string {
+	return host + "|" + string(protocol) + "|" + tlsFingerprint(backendTLS)
+}
+
+// tlsFingerprint returns a stable short hash of the TLS config, or "" when nil.
+func tlsFingerprint(backendTLS *BackendTLSConfig) string {
+	if backendTLS == nil {
+		return ""
+	}
+
+	hasher := sha256.New()
+	hasher.Write([]byte(backendTLS.CABundlePEM))
+	hasher.Write([]byte{0})
+	hasher.Write([]byte(backendTLS.ServerName))
+	hasher.Write([]byte{0})
+
+	for _, san := range backendTLS.SubjectAltNames {
+		hasher.Write([]byte(san))
+		hasher.Write([]byte{0})
+	}
+
+	sum := hasher.Sum(nil)
+
+	return hex.EncodeToString(sum[:8])
 }
 
 // NewHandler creates a new proxy Handler backed by the given Router.
@@ -156,12 +184,12 @@ func (h *Handler) proxyToBackend(writer http.ResponseWriter, req *http.Request, 
 	// requests reading the same compiled rule.
 	allFilters := slices.Concat(result.Filters, result.BackendFilters)
 
-	proxy := h.createReverseProxy(backendURL, backend.Protocol, allFilters)
+	proxy := h.createReverseProxy(backendURL, backend.Protocol, backend.TLS, allFilters)
 	proxy.ServeHTTP(writer, req)
 }
 
 // createReverseProxy builds an httputil.ReverseProxy for the given backend.
-func (h *Handler) createReverseProxy(backendURL *url.URL, protocol BackendProtocol, filters []Filter) *httputil.ReverseProxy {
+func (h *Handler) createReverseProxy(backendURL *url.URL, protocol BackendProtocol, backendTLS *BackendTLSConfig, filters []Filter) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.URL.Scheme = backendURL.Scheme
@@ -191,7 +219,7 @@ func (h *Handler) createReverseProxy(backendURL *url.URL, protocol BackendProtoc
 				req.Header.Set("User-Agent", "")
 			}
 		},
-		Transport:    h.getTransport(backendURL.Host, protocol),
+		Transport:    h.getTransport(backendURL.Host, protocol, backendTLS),
 		ErrorHandler: errorHandler,
 		ModifyResponse: func(resp *http.Response) error {
 			ApplyResponseFilters(filters, resp)
@@ -201,11 +229,11 @@ func (h *Handler) createReverseProxy(backendURL *url.URL, protocol BackendProtoc
 	}
 }
 
-// getTransport returns a shared transport for the given backend host/protocol.
-// The cache key includes the protocol so that flipping a Service's appProtocol
-// (e.g. http -> h2c) does not silently reuse a stale HTTP/1.1 transport.
-func (h *Handler) getTransport(host string, protocol BackendProtocol) http.RoundTripper {
-	key := transportKey(host, protocol)
+// getTransport returns a shared transport for the given backend host/protocol/TLS.
+// The cache key includes protocol AND TLS identity so config flips that swap
+// out either don't silently reuse a stale transport.
+func (h *Handler) getTransport(host string, protocol BackendProtocol, backendTLS *BackendTLSConfig) http.RoundTripper {
+	key := transportKey(host, protocol, backendTLS)
 
 	if transport, ok := h.transports.Load(key); ok {
 		if rt, castOK := transport.(http.RoundTripper); castOK {
@@ -213,7 +241,7 @@ func (h *Handler) getTransport(host string, protocol BackendProtocol) http.Round
 		}
 	}
 
-	transport := newTransport(protocol)
+	transport := newTransport(protocol, backendTLS)
 	actual, _ := h.transports.LoadOrStore(key, transport)
 
 	if rt, ok := actual.(http.RoundTripper); ok {
@@ -251,10 +279,17 @@ func newH2CDialer() *net.Dialer {
 	}
 }
 
-// newTransport builds a backend transport for the given protocol. For h2c it
-// returns an HTTP/2 transport that negotiates cleartext via prior knowledge
-// (AllowHTTP with a plaintext dialer); otherwise a clone of the default transport.
-func newTransport(protocol BackendProtocol) http.RoundTripper {
+// newTransport builds a backend transport for the given protocol and optional
+// TLS policy. Precedence: when backendTLS is set, the proxy dials TLS (HTTPS,
+// with HTTP/2 auto-negotiated via ALPN) — h2c (cleartext) cannot coexist with
+// TLS, so the protocol marker is intentionally ignored in that path. Otherwise
+// h2c uses an HTTP/2 plaintext transport; default is a clone of the stdlib
+// transport.
+func newTransport(protocol BackendProtocol, backendTLS *BackendTLSConfig) http.RoundTripper {
+	if backendTLS != nil {
+		return newTLSTransport(backendTLS)
+	}
+
 	if protocol == BackendProtocolH2C {
 		dialer := newH2CDialer()
 
@@ -273,6 +308,127 @@ func newTransport(protocol BackendProtocol) http.RoundTripper {
 	}
 
 	return http.DefaultTransport
+}
+
+// Sentinel errors for backend TLS verification so wrappers can be matched with errors.Is.
+var (
+	errBackendTLSNoPeerCert  = errors.New("backend tls: no peer certificates presented")
+	errBackendTLSSANMissing  = errors.New("backend tls: required SAN not present in cert SANs")
+	errBackendTLSChainVerify = errors.New("backend tls: chain verification failed")
+)
+
+// newTLSTransport wires a BackendTLSConfig into an http.Transport that
+// validates the backend cert chain against the policy's CA bundle.
+//
+// Two verification modes, per Gateway API BackendTLSPolicy spec:
+//
+//   - SubjectAltNames empty: stdlib hostname verification against ServerName
+//     (i.e. policy Hostname is the authentication identity). ServerName is
+//     also used as SNI.
+//   - SubjectAltNames non-empty: Hostname is used ONLY for SNI/selection, NOT
+//     authentication. We disable the default ServerName-vs-cert match and
+//     manually verify the chain + OR-match the leaf against the policy's SAN
+//     list using x509.VerifyHostname so RFC 6125 wildcards work.
+//
+// In both modes a CA pool that fails to parse any PEM block is treated as a
+// hard failure so misconfigured operators see a TLS handshake error instead of
+// silently trusting nothing (gosec G402-safe path).
+func newTLSTransport(backendTLS *BackendTLSConfig) http.RoundTripper {
+	rootCAs := x509.NewCertPool()
+	if ok := rootCAs.AppendCertsFromPEM([]byte(backendTLS.CABundlePEM)); !ok {
+		slog.Error("BackendTLSPolicy CA bundle did not parse — all backend TLS handshakes will fail",
+			"serverName", backendTLS.ServerName,
+		)
+	}
+
+	tlsConfig := buildBackendTLSConfig(backendTLS, rootCAs)
+
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		// stdlib's DefaultTransport is always *http.Transport; fall back is
+		// defensive only.
+		return http.DefaultTransport
+	}
+
+	transport := base.Clone()
+	transport.TLSClientConfig = tlsConfig
+
+	return transport
+}
+
+// buildBackendTLSConfig assembles the *tls.Config for the two backend-TLS
+// verification modes. Split from newTLSTransport for testability and to keep
+// per-function complexity within the funlen budget.
+func buildBackendTLSConfig(backendTLS *BackendTLSConfig, rootCAs *x509.CertPool) *tls.Config {
+	if len(backendTLS.SubjectAltNames) == 0 {
+		// Mode 1: Hostname-based authentication via ServerName.
+		return &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    rootCAs,
+			ServerName: backendTLS.ServerName,
+		}
+	}
+
+	// Mode 2: SAN-list authentication. ServerName drives SNI only.
+	expected := slices.Clone(backendTLS.SubjectAltNames)
+
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    rootCAs,
+		ServerName: backendTLS.ServerName,
+		// Hostname matching is intentionally bypassed — VerifyConnection
+		// performs full chain validation AND the SAN OR-match below.
+		// gosec G402: this is the documented Gateway API SAN-only verification
+		// path; chain validation is preserved via leaf.Verify().
+		InsecureSkipVerify: true, //nolint:gosec // see comment above
+		VerifyConnection:   verifyBackendChainAndSANs(rootCAs, expected),
+	}
+
+	return tlsConfig
+}
+
+// verifyBackendChainAndSANs returns a VerifyConnection callback that runs both
+// on fresh and resumed handshakes (per gosec G123). It manually verifies the
+// chain against rootCAs (since InsecureSkipVerify=true disables the default
+// path) and asserts the leaf cert matches at least one of the expected SANs.
+// Wildcard SANs are honoured via x509.Certificate.VerifyHostname.
+func verifyBackendChainAndSANs(rootCAs *x509.CertPool, expected []string) func(tls.ConnectionState) error {
+	return func(state tls.ConnectionState) error {
+		if len(state.PeerCertificates) == 0 {
+			return errBackendTLSNoPeerCert
+		}
+
+		leaf := state.PeerCertificates[0]
+
+		intermediates := x509.NewCertPool()
+		for _, intermediate := range state.PeerCertificates[1:] {
+			intermediates.AddCert(intermediate)
+		}
+
+		// DNSName intentionally empty: hostname auth happens via the SAN
+		// OR-match below per BackendTLSPolicy semantics.
+		_, verifyErr := leaf.Verify(x509.VerifyOptions{
+			Roots:         rootCAs,
+			Intermediates: intermediates,
+		})
+		if verifyErr != nil {
+			return fmt.Errorf("%w: %w", errBackendTLSChainVerify, verifyErr)
+		}
+
+		// Gateway API spec: the cert must match AT LEAST ONE of the policy's
+		// SubjectAltNames (OR semantics). VerifyHostname handles RFC 6125
+		// wildcard SANs correctly (e.g. cert SAN "*.example.com" matches a
+		// policy SAN "foo.example.com").
+		for _, want := range expected {
+			sanErr := leaf.VerifyHostname(want)
+			if sanErr == nil {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("%w: required one of %v, cert SANs %v",
+			errBackendTLSSANMissing, expected, leaf.DNSNames)
+	}
 }
 
 // errorHandler handles proxy errors with appropriate HTTP status codes.

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -441,7 +441,7 @@ func TestHandler_PruneTransportsRemovesStaleHostFromSyncMap(t *testing.T) {
 
 	// Verify transport for backend A was created.
 	hostA := backendA.Listener.Addr().String()
-	keyA := proxy.TransportKey(hostA, proxy.BackendProtocolHTTP)
+	keyA := proxy.TransportKey(hostA, proxy.BackendProtocolHTTP, nil)
 	_, loaded := handler.Transports().Load(keyA)
 	require.True(t, loaded, "transport for backend A should exist after request")
 

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -1,6 +1,7 @@
 package proxy_test
 
 import (
+	"encoding/pem"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -120,7 +121,7 @@ func TestHandler_BackendProtocolH2C(t *testing.T) {
 func TestNewTransport_H2C_HasLivenessDefaults(t *testing.T) {
 	t.Parallel()
 
-	rt := proxy.NewTransportForTest(proxy.BackendProtocolH2C)
+	rt := proxy.NewTransportForTest(proxy.BackendProtocolH2C, nil)
 
 	tr, ok := rt.(*http2.Transport)
 	require.True(t, ok, "h2c transport must be *http2.Transport, got %T", rt)
@@ -388,6 +389,305 @@ func TestHandler_MirrorPercentDistribution(t *testing.T) {
 		"mirrored request count %d below 20%% expected ±15%% tolerance", got)
 	assert.LessOrEqual(t, got, expected+tolerance,
 		"mirrored request count %d above 20%% expected ±15%% tolerance", got)
+}
+
+// caPEMFromTLSServer returns the PEM-encoded test certificate authority that
+// httptest.NewTLSServer self-signed for itself. Suitable as a CABundle for
+// BackendTLSConfig so the proxy trusts the test server.
+func caPEMFromTLSServer(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+
+	require.NotNil(t, server.TLS, "expected *httptest.Server in TLS mode")
+	require.NotEmpty(t, server.TLS.Certificates)
+
+	cert := server.TLS.Certificates[0].Certificate[0]
+	pemBlock := &pem.Block{Type: "CERTIFICATE", Bytes: cert}
+
+	return string(pem.EncodeToMemory(pemBlock))
+}
+
+func TestHandler_BackendTLSPolicy_ValidCA_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	tlsBackend := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("X-Backend", "tls")
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(tlsBackend.Close)
+
+	caPEM := caPEMFromTLSServer(t, tlsBackend)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends: []proxy.BackendRef{
+					{
+						URL:    tlsBackend.URL,
+						Weight: 1,
+						TLS: &proxy.BackendTLSConfig{
+							CABundlePEM: caPEM,
+							ServerName:  "example.com", // httptest.NewTLSServer cert SAN
+						},
+					},
+				},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "tls", resp.Header.Get("X-Backend"))
+}
+
+func TestHandler_BackendTLSPolicy_BogusCA_Fails(t *testing.T) {
+	t.Parallel()
+
+	tlsBackend := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(tlsBackend.Close)
+
+	bogusCA := `-----BEGIN CERTIFICATE-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1234567890BOGUSCAFORTEST
+-----END CERTIFICATE-----
+`
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends: []proxy.BackendRef{
+					{
+						URL:    tlsBackend.URL,
+						Weight: 1,
+						TLS: &proxy.BackendTLSConfig{
+							CABundlePEM: bogusCA,
+							ServerName:  "example.com",
+						},
+					},
+				},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Result().StatusCode,
+		"BackendTLSPolicy with mismatched CA must fail TLS verification → proxy returns 502")
+}
+
+func TestHandler_BackendTLSPolicy_MismatchedHostname_Fails(t *testing.T) {
+	t.Parallel()
+
+	tlsBackend := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(tlsBackend.Close)
+
+	caPEM := caPEMFromTLSServer(t, tlsBackend)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends: []proxy.BackendRef{
+					{
+						URL:    tlsBackend.URL,
+						Weight: 1,
+						TLS: &proxy.BackendTLSConfig{
+							CABundlePEM: caPEM,
+							ServerName:  "wrong-hostname.invalid",
+						},
+					},
+				},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Result().StatusCode,
+		"BackendTLSPolicy with hostname not in cert SAN must fail TLS verification → proxy returns 502")
+}
+
+// TestHandler_BackendTLSPolicy_PoisonedConfig_HandshakeFails verifies the
+// end-to-end fail-closed contract: when the controller pushes a config with an
+// empty CABundlePEM (e.g. because the BackendTLSPolicy CA reference cannot be
+// resolved), the proxy MUST refuse the request via a 502 rather than silently
+// downgrading to plaintext. Pairs with
+// TestProxySyncer_SyncRoutes_BackendTLSPolicyMissingCA_FailsClosed which
+// covers the config-push side; this test pins the runtime side.
+func TestHandler_BackendTLSPolicy_PoisonedConfig_HandshakeFails(t *testing.T) {
+	t.Parallel()
+
+	tlsBackend := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(tlsBackend.Close)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends: []proxy.BackendRef{
+					{
+						URL:    tlsBackend.URL,
+						Weight: 1,
+						// Poisoned config: empty CA bundle. The controller
+						// pushes exactly this when a policy targets the
+						// Service but its CA ref cannot be resolved.
+						TLS: &proxy.BackendTLSConfig{
+							CABundlePEM: "",
+							ServerName:  "example.com",
+						},
+					},
+				},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Result().StatusCode,
+		"poisoned TLS config (empty CA pool) MUST fail TLS verification at handshake → 502, "+
+			"the operator's intent is preserved over silent plaintext downgrade")
+}
+
+// TestHandler_BackendTLSPolicy_SANOnly_AcceptsMatchingSAN verifies the
+// SAN-list authentication path: when SubjectAltNames is non-empty the proxy
+// uses x509.VerifyHostname against each entry rather than treating ServerName
+// as an authentication identity. The first SAN in the list does NOT match the
+// cert, the second one DOES — OR-semantics must accept.
+func TestHandler_BackendTLSPolicy_SANOnly_AcceptsMatchingSAN(t *testing.T) {
+	t.Parallel()
+
+	tlsBackend := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(tlsBackend.Close)
+
+	caPEM := caPEMFromTLSServer(t, tlsBackend)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends: []proxy.BackendRef{
+					{
+						URL:    tlsBackend.URL,
+						Weight: 1,
+						TLS: &proxy.BackendTLSConfig{
+							CABundlePEM: caPEM,
+							// ServerName intentionally set to a value the cert
+							// does NOT carry — when SANs are present, this
+							// must be used for SNI only and the leaf
+							// authentication runs over the SAN list below.
+							ServerName: "sni-only.invalid",
+							SubjectAltNames: []string{
+								"does-not-match.invalid",
+								"example.com", // matches httptest.NewTLSServer cert SAN
+							},
+						},
+					},
+				},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Result().StatusCode,
+		"SAN OR-matching must succeed when any policy SAN matches the cert")
+}
+
+// TestHandler_BackendTLSPolicy_SANOnly_RejectsAllMismatching verifies that the
+// SAN-list authentication path returns 502 when NO policy SAN matches the
+// cert. ServerName must NOT rescue the request — it's SNI only in this mode.
+func TestHandler_BackendTLSPolicy_SANOnly_RejectsAllMismatching(t *testing.T) {
+	t.Parallel()
+
+	tlsBackend := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(tlsBackend.Close)
+
+	caPEM := caPEMFromTLSServer(t, tlsBackend)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends: []proxy.BackendRef{
+					{
+						URL:    tlsBackend.URL,
+						Weight: 1,
+						TLS: &proxy.BackendTLSConfig{
+							CABundlePEM: caPEM,
+							// ServerName matches the cert — but since SANs are
+							// set, ServerName must NOT be used for auth.
+							ServerName: "example.com",
+							SubjectAltNames: []string{
+								"only-wrong.invalid",
+								"also-wrong.invalid",
+							},
+						},
+					},
+				},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Result().StatusCode,
+		"SAN OR-matching must reject when NO policy SAN matches, regardless of ServerName")
 }
 
 func TestHandler_BackendProtocolToggleSameHostPort(t *testing.T) {

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -158,9 +158,9 @@ func (r *Router) UpdateConfig(cfg *Config) error {
 }
 
 // extractActiveTransportKeys collects all backend transport-pool keys from the
-// config's rules. Keys are formed by transportKey(host, protocol) so
-// PruneTransports can evict stale entries when either changes (e.g. on a
-// Service appProtocol flip).
+// config's rules. Keys are formed by transportKey(host, protocol, tls) so
+// PruneTransports can evict stale entries when any of those change (e.g. on a
+// Service appProtocol flip or a BackendTLSPolicy swap).
 func extractActiveTransportKeys(cfg *Config) map[string]bool {
 	keys := make(map[string]bool)
 
@@ -171,7 +171,7 @@ func extractActiveTransportKeys(cfg *Config) map[string]bool {
 				continue
 			}
 
-			keys[transportKey(parsed.Host, backend.Protocol)] = true
+			keys[transportKey(parsed.Host, backend.Protocol, backend.TLS)] = true
 		}
 	}
 

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -53,6 +53,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		features.SupportHTTPRouteBackendProtocolH2C,
 		features.SupportHTTPRouteRequestMultipleMirrors,
 		features.SupportHTTPRouteRequestPercentageMirror,
+		features.SupportBackendTLSPolicy,
 		// NOTE: 303/307/308 redirect status codes work correctly in the proxy,
 		// but Cloudflare edge rewrites Location scheme to HTTPS, so conformance
 		// tests that verify http:// scheme in redirects will always fail.
@@ -78,7 +79,8 @@ func TestGatewayAPIConformance(t *testing.T) {
 		features.SupportTLSRoute,
 		features.SupportTLSRouteModeTerminate,
 		features.SupportTLSRouteModeMixed,
-		features.SupportBackendTLSPolicy,
+		// SANValidation requires URI-SAN support end-to-end; this minimum
+		// BackendTLSPolicy implementation handles Hostname SANs only.
 		features.SupportBackendTLSPolicySANValidation,
 		features.SupportUDPRoute,
 		features.SupportMesh,
@@ -150,12 +152,22 @@ func TestGatewayAPIConformance(t *testing.T) {
 		"MeshHTTPRouteSimpleSameNamespace",
 		"MeshHTTPRouteWeight",
 
-		// BackendTLSPolicy: not supported — tunnel terminates TLS at edge.
+		// BackendTLSPolicy: the main test exercises Re-encrypt against the
+		// "same-namespace-with-https-listener" Gateway; Cloudflare terminates
+		// TLS at the edge so HTTPS listeners are not supported (see the
+		// HTTPRouteHTTPSListener skip above) and the parent test would fail on
+		// its first sub-test. The subsequent HTTP sub-tests are covered by the
+		// HTTPRoute_ extended suite. ConflictResolution requires cross-policy
+		// conflict tracking (loser stamped with Reason=Conflicted) that this
+		// implementation does not yet do — older policy wins, others share the
+		// same Accepted=True status. SANValidation requires URI-type
+		// SubjectAltNames which are rejected by validateSANs (see the
+		// BackendTLSPolicy section in docs/gateway-api/limitations.md).
+		// InvalidCACertificateRef and ObservedGenerationBump are enabled —
+		// the controller emits the conformance-required Reasons and updates
+		// ObservedGeneration on every reconcile.
 		"BackendTLSPolicy",
 		"BackendTLSPolicyConflictResolution",
-		"BackendTLSPolicyInvalidCACertificateRef",
-		"BackendTLSPolicyInvalidKind",
-		"BackendTLSPolicyObservedGenerationBump",
 		"BackendTLSPolicySANValidation",
 
 		// Gateway features not applicable to tunnel architecture.


### PR DESCRIPTION
# Pull Request

## Summary

Implements Gateway API `BackendTLSPolicy` (standard channel, v1.5) for proxy → backend TLS in the L7 proxy. Operators can now require authenticated TLS on the backend hop, with explicit fail-closed semantics when the policy cannot be enforced.

## Changes

- New `BackendTLSConfig` on proxy `BackendRef` carries the CA bundle, ServerName, and SubjectAltNames from the controller to the data plane.
- New `BackendTLSPolicyReconciler` maintains `Status.Ancestors` per fronting Gateway with `Accepted` / `ResolvedRefs` conditions, the 16-entry cap, and `meta.SetStatusCondition` for honest `LastTransitionTime`. Foreign controllers' entries are always preserved.
- New TLS transport in the proxy with two verification modes:
  - SAN list empty → stdlib hostname verification against `ServerName`.
  - SAN list non-empty → manual chain verification + OR-match each policy SAN via `x509.VerifyHostname` (RFC 6125 wildcards work). `VerifyConnection` covers resumed sessions (closes gosec G123).
- Per-host transport pool keys on `host|protocol|tlsFingerprint(CA+SN+SANs)` so policy churn evicts stale transports cleanly.
- `ProxySyncer` resolves a precedence winner per Service+Port (oldest creationTimestamp wins, alphabetical tiebreak), honours `SectionName` for per-port targeting, and emits a poisoned config (empty CA pool) when the policy targets a Service but the CA can't be resolved or the SAN type isn't supported — traffic fails closed with 502 instead of silently downgrading to plaintext.
- ConfigMap watch on the route reconciler is filtered to ConfigMaps actually referenced by a `BackendTLSPolicy` so kube-root-ca and leader-election leases don't fan out across the cluster.
- `appProtocol: https` without a matching policy logs a WARN; `appProtocol: kubernetes.io/h2c` suppressed by a matching policy logs a WARN (TLS wins, HTTP/2 via ALPN).
- `RequestMirror` filter logs a WARN at conversion time when the mirror destination has a matching policy — the mirror path uses a separate plaintext HTTP client and bypasses backend TLS; tracked as a follow-up in `limitations.md`.
- RBAC: `get/list/watch` on `backendtlspolicies`, `patch/update` on `backendtlspolicies/status` in both `deploy/rbac/role.yaml` and the Helm chart.
- Conformance: `SupportBackendTLSPolicy` moves into `SupportedFeatures`. The `BackendTLSPolicyInvalidCACertificateRef`, `BackendTLSPolicyInvalidKind`, and `BackendTLSPolicyObservedGenerationBump` subtests are enabled. `BackendTLSPolicy` parent (HTTPS Listener Re-encrypt — Cloudflare terminates frontend TLS), `BackendTLSPolicyConflictResolution` (loser-stamping pending), and `BackendTLSPolicySANValidation` (URI SAN pending) remain in `SkipTests` with detailed rationales.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint-cli2 'docs/**/*.md' 'README.md'`)
- [x] Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller` — 196 tests)
- [x] Helm lint passes (`helm lint`)
- [x] Helm README regenerated (`helm-docs`)
- [ ] Conformance on homelab — pending; will run via in-cluster pod with feature-branch images before requesting merge

New tests covering this PR:

- Controller unit tests: `parseCABundle`, `validateCARefs` (every failure mode), `validateSANs` (URI rejection), `computeConditions` (all reason combos), `selectPolicyForServicePort` (precedence + SectionName), `policyTargetsServicePort`, `collectGatewayKeys` (deterministic sort), `updateStatus` (preserves other controllers under and over the 16-cap, `LastTransitionTime`, `ObservedGeneration`), `Reconcile` (happy path, not found, no managed Gateway).
- Resolver fail-closed: `TestBackendTLSResolver_PolicyTargetsButCAMissing_ReturnsPoisonedConfig`, `..._CAMalformed_...`, `..._URISubjectAltName_...`, plus `TestBackendTLSResolver_ListErrorFailsOpen` pinning the cache-error asymmetry.
- ProxySyncer integration: `..._BackendTLSPolicyMissingCA_FailsClosed`, `..._URISubjectAltName_PushesPoisonedConfig`.
- Proxy handler integration: `TestHandler_BackendTLSPolicy_PoisonedConfig_HandshakeFails`, `..._SANOnly_AcceptsMatchingSAN`, `..._SANOnly_RejectsAllMismatching`, `..._ValidCA_Succeeds`, `..._BogusCA_Fails`, `..._MismatchedHostname_Fails`.
- Converter: `appProtocol` plaintext / HTTPS / unknown matrix, `..._BackendTLSPolicy_OverridesH2C`, `..._Mirror_TargetHasBackendTLSPolicy_Warns`, multiple-CARef concat test.
- Pinned-broken-behaviour: `TestUpdateStatus_ConflictResolution_LoserSharesAcceptedTrue` matching the project convention.
- Helm RBAC tests cover the new `backendtlspolicies` and `backendtlspolicies/status` rules.

## Documentation

- [x] README "Known Limitations" updated with BackendTLSPolicy scope and gaps.
- [x] `docs/gateway-api/limitations.md` Backend mTLS section: support matrix, fail-closed enforcement, `appProtocol: h2c` + `https` interactions, `RequestMirror` plaintext gap.
- [x] Code comments on every non-obvious path (verification modes, ancestor truncation, fail-open vs fail-closed asymmetry).
- [ ] CLAUDE.md update — none needed (no workflow change).

## Checklist

- [x] Commit message follows semantic format (`feat: support BackendTLSPolicy with SAN validation`).
- [x] No secrets or credentials in code.
- [x] Breaking changes: none. `BackendTLSPolicy` is a strict addition; pre-existing routes without a policy continue to dial plaintext exactly as before.

## Additional Notes

Reviewed by Opus.

Known limitations explicitly documented (not blockers — minimum-viable scope):

- URI-type `SubjectAltName` (e.g. SPIFFE) is rejected with `Accepted=False, Reason=Invalid`. Implementing URI-based identity is a follow-up.
- Conflict resolution picks the precedence winner correctly but does not yet stamp losing policies with `Accepted=False, Reason=Conflicted`. Pinned by a test and the `BackendTLSPolicyConflictResolution` conformance subtest stays skipped.
- HTTPS-listener Re-encrypt: not supported because Cloudflare terminates frontend TLS at the edge. The parent `BackendTLSPolicy` conformance test is skipped for this reason; the HTTP-listener sub-tests are covered through the extended HTTPRoute suite.
- `WellKnownCACertificates: System` is not honoured — only explicit `CACertificateRefs`.
- `RequestMirror` filter sends mirrored copies in plaintext even when the destination has a policy. WARN at conversion time; TLS-aware mirror dial path is a tracked follow-up.
