### PR TITLE
feat: support URI-type SubjectAltName in BackendTLSPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Cloudflare Tunnel has path matching behavior that differs from Gateway API:
 
 `BackendTLSPolicy` (proxy → backend TLS) is supported at minimum-viable scope:
 
-- Hostname-type `SubjectAltNames` only — URI/SPIFFE SANs are rejected with `Accepted=False, Reason=Invalid`
+- `SubjectAltNames` of both `Hostname` (RFC 6125 wildcards via `VerifyHostname`) and `URI` types (e.g. SPIFFE IDs, exact string match against the leaf cert's URIs) are supported, with OR-matching across the list
 - `WellKnownCACertificates: System` is not honoured — only explicit `CACertificateRefs`
 - Multi-policy conflicts resolve by oldest-creationTimestamp (then alphabetical), but losing policies are not yet stamped `Accepted=False, Reason=Conflicted`
 - HTTPS-listener Re-encrypt is not supported (Cloudflare terminates frontend TLS at the edge)

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -229,8 +229,9 @@ with the following minimum-viable scope:
 | CA via same-namespace `ConfigMap` ref with `ca.crt` | Yes | Core support level. The CA bundle is parsed as PEM and rejected with `Accepted=False, Reason=NoValidCACertificate` if it contains no `CERTIFICATE` blocks |
 | Multiple `CACertificateRefs` per policy | Yes | All bundles are concatenated into the trust pool |
 | `Hostname` as TLS SNI + authentication (when no SANs) | Yes | Required field; matches stdlib RFC 6125 hostname verification |
-| `SubjectAltNames` of type `Hostname` (OR-matching) | Yes | Cert must match at least one entry. Wildcards in the cert SAN list are honoured via `x509.Certificate.VerifyHostname`. When `SubjectAltNames` is set, `Hostname` is used for SNI only and NOT for authentication, per Gateway API spec |
-| `SubjectAltNames` of type `URI` (e.g. SPIFFE) | No | The policy is stamped `Accepted=False, Reason=Invalid` rather than silently dropping the URI entries — operators see a clear failure instead of a weaker-than-requested enforcement |
+| `SubjectAltNames` of type `Hostname` (OR-matching) | Yes | Cert must match at least one entry. Wildcards in the cert SAN list are honoured via `x509.Certificate.VerifyHostname` |
+| `SubjectAltNames` of type `URI` (e.g. SPIFFE) | Yes | Matched by exact string equality against the leaf cert's `URIs` field. OR-matched alongside Hostname SANs in the same policy — either path passing accepts the handshake (matches `BackendTLSPolicySANValidation` conformance) |
+| SNI / authentication split when SANs are set | Yes | When ANY `SubjectAltNames` entry is present (Hostname OR URI), `Hostname` is used only for SNI and NOT for authentication, per Gateway API spec. Authentication runs against the SAN list |
 | `WellKnownCACertificates: System` | No | Only explicit `CACertificateRefs` are honoured |
 | Multiple `targetRefs` per policy | Yes | All targeted Services share the same TLS config |
 | `SectionName` per-port targeting | Yes | When a `TargetRef` carries `sectionName`, only the matching named Service port receives TLS; siblings on the same Service stay plaintext |
@@ -249,14 +250,13 @@ only flips when `Status`, `Reason`, or `Message` actually changes.
 
 ### Fail-closed enforcement
 
-When a `BackendTLSPolicy` targets a Service but cannot be enforced (CA
-`ConfigMap` missing or unreadable, `ca.crt` empty or malformed PEM,
-unsupported `SubjectAltName` type), the proxy receives a poisoned TLS config
-(empty CA pool) and the next request to that Service fails with HTTP 502 — it
-is NOT silently downgraded to plaintext. The operator's stated intent ("this
-hop MUST be authenticated TLS") is preserved. Monitor the policy's
-`Accepted` condition to detect the failure mode (`Reason=NoValidCACertificate`
-or `Reason=Invalid`).
+When a `BackendTLSPolicy` targets a Service but cannot be enforced — the CA
+`ConfigMap` is missing or unreadable, `ca.crt` is empty, or the bundle is
+malformed PEM — the proxy receives a poisoned TLS config (empty CA pool) and
+the next request to that Service fails with HTTP 502. It is NOT silently
+downgraded to plaintext. The operator's stated intent ("this hop MUST be
+authenticated TLS") is preserved. Monitor the policy's `Accepted` condition
+to detect the failure mode (`Reason=NoValidCACertificate`).
 
 ### Interaction with `appProtocol: kubernetes.io/h2c`
 

--- a/internal/controller/backendtlspolicy_controller.go
+++ b/internal/controller/backendtlspolicy_controller.go
@@ -40,13 +40,12 @@ const policyAncestorStatusMaxCount = 16
 
 // Sentinel errors for BackendTLSPolicy CA validation so wrappers can be matched.
 var (
-	errBackendTLSNoCARef            = errors.New("BackendTLSPolicy has no CACertificateRefs (WellKnownCACertificates not supported)")
-	errBackendTLSUnsupportedGroup   = errors.New("BackendTLSPolicy CACertificateRef group not supported (only core)")
-	errBackendTLSUnsupportedKind    = errors.New("BackendTLSPolicy CACertificateRef kind not supported (only ConfigMap)")
-	errBackendTLSCAKeyMissing       = errors.New("BackendTLSPolicy CA ConfigMap is missing the ca.crt key")
-	errBackendTLSCABundleMalformed  = errors.New("BackendTLSPolicy CA bundle is not valid PEM")
-	errBackendTLSCABundleNoCerts    = errors.New("BackendTLSPolicy CA bundle contains no CERTIFICATE blocks")
-	errBackendTLSUnsupportedSANType = errors.New("BackendTLSPolicy SubjectAltName type not supported (only Hostname)")
+	errBackendTLSNoCARef           = errors.New("BackendTLSPolicy has no CACertificateRefs (WellKnownCACertificates not supported)")
+	errBackendTLSUnsupportedGroup  = errors.New("BackendTLSPolicy CACertificateRef group not supported (only core)")
+	errBackendTLSUnsupportedKind   = errors.New("BackendTLSPolicy CACertificateRef kind not supported (only ConfigMap)")
+	errBackendTLSCAKeyMissing      = errors.New("BackendTLSPolicy CA ConfigMap is missing the ca.crt key")
+	errBackendTLSCABundleMalformed = errors.New("BackendTLSPolicy CA bundle is not valid PEM")
+	errBackendTLSCABundleNoCerts   = errors.New("BackendTLSPolicy CA bundle contains no CERTIFICATE blocks")
 )
 
 // parseCABundle decodes every PEM block in the supplied bundle and verifies
@@ -182,11 +181,11 @@ func (r *BackendTLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 // computeConditions evaluates the policy spec and returns the two conditions
 // to expose (Accepted and ResolvedRefs) per Gateway API semantics.
 //
-//   - Unsupported SubjectAltName type (URI etc.): Accepted=False, Reason=Invalid;
-//     ResolvedRefs is reported True because CA refs themselves resolved cleanly.
 //   - CA reference invalid or unresolvable: Accepted=False, Reason=NoValidCACertificate;
-//     ResolvedRefs=False, Reason=InvalidCACertificateRef.
-//   - All happy: both True.
+//     ResolvedRefs=False, Reason=InvalidCACertificateRef (or InvalidKind for
+//     Group/Kind mismatches).
+//   - All happy: both True. Both DNS-Hostname and URI-type SubjectAltNames
+//     are honoured end-to-end by the proxy.
 //
 // LastTransitionTime is left zero; callers route through meta.SetStatusCondition
 // in updateStatus so the timestamp reflects an actual transition rather than
@@ -195,37 +194,11 @@ func (r *BackendTLSPolicyReconciler) computeConditions(
 	ctx context.Context,
 	policy *gatewayv1.BackendTLSPolicy,
 ) []metav1.Condition {
-	if err := r.validateSANs(policy); err != nil {
-		return sanInvalidConditions(policy.Generation, err)
-	}
-
 	if err := r.validateCARefs(ctx, policy); err != nil {
 		return caInvalidConditions(policy.Generation, err)
 	}
 
 	return acceptedConditions(policy.Generation)
-}
-
-// sanInvalidConditions returns Accepted=False/Invalid + ResolvedRefs=True for
-// the URI-SAN-not-supported case: CA refs themselves resolved fine but the
-// policy is rejected by the controller for an unsupported SubjectAltName type.
-func sanInvalidConditions(generation int64, err error) []metav1.Condition {
-	return []metav1.Condition{
-		{
-			Type:               string(gatewayv1.PolicyConditionAccepted),
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: generation,
-			Reason:             string(gatewayv1.PolicyReasonInvalid),
-			Message:            err.Error(),
-		},
-		{
-			Type:               string(gatewayv1.BackendTLSPolicyConditionResolvedRefs),
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: generation,
-			Reason:             string(gatewayv1.BackendTLSPolicyReasonResolvedRefs),
-			Message:            "CA references resolved; SAN validation rejected the policy",
-		},
-	}
 }
 
 // caInvalidConditions returns the Accepted=False/NoValidCACertificate +
@@ -275,19 +248,6 @@ func acceptedConditions(generation int64) []metav1.Condition {
 			Message:            "All CA certificate references resolved",
 		},
 	}
-}
-
-// validateSANs rejects any SubjectAltName whose type is not Hostname. URI-type
-// SANs (SPIFFE etc.) are not yet implemented end-to-end and silently dropping
-// them would weaken the policy below what the operator requested.
-func (r *BackendTLSPolicyReconciler) validateSANs(policy *gatewayv1.BackendTLSPolicy) error {
-	for _, san := range policy.Spec.Validation.SubjectAltNames {
-		if san.Type != gatewayv1.HostnameSubjectAltNameType {
-			return fmt.Errorf("%w: %q", errBackendTLSUnsupportedSANType, san.Type)
-		}
-	}
-
-	return nil
 }
 
 // validateCARefs returns an error describing the first invalid CA reference,

--- a/internal/controller/backendtlspolicy_controller_test.go
+++ b/internal/controller/backendtlspolicy_controller_test.go
@@ -317,47 +317,6 @@ func TestValidateCARefs_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// ---- validateSANs ----
-
-func TestValidateSANs_AcceptsHostnameOnly(t *testing.T) {
-	t.Parallel()
-
-	r := &BackendTLSPolicyReconciler{ControllerName: "test"}
-
-	policy := &gatewayv1.BackendTLSPolicy{
-		Spec: gatewayv1.BackendTLSPolicySpec{
-			Validation: gatewayv1.BackendTLSPolicyValidation{
-				SubjectAltNames: []gatewayv1.SubjectAltName{
-					{Type: gatewayv1.HostnameSubjectAltNameType, Hostname: "alt.example.com"},
-				},
-			},
-		},
-	}
-
-	require.NoError(t, r.validateSANs(policy))
-}
-
-func TestValidateSANs_RejectsURIType(t *testing.T) {
-	t.Parallel()
-
-	r := &BackendTLSPolicyReconciler{ControllerName: "test"}
-
-	uriType := gatewayv1.URISubjectAltNameType
-	policy := &gatewayv1.BackendTLSPolicy{
-		Spec: gatewayv1.BackendTLSPolicySpec{
-			Validation: gatewayv1.BackendTLSPolicyValidation{
-				SubjectAltNames: []gatewayv1.SubjectAltName{
-					{Type: uriType},
-				},
-			},
-		},
-	}
-
-	err := r.validateSANs(policy)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, errBackendTLSUnsupportedSANType))
-}
-
 // ---- computeConditions ----
 
 func TestComputeConditions_HappyPath(t *testing.T) {
@@ -427,29 +386,119 @@ func TestComputeConditions_InvalidCACertificateRef(t *testing.T) {
 	assert.Equal(t, string(gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef), conditions[1].Reason)
 }
 
-func TestComputeConditions_URISANRejected(t *testing.T) {
+// TestComputeConditions_NeverEmitsPolicyReasonInvalid pins the invariant
+// that — since this controller fully supports both Hostname and URI
+// SubjectAltNames — `computeConditions` MUST NOT stamp the Accepted Reason
+// with `PolicyReasonInvalid`. The previous controller emitted that Reason
+// when it rejected URI SANs; that path is gone and the docs (fail-closed
+// section in docs/gateway-api/limitations.md) no longer mention it. A
+// regression that silently reintroduces the rejection branch must surface
+// here, not at conformance time on homelab.
+func TestComputeConditions_NeverEmitsPolicyReasonInvalid(t *testing.T) {
 	t.Parallel()
 
 	scheme := newBackendTLSPolicyScheme(t)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	configMap := caConfigMap("ns", "cm", generateSelfSignedCAPEM(t))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
 	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
 
-	uriType := gatewayv1.URISubjectAltNameType
-	policy := &gatewayv1.BackendTLSPolicy{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p", Generation: 7},
-		Spec: gatewayv1.BackendTLSPolicySpec{
-			Validation: gatewayv1.BackendTLSPolicyValidation{
-				SubjectAltNames: []gatewayv1.SubjectAltName{{Type: uriType}},
-			},
-		},
+	noSAN := backendTLSPolicyFor("ns", "no-san", "svc", "cm", time.Time{})
+
+	hostOnly := backendTLSPolicyFor("ns", "host-only", "svc", "cm", time.Time{})
+	hostOnly.Spec.Validation.SubjectAltNames = []gatewayv1.SubjectAltName{
+		{Type: gatewayv1.HostnameSubjectAltNameType, Hostname: "alt.example.com"},
+	}
+
+	uriOnly := backendTLSPolicyFor("ns", "uri-only", "svc", "cm", time.Time{})
+	uriOnly.Spec.Validation.SubjectAltNames = []gatewayv1.SubjectAltName{
+		{Type: gatewayv1.URISubjectAltNameType, URI: "spiffe://example/identity"},
+	}
+
+	mixed := backendTLSPolicyFor("ns", "mixed", "svc", "cm", time.Time{})
+	mixed.Spec.Validation.SubjectAltNames = []gatewayv1.SubjectAltName{
+		{Type: gatewayv1.HostnameSubjectAltNameType, Hostname: "alt.example.com"},
+		{Type: gatewayv1.URISubjectAltNameType, URI: "spiffe://example/identity"},
+	}
+
+	for _, policy := range []*gatewayv1.BackendTLSPolicy{noSAN, hostOnly, uriOnly, mixed} {
+		t.Run(policy.Name, func(t *testing.T) {
+			t.Parallel()
+
+			conds := r.computeConditions(context.Background(), policy)
+			require.NotEmpty(t, conds)
+
+			for _, condition := range conds {
+				if condition.Type == string(gatewayv1.PolicyConditionAccepted) {
+					assert.NotEqual(t, string(gatewayv1.PolicyReasonInvalid), condition.Reason,
+						"controller MUST NOT emit Reason=Invalid on Accepted — that path was removed when URI SANs became supported")
+				}
+			}
+		})
+	}
+}
+
+// TestBackendTLSResolver_UnknownSANType_ReturnsPoisonedConfig pins the
+// CRD-newer-than-controller defence: if a future Gateway API release adds a
+// SubjectAltName type (Email, IP, etc.) and a cluster's CRD ships that enum
+// value, the resolver MUST fail closed rather than silently enforce the
+// subset it understands. Otherwise an operator who writes a policy requiring
+// the new SAN type would get plaintext-equivalent enforcement, downgrading
+// their stated intent.
+func TestBackendTLSResolver_UnknownSANType_ReturnsPoisonedConfig(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	// Fabricated SAN type — not Hostname or URI. Mimics the case where the
+	// cluster CRD enum is ahead of this controller's compiled spec.
+	policy.Spec.Validation.SubjectAltNames = []gatewayv1.SubjectAltName{
+		{Type: gatewayv1.SubjectAltNameType("Email")},
+	}
+
+	configMap := caConfigMap("ns", "cm", generateSelfSignedCAPEM(t))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy, configMap).
+		Build()
+
+	resolver := newBackendTLSResolver(fakeClient)
+
+	got := resolver(context.Background(), "ns", "svc", 443)
+	require.NotNil(t, got, "policy targets the Service — resolver MUST NOT return nil (would downgrade to plaintext)")
+	assert.Empty(t, got.CABundlePEM,
+		"unknown SAN type → poisoned config (empty CA pool) so handshake fails closed")
+	assert.Empty(t, got.SubjectAltNames,
+		"poisoned config drops the partial SAN list")
+	assert.Empty(t, got.SubjectAltNameURIs,
+		"poisoned config drops URI SAN list too")
+}
+
+// TestComputeConditions_URISANAccepted verifies that a BackendTLSPolicy
+// carrying URI-type SubjectAltNames is accepted end-to-end (Accepted=True,
+// ResolvedRefs=True). URI SANs (e.g. SPIFFE IDs) are matched against the
+// leaf cert's URIs[] by the proxy.
+func TestComputeConditions_URISANAccepted(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+	configMap := caConfigMap("ns", "cm", generateSelfSignedCAPEM(t))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test"}
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	policy.Generation = 7
+	policy.Spec.Validation.SubjectAltNames = []gatewayv1.SubjectAltName{
+		{Type: gatewayv1.URISubjectAltNameType, URI: "spiffe://abc.example.com/test-identity"},
 	}
 
 	conditions := r.computeConditions(context.Background(), policy)
 
 	require.Len(t, conditions, 2)
-	assert.Equal(t, metav1.ConditionFalse, conditions[0].Status)
-	assert.Equal(t, string(gatewayv1.PolicyReasonInvalid), conditions[0].Reason)
-	// SAN failure does not invalidate the CA refs themselves.
+	assert.Equal(t, metav1.ConditionTrue, conditions[0].Status,
+		"URI SubjectAltName is now fully supported — Accepted MUST be True")
+	assert.Equal(t, string(gatewayv1.PolicyReasonAccepted), conditions[0].Reason)
 	assert.Equal(t, metav1.ConditionTrue, conditions[1].Status)
 	assert.Equal(t, string(gatewayv1.BackendTLSPolicyReasonResolvedRefs), conditions[1].Reason)
 	assert.Equal(t, int64(7), conditions[0].ObservedGeneration)
@@ -1002,15 +1051,19 @@ func TestBackendTLSResolver_PolicyTargetsButCAMalformed_ReturnsPoisonedConfig(t 
 	assert.Empty(t, got.CABundlePEM)
 }
 
-func TestBackendTLSResolver_URISubjectAltName_ReturnsPoisonedConfig(t *testing.T) {
+// TestBackendTLSResolver_URISubjectAltName_ForwardsURIToProxy verifies that
+// URI-type SubjectAltNames are forwarded to the proxy BackendTLSConfig as
+// plain strings on the SubjectAltNameURIs field. Hostname-type SANs go to
+// SubjectAltNames. Both lists are OR-matched by the proxy at handshake time.
+func TestBackendTLSResolver_URISubjectAltName_ForwardsURIToProxy(t *testing.T) {
 	t.Parallel()
 
 	scheme := newBackendTLSPolicyScheme(t)
 
 	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
-	uriType := gatewayv1.URISubjectAltNameType
 	policy.Spec.Validation.SubjectAltNames = []gatewayv1.SubjectAltName{
-		{Type: uriType},
+		{Type: gatewayv1.URISubjectAltNameType, URI: "spiffe://abc.example.com/identity"},
+		{Type: gatewayv1.HostnameSubjectAltNameType, Hostname: "alt.example.com"},
 	}
 
 	configMap := caConfigMap("ns", "cm", generateSelfSignedCAPEM(t))
@@ -1023,10 +1076,12 @@ func TestBackendTLSResolver_URISubjectAltName_ReturnsPoisonedConfig(t *testing.T
 	resolver := newBackendTLSResolver(fakeClient)
 
 	got := resolver(context.Background(), "ns", "svc", 443)
-	require.NotNil(t, got,
-		"URI-type SubjectAltName is not supported — resolver must NOT return nil (plaintext); "+
-			"must return a poisoned config so traffic fails closed")
-	assert.Empty(t, got.CABundlePEM)
+	require.NotNil(t, got, "happy-path policy must produce a real TLS config")
+	assert.NotEmpty(t, got.CABundlePEM, "valid CA bundle must be forwarded — not a poisoned config")
+	assert.Equal(t, []string{"alt.example.com"}, got.SubjectAltNames,
+		"Hostname SANs go to SubjectAltNames")
+	assert.Equal(t, []string{"spiffe://abc.example.com/identity"}, got.SubjectAltNameURIs,
+		"URI SANs go to SubjectAltNameURIs")
 }
 
 // TestBackendTLSResolver_ListErrorFailsOpen pins the documented asymmetry

--- a/internal/controller/proxy_syncer.go
+++ b/internal/controller/proxy_syncer.go
@@ -93,13 +93,15 @@ func NewProxySyncer(
 //     dials the backend in plaintext (no policy applies, so there's no
 //     operator intent to enforce).
 //   - A policy targets the service BUT the CA cannot be resolved (missing
-//     ConfigMap, unsupported Group/Kind, empty ca.crt, malformed PEM) OR the
-//     policy carries a non-Hostname SubjectAltName type that this controller
-//     does not support: returns a *poisoned* config — an empty CA pool with
-//     the policy's Hostname. This causes the proxy's TLS handshake to fail
-//     and the request returns 502, NOT a silent plaintext downgrade. The
-//     operator's stated intent ("traffic to this Service MUST be
-//     authenticated TLS") is preserved.
+//     ConfigMap, unsupported Group/Kind, empty ca.crt, malformed PEM):
+//     returns a *poisoned* config — an empty CA pool with the policy's
+//     Hostname. This causes the proxy's TLS handshake to fail and the
+//     request returns 502, NOT a silent plaintext downgrade.
+//   - Hostname and URI SubjectAltNames are both honoured. URI SANs are
+//     forwarded to the proxy as plain strings and matched via exact equality
+//     against the leaf cert's URIs (SPIFFE convention used by the Gateway
+//     API conformance suite). DNS Hostname SANs are matched via
+//     x509.VerifyHostname (RFC 6125 wildcards).
 //
 // Precedence per Gateway API: oldest creationTimestamp wins; on tie,
 // alphabetical {namespace}/{name}.
@@ -123,43 +125,62 @@ func newBackendTLSResolver(c client.Client) proxy.BackendTLSResolver {
 			return nil
 		}
 
-		// Fail closed for any unsupported SAN type — the operator asked for
-		// stricter identity than this controller can enforce.
-		if !hasOnlyHostnameSANs(policy) {
-			return poisonedBackendTLS(policy)
-		}
-
 		caBundle, ok := resolveCABundlePEM(ctx, c, policy)
 		if !ok {
 			return poisonedBackendTLS(policy)
 		}
 
-		sans := make([]string, 0, len(policy.Spec.Validation.SubjectAltNames))
-		for _, san := range policy.Spec.Validation.SubjectAltNames {
-			if san.Hostname != "" {
-				sans = append(sans, string(san.Hostname))
-			}
+		dnsSANs, uriSANs, hasUnknown := splitSANsByType(policy)
+		if hasUnknown {
+			// CRD-newer-than-controller scenario: a SAN entry carries a Type
+			// this controller doesn't recognise (Hostname/URI are the only
+			// enum values today, but the spec may add more). Fail closed
+			// rather than silently enforcing the subset we understand —
+			// downgrading is worse than refusing the request.
+			slog.Warn("BackendTLSPolicy carries a SubjectAltName of unsupported type — falling back to poisoned config to preserve operator intent",
+				"namespace", policy.Namespace,
+				"name", policy.Name,
+			)
+
+			return poisonedBackendTLS(policy)
 		}
 
 		return &proxy.BackendTLSConfig{
-			CABundlePEM:     caBundle,
-			ServerName:      string(policy.Spec.Validation.Hostname),
-			SubjectAltNames: sans,
+			CABundlePEM:        caBundle,
+			ServerName:         string(policy.Spec.Validation.Hostname),
+			SubjectAltNames:    dnsSANs,
+			SubjectAltNameURIs: uriSANs,
 		}
 	}
 }
 
-// hasOnlyHostnameSANs reports whether every SubjectAltName entry on the
-// policy is of the supported Hostname type. URI-type SANs (SPIFFE etc.) are
-// not yet implemented end-to-end and must not silently degrade enforcement.
-func hasOnlyHostnameSANs(policy *gatewayv1.BackendTLSPolicy) bool {
+// splitSANsByType separates the policy's SubjectAltNames into the DNS-hostname
+// list and the URI list the proxy expects. The third return reports whether
+// any entry carries a Type this controller doesn't recognise — the caller
+// must then fail closed rather than ship the partial result.
+func splitSANsByType(policy *gatewayv1.BackendTLSPolicy) ([]string, []string, bool) {
+	sansLen := len(policy.Spec.Validation.SubjectAltNames)
+	dnsSANs := make([]string, 0, sansLen)
+	uriSANs := make([]string, 0, sansLen)
+
+	hasUnknown := false
+
 	for _, san := range policy.Spec.Validation.SubjectAltNames {
-		if san.Type != gatewayv1.HostnameSubjectAltNameType {
-			return false
+		switch san.Type {
+		case gatewayv1.HostnameSubjectAltNameType:
+			if san.Hostname != "" {
+				dnsSANs = append(dnsSANs, string(san.Hostname))
+			}
+		case gatewayv1.URISubjectAltNameType:
+			if san.URI != "" {
+				uriSANs = append(uriSANs, string(san.URI))
+			}
+		default:
+			hasUnknown = true
 		}
 	}
 
-	return true
+	return dnsSANs, uriSANs, hasUnknown
 }
 
 // poisonedBackendTLS returns a TLS config that is guaranteed to fail handshake

--- a/internal/controller/proxy_syncer_test.go
+++ b/internal/controller/proxy_syncer_test.go
@@ -2,12 +2,20 @@ package controller_test
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"log/slog"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +28,31 @@ import (
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/controller"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
 )
+
+// testSelfSignedCAPEM emits a fresh PEM-encoded self-signed CA so tests that
+// need a non-poisoned trust pool can stand one up without touching the
+// filesystem. Used by URI-SAN tests where the resolver must produce a real
+// (non-poisoned) BackendTLSConfig.
+func testSelfSignedCAPEM(t *testing.T) string {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageCertSign,
+		IsCA:         true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}))
+}
 
 func TestProxySyncer_SyncRoutes(t *testing.T) {
 	t.Parallel()
@@ -278,15 +311,14 @@ func TestProxySyncer_SyncRoutes_BackendTLSPolicyMissingCA_FailsClosed(t *testing
 		"poisoned config has empty CA bundle → handshake fails closed at the proxy")
 }
 
-// TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesPoisonedConfig
-// verifies the URI-SAN fail-closed path end-to-end: when a BackendTLSPolicy
-// requires a URI-type SubjectAltName (SPIFFE etc.), the resolver MUST emit a
-// poisoned TLS config rather than silently dropping the SAN requirement.
-// This pairs with the integration handshake test
-// (TestHandler_BackendTLSPolicy_PoisonedConfig_HandshakeFails in
-// internal/proxy/integration_test.go) which confirms the proxy turns that
-// poisoned config into a 502 at handshake time.
-func TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesPoisonedConfig(t *testing.T) {
+// TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesURIList
+// verifies the URI-SAN happy path end-to-end: when a BackendTLSPolicy carries
+// a URI-type SubjectAltName (e.g. SPIFFE ID), the resolver forwards it on
+// BackendTLSConfig.SubjectAltNameURIs to the proxy where it's matched against
+// the leaf cert's URIs at handshake time. Pairs with
+// internal/proxy/integration_test.go's TestHandler_BackendTLSPolicy_URISAN_*
+// which exercise the proxy-side matching.
+func TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesURIList(t *testing.T) {
 	t.Parallel()
 
 	pathPrefix := gatewayv1.PathMatchPathPrefix
@@ -310,6 +342,11 @@ func TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesPoisone
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, gatewayv1.Install(scheme))
 
+	caCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "spiffe-ca", Namespace: "default"},
+		Data:       map[string]string{"ca.crt": testSelfSignedCAPEM(t)},
+	}
+
 	policy := &gatewayv1.BackendTLSPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "spiffe-policy", Namespace: "default"},
 		Spec: gatewayv1.BackendTLSPolicySpec{
@@ -322,17 +359,18 @@ func TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesPoisone
 				},
 			},
 			Validation: gatewayv1.BackendTLSPolicyValidation{
-				// URI-type SAN — unsupported by this controller. The resolver
-				// MUST poison rather than fall back to plaintext.
+				CACertificateRefs: []gatewayv1.LocalObjectReference{
+					{Kind: "ConfigMap", Name: "spiffe-ca"},
+				},
+				Hostname: "spiffe.example.com",
 				SubjectAltNames: []gatewayv1.SubjectAltName{
 					{Type: gatewayv1.URISubjectAltNameType, URI: "spiffe://example.org/server"},
 				},
-				Hostname: "spiffe.example.com",
 			},
 		},
 	}
 
-	testClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy).Build()
+	testClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, caCM).Build()
 
 	syncer := controller.NewProxySyncer("cluster.local", "", testClient, slog.Default())
 
@@ -359,14 +397,11 @@ func TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesPoisone
 	require.Len(t, receivedConfig.Rules[0].Backends, 1)
 	backend := receivedConfig.Rules[0].Backends[0]
 
-	require.NotNil(t, backend.TLS,
-		"URI-type SAN is unsupported but the policy targets the Service — the resolver MUST emit "+
-			"a TLS block (poisoned) so traffic fails closed at handshake time. nil here would "+
-			"silently downgrade to plaintext.")
-	assert.Empty(t, backend.TLS.CABundlePEM,
-		"poisoned config carries an empty CA bundle so handshake fails closed")
-	assert.Empty(t, backend.TLS.SubjectAltNames,
-		"poisoned config drops SAN list — chain verification fails before SAN matching matters")
+	require.NotNil(t, backend.TLS, "valid policy must produce a real TLS config")
+	assert.NotEmpty(t, backend.TLS.CABundlePEM, "valid CA bundle must be forwarded — not poisoned")
+	assert.Empty(t, backend.TLS.SubjectAltNames, "no Hostname SAN on the policy → empty DNS list")
+	assert.Equal(t, []string{"spiffe://example.org/server"}, backend.TLS.SubjectAltNameURIs,
+		"URI SAN must flow through to BackendTLSConfig.SubjectAltNameURIs for proxy-side matching")
 }
 
 // Helper functions.

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -220,10 +220,26 @@ type BackendTLSConfig struct {
 	// ServerName is used both as the TLS SNI value and as the expected
 	// hostname during certificate verification (DNS SAN match).
 	ServerName string `json:"serverName,omitempty"`
-	// SubjectAltNames lists additional hostnames that the backend cert may
-	// present in its SAN to satisfy this policy. ServerName is implied; this
-	// list is additive.
+	// SubjectAltNames lists hostnames (DNS SAN) that the backend cert may
+	// present to satisfy this policy. Empty when only URI SANs are required.
+	// When SubjectAltNames or SubjectAltNameURIs is non-empty, ServerName is
+	// used for SNI only and NOT for authentication (per Gateway API spec).
 	SubjectAltNames []string `json:"subjectAltNames,omitempty"`
+	// SubjectAltNameURIs lists URI SANs (e.g. SPIFFE IDs) that the backend
+	// cert may present to satisfy this policy. Matched by exact string
+	// equality against each URI in the leaf cert's URIs field.
+	SubjectAltNameURIs []string `json:"subjectAltNameUris,omitempty"`
+}
+
+// HasSANConstraints reports whether the policy requires SAN-list verification
+// (any of DNS or URI). When true, the proxy disables stdlib hostname
+// verification and runs the manual chain + OR-match path.
+func (c *BackendTLSConfig) HasSANConstraints() bool {
+	if c == nil {
+		return false
+	}
+
+	return len(c.SubjectAltNames) > 0 || len(c.SubjectAltNameURIs) > 0
 }
 
 // BackendRef identifies a backend service with a weight for traffic splitting.

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -42,6 +42,8 @@ func transportKey(host string, protocol BackendProtocol, backendTLS *BackendTLSC
 }
 
 // tlsFingerprint returns a stable short hash of the TLS config, or "" when nil.
+// The hash covers CA + ServerName + DNS SANs + URI SANs so any change to the
+// effective trust policy evicts the cached transport.
 func tlsFingerprint(backendTLS *BackendTLSConfig) string {
 	if backendTLS == nil {
 		return ""
@@ -55,6 +57,14 @@ func tlsFingerprint(backendTLS *BackendTLSConfig) string {
 
 	for _, san := range backendTLS.SubjectAltNames {
 		hasher.Write([]byte(san))
+		hasher.Write([]byte{0})
+	}
+	// Use a distinct separator between DNS and URI SAN sections so a config
+	// with DNS "foo" + URI "" can't collide with one carrying URI "foo" + DNS "".
+	hasher.Write([]byte("|uri|"))
+
+	for _, sanURI := range backendTLS.SubjectAltNameURIs {
+		hasher.Write([]byte(sanURI))
 		hasher.Write([]byte{0})
 	}
 
@@ -360,7 +370,7 @@ func newTLSTransport(backendTLS *BackendTLSConfig) http.RoundTripper {
 // verification modes. Split from newTLSTransport for testability and to keep
 // per-function complexity within the funlen budget.
 func buildBackendTLSConfig(backendTLS *BackendTLSConfig, rootCAs *x509.CertPool) *tls.Config {
-	if len(backendTLS.SubjectAltNames) == 0 {
+	if !backendTLS.HasSANConstraints() {
 		// Mode 1: Hostname-based authentication via ServerName.
 		return &tls.Config{
 			MinVersion: tls.VersionTLS12,
@@ -370,7 +380,8 @@ func buildBackendTLSConfig(backendTLS *BackendTLSConfig, rootCAs *x509.CertPool)
 	}
 
 	// Mode 2: SAN-list authentication. ServerName drives SNI only.
-	expected := slices.Clone(backendTLS.SubjectAltNames)
+	expectedHostnames := slices.Clone(backendTLS.SubjectAltNames)
+	expectedURIs := slices.Clone(backendTLS.SubjectAltNameURIs)
 
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
@@ -381,7 +392,7 @@ func buildBackendTLSConfig(backendTLS *BackendTLSConfig, rootCAs *x509.CertPool)
 		// gosec G402: this is the documented Gateway API SAN-only verification
 		// path; chain validation is preserved via leaf.Verify().
 		InsecureSkipVerify: true, //nolint:gosec // see comment above
-		VerifyConnection:   verifyBackendChainAndSANs(rootCAs, expected),
+		VerifyConnection:   verifyBackendChainAndSANs(rootCAs, expectedHostnames, expectedURIs),
 	}
 
 	return tlsConfig
@@ -391,8 +402,14 @@ func buildBackendTLSConfig(backendTLS *BackendTLSConfig, rootCAs *x509.CertPool)
 // on fresh and resumed handshakes (per gosec G123). It manually verifies the
 // chain against rootCAs (since InsecureSkipVerify=true disables the default
 // path) and asserts the leaf cert matches at least one of the expected SANs.
-// Wildcard SANs are honoured via x509.Certificate.VerifyHostname.
-func verifyBackendChainAndSANs(rootCAs *x509.CertPool, expected []string) func(tls.ConnectionState) error {
+// DNS SANs honour RFC 6125 wildcards via x509.Certificate.VerifyHostname;
+// URI SANs are matched by exact string equality against leaf.URIs per the
+// SPIFFE convention used by the Gateway API conformance suite.
+func verifyBackendChainAndSANs(
+	rootCAs *x509.CertPool,
+	expectedHostnames []string,
+	expectedURIs []string,
+) func(tls.ConnectionState) error {
 	return func(state tls.ConnectionState) error {
 		if len(state.PeerCertificates) == 0 {
 			return errBackendTLSNoPeerCert
@@ -415,20 +432,55 @@ func verifyBackendChainAndSANs(rootCAs *x509.CertPool, expected []string) func(t
 			return fmt.Errorf("%w: %w", errBackendTLSChainVerify, verifyErr)
 		}
 
-		// Gateway API spec: the cert must match AT LEAST ONE of the policy's
-		// SubjectAltNames (OR semantics). VerifyHostname handles RFC 6125
-		// wildcard SANs correctly (e.g. cert SAN "*.example.com" matches a
-		// policy SAN "foo.example.com").
-		for _, want := range expected {
-			sanErr := leaf.VerifyHostname(want)
-			if sanErr == nil {
-				return nil
-			}
+		if matchAnyDNSSan(leaf, expectedHostnames) {
+			return nil
 		}
 
-		return fmt.Errorf("%w: required one of %v, cert SANs %v",
-			errBackendTLSSANMissing, expected, leaf.DNSNames)
+		if matchAnyURISan(leaf, expectedURIs) {
+			return nil
+		}
+
+		certURIs := make([]string, 0, len(leaf.URIs))
+		for _, certURI := range leaf.URIs {
+			certURIs = append(certURIs, certURI.String())
+		}
+
+		return fmt.Errorf("%w: required one of DNS%v / URI%v, cert DNS%v / cert URIs%v",
+			errBackendTLSSANMissing, expectedHostnames, expectedURIs, leaf.DNSNames, certURIs)
 	}
+}
+
+// matchAnyDNSSan reports whether the leaf cert satisfies at least one of the
+// expected DNS SAN values via x509.Certificate.VerifyHostname (RFC 6125,
+// wildcard-aware). Empty expected list reports false.
+func matchAnyDNSSan(leaf *x509.Certificate, expected []string) bool {
+	for _, want := range expected {
+		hostErr := leaf.VerifyHostname(want)
+		if hostErr == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchAnyURISan reports whether the leaf cert presents at least one URI SAN
+// (as carried in leaf.URIs) that exactly matches one of the expected URI
+// strings. Empty expected list reports false. Matching is plain string
+// equality on the URI's canonical String() form — this is the convention
+// used by SPIFFE and the Gateway API conformance suite.
+func matchAnyURISan(leaf *x509.Certificate, expected []string) bool {
+	if len(expected) == 0 {
+		return false
+	}
+
+	for _, certURI := range leaf.URIs {
+		if slices.Contains(expected, certURI.String()) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // errorHandler handles proxy errors with appropriate HTTP status codes.

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -1,10 +1,19 @@
 package proxy_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"io"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -406,6 +415,71 @@ func caPEMFromTLSServer(t *testing.T, server *httptest.Server) string {
 	return string(pem.EncodeToMemory(pemBlock))
 }
 
+// uriSANTestServer is the shared output of newURITLSServer: a TLS-enabled
+// httptest.Server plus the PEM-encoded CA bundle (== the self-signed leaf,
+// since it's its own root) that BackendTLSConfig should use as the trust
+// anchor.
+type uriSANTestServer struct {
+	Server *httptest.Server
+	CAPEM  string
+}
+
+// newURITLSServer spins up a TLS httptest.Server whose certificate carries
+// the supplied DNS SANs AND URI SANs. Used to exercise the URI-SAN matching
+// path that the Gateway API BackendTLSPolicySANValidation conformance test
+// drives. The cert is self-signed; CAPEM is the same cert encoded as PEM so
+// the proxy trusts it.
+func newURITLSServer(t *testing.T, dnsSANs []string, uriSANs []string) *uriSANTestServer {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	uris := make([]*url.URL, 0, len(uriSANs))
+	for _, raw := range uriSANs {
+		u, parseErr := url.Parse(raw)
+		require.NoError(t, parseErr, "failed to parse test URI SAN %q", raw)
+		uris = append(uris, u)
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "uri-san-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              append([]string{}, dnsSANs...),
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		URIs:                  uris,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{derBytes},
+		PrivateKey:  priv,
+	}
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("X-Backend", "uri-san-tls")
+		writer.WriteHeader(http.StatusOK)
+	}))
+	server.TLS = &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{tlsCert},
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	return &uriSANTestServer{Server: server, CAPEM: string(certPEM)}
+}
+
 func TestHandler_BackendTLSPolicy_ValidCA_Succeeds(t *testing.T) {
 	t.Parallel()
 
@@ -688,6 +762,205 @@ func TestHandler_BackendTLSPolicy_SANOnly_RejectsAllMismatching(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadGateway, rec.Result().StatusCode,
 		"SAN OR-matching must reject when NO policy SAN matches, regardless of ServerName")
+}
+
+// TestHandler_BackendTLSPolicy_URISAN_AcceptsMatchingURI verifies that a
+// policy with URI-type SubjectAltName (e.g. SPIFFE ID) succeeds when the
+// backend cert presents an exact-matching URI SAN. The Gateway API
+// BackendTLSPolicySANValidation conformance test drives this end-to-end.
+func TestHandler_BackendTLSPolicy_URISAN_AcceptsMatchingURI(t *testing.T) {
+	t.Parallel()
+
+	srv := newURITLSServer(t,
+		[]string{"abc.example.com"},
+		[]string{"spiffe://abc.example.com/test-identity"},
+	)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends: []proxy.BackendRef{
+					{
+						URL:    srv.Server.URL,
+						Weight: 1,
+						TLS: &proxy.BackendTLSConfig{
+							CABundlePEM: srv.CAPEM,
+							// ServerName must NOT be used for auth (per spec) when SANs are set.
+							// Use a value not in the cert to prove that.
+							ServerName:         "sni-only.invalid",
+							SubjectAltNameURIs: []string{"spiffe://abc.example.com/test-identity"},
+						},
+					},
+				},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Result().StatusCode,
+		"URI SAN matching the cert's URI must accept the handshake")
+}
+
+// TestHandler_BackendTLSPolicy_URISAN_RejectsMismatching verifies that a
+// policy with URI SAN that doesn't appear in the leaf cert fails the
+// handshake — the proxy returns 502.
+func TestHandler_BackendTLSPolicy_URISAN_RejectsMismatching(t *testing.T) {
+	t.Parallel()
+
+	srv := newURITLSServer(t,
+		[]string{"abc.example.com"},
+		[]string{"spiffe://abc.example.com/test-identity"},
+	)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends: []proxy.BackendRef{
+					{
+						URL:    srv.Server.URL,
+						Weight: 1,
+						TLS: &proxy.BackendTLSConfig{
+							CABundlePEM:        srv.CAPEM,
+							ServerName:         "abc.example.com",
+							SubjectAltNameURIs: []string{"spiffe://def.example.com/test-identity"},
+						},
+					},
+				},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Result().StatusCode,
+		"URI SAN not present in the cert must fail TLS verification → proxy returns 502")
+}
+
+// TestHandler_BackendTLSPolicy_MixedSAN_OrMatch verifies that when a policy
+// lists BOTH DNS hostnames AND URI SANs, the matching is OR — either path
+// passing accepts the handshake. Matches the Gateway API multiple-sans test.
+func TestHandler_BackendTLSPolicy_MixedSAN_OrMatch(t *testing.T) {
+	t.Parallel()
+
+	srv := newURITLSServer(t,
+		[]string{"abc.example.com"},
+		[]string{"spiffe://abc.example.com/test-identity"},
+	)
+
+	cases := []struct {
+		name string
+		dns  []string
+		uris []string
+	}{
+		{
+			name: "dns matches, uri does not",
+			dns:  []string{"abc.example.com"},
+			uris: []string{"spiffe://def.example.com/test-identity"},
+		},
+		{
+			name: "uri matches, dns does not",
+			dns:  []string{"def.example.com"},
+			uris: []string{"spiffe://abc.example.com/test-identity"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			router := proxy.NewRouter()
+			require.NoError(t, router.UpdateConfig(&proxy.Config{
+				Version: 1,
+				Rules: []proxy.RouteRule{
+					{
+						Hostnames: []string{"app.example.com"},
+						Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+						Backends: []proxy.BackendRef{
+							{
+								URL:    srv.Server.URL,
+								Weight: 1,
+								TLS: &proxy.BackendTLSConfig{
+									CABundlePEM:        srv.CAPEM,
+									ServerName:         "sni-only.invalid",
+									SubjectAltNames:    tc.dns,
+									SubjectAltNameURIs: tc.uris,
+								},
+							},
+						},
+					},
+				},
+			}))
+
+			handler := proxy.NewHandler(router)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Result().StatusCode,
+				"OR semantics: either DNS SAN or URI SAN matching must accept the handshake")
+		})
+	}
+}
+
+// TestHandler_BackendTLSPolicy_MixedSAN_AllMismatch confirms that when neither
+// DNS nor URI lists match the cert, the handshake fails closed.
+func TestHandler_BackendTLSPolicy_MixedSAN_AllMismatch(t *testing.T) {
+	t.Parallel()
+
+	srv := newURITLSServer(t,
+		[]string{"abc.example.com"},
+		[]string{"spiffe://abc.example.com/test-identity"},
+	)
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches:   []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				Backends: []proxy.BackendRef{
+					{
+						URL:    srv.Server.URL,
+						Weight: 1,
+						TLS: &proxy.BackendTLSConfig{
+							CABundlePEM:        srv.CAPEM,
+							ServerName:         "abc.example.com",
+							SubjectAltNames:    []string{"def.example.com"},
+							SubjectAltNameURIs: []string{"spiffe://def.example.com/test-identity"},
+						},
+					},
+				},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Result().StatusCode,
+		"with neither DNS nor URI SAN matching, both lists must fail → proxy returns 502")
 }
 
 func TestHandler_BackendProtocolToggleSameHostPort(t *testing.T) {

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -54,6 +54,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		features.SupportHTTPRouteRequestMultipleMirrors,
 		features.SupportHTTPRouteRequestPercentageMirror,
 		features.SupportBackendTLSPolicy,
+		features.SupportBackendTLSPolicySANValidation,
 		// NOTE: 303/307/308 redirect status codes work correctly in the proxy,
 		// but Cloudflare edge rewrites Location scheme to HTTPS, so conformance
 		// tests that verify http:// scheme in redirects will always fail.
@@ -79,9 +80,6 @@ func TestGatewayAPIConformance(t *testing.T) {
 		features.SupportTLSRoute,
 		features.SupportTLSRouteModeTerminate,
 		features.SupportTLSRouteModeMixed,
-		// SANValidation requires URI-SAN support end-to-end; this minimum
-		// BackendTLSPolicy implementation handles Hostname SANs only.
-		features.SupportBackendTLSPolicySANValidation,
 		features.SupportUDPRoute,
 		features.SupportMesh,
 
@@ -160,15 +158,15 @@ func TestGatewayAPIConformance(t *testing.T) {
 		// HTTPRoute_ extended suite. ConflictResolution requires cross-policy
 		// conflict tracking (loser stamped with Reason=Conflicted) that this
 		// implementation does not yet do — older policy wins, others share the
-		// same Accepted=True status. SANValidation requires URI-type
-		// SubjectAltNames which are rejected by validateSANs (see the
-		// BackendTLSPolicy section in docs/gateway-api/limitations.md).
-		// InvalidCACertificateRef and ObservedGenerationBump are enabled —
-		// the controller emits the conformance-required Reasons and updates
-		// ObservedGeneration on every reconcile.
+		// same Accepted=True status.
+		// InvalidCACertificateRef, InvalidKind, ObservedGenerationBump, and
+		// SANValidation (both Hostname and URI types, including OR-matching)
+		// are enabled — the controller emits the conformance-required Reasons,
+		// updates ObservedGeneration on every reconcile, and the proxy
+		// matches DNS Hostname SANs via VerifyHostname (RFC 6125 wildcards)
+		// and URI SANs by exact string equality against the leaf's URIs.
 		"BackendTLSPolicy",
 		"BackendTLSPolicyConflictResolution",
-		"BackendTLSPolicySANValidation",
 
 		// Gateway features not applicable to tunnel architecture.
 		"GatewayStaticAddresses",


### PR DESCRIPTION
# Pull Request

## Summary

Extend `BackendTLSPolicy` SAN validation to support URI-type `SubjectAltNames` (e.g. SPIFFE IDs), completing the `BackendTLSPolicySANValidation` Gateway API conformance feature.

## Changes

- `BackendTLSConfig` gains `SubjectAltNameURIs []string`. The proxy matches URI SANs by exact string equality against the leaf cert's `URIs[]` field (SPIFFE convention used by the Gateway API conformance suite). DNS Hostname SANs continue to match via `x509.VerifyHostname` (RFC 6125 wildcards). Either list passing accepts the handshake (OR-semantics).
- `tlsFingerprint` hashes both DNS and URI SAN lists with a `|uri|` separator so policy churn evicts the transport pool cleanly.
- `BackendTLSPolicyReconciler.computeConditions` no longer rejects policies with URI SANs. All well-formed SAN combinations stamp `Accepted=True`. The `sanInvalidConditions` branch and `errBackendTLSUnsupportedSANType` sentinel are gone.
- `proxy_syncer` resolver splits SANs by type into `SubjectAltNames` (Hostname) and `SubjectAltNameURIs` (URI) before pushing to the proxy. CRD-newer-than-controller defence: if a future SAN type appears (Email, IP, etc.), the resolver fails closed with a poisoned config rather than silently enforcing the subset it understands.
- Conformance: `SupportBackendTLSPolicySANValidation` moves from `ExemptFeatures` to `SupportedFeatures`; the `BackendTLSPolicySANValidation` entry is removed from `SkipTests`. The upstream subtest exercises `san-dns` / `san-uri` / `multiple-sans` success paths and the matching `*-mismatch` failure paths against a backend cert carrying both DNS and URI SANs.
- README and `docs/gateway-api/limitations.md` updated: URI SANs are now listed as supported with SPIFFE/exact-match semantics, and the SNI-vs-authentication split note explicitly covers both SAN types.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint-cli2 'docs/**/*.md' 'README.md'`)
- [x] Helm tests pass (`helm unittest` — 196 tests)
- [x] Helm lint passes (`helm lint`)
- [x] Helm README regenerated (`helm-docs`)
- [ ] Conformance on homelab — pending; will run via in-cluster pod with feature-branch images before requesting merge

New tests in this PR:

- Proxy integration: `TestHandler_BackendTLSPolicy_URISAN_AcceptsMatchingURI`, `TestHandler_BackendTLSPolicy_URISAN_RejectsMismatching`, `TestHandler_BackendTLSPolicy_MixedSAN_OrMatch` (DNS-matches + URI-matches subtests), `TestHandler_BackendTLSPolicy_MixedSAN_AllMismatch`.
- Test fixture: `newURITLSServer` builds a self-signed `httptest.NewUnstartedServer` whose cert carries arbitrary DNS and URI SANs, so tests can exercise the real `x509.Certificate.URIs` matching path.
- ProxySyncer integration: `TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesURIList` confirms the resolver forwards URI SANs on `SubjectAltNameURIs` rather than poisoning the config.
- Controller unit: `TestComputeConditions_URISANAccepted` (URI SAN gets `Accepted=True`), `TestComputeConditions_NeverEmitsPolicyReasonInvalid` (invariant: dropped Reason never surfaces), `TestBackendTLSResolver_URISubjectAltName_ForwardsURIToProxy`, `TestBackendTLSResolver_UnknownSANType_ReturnsPoisonedConfig` (CRD-newer-than-controller defence).

## Documentation

- [x] README "Known Limitations" updated — URI SAN line replaced with the support description.
- [x] `docs/gateway-api/limitations.md` Backend mTLS table: URI SAN row flipped to `Yes`, SPIFFE/exact-match semantics noted, SNI/authentication split row added covering both SAN types, fail-closed enforcement section trimmed (Reason=Invalid no longer emitted).
- [x] Code comments updated.
- [ ] CLAUDE.md — no workflow change.

## Checklist

- [x] Commit message follows semantic format (`feat: support URI-type SubjectAltName in BackendTLSPolicy`).
- [x] No secrets or credentials in code.
- [x] Breaking changes: none. Existing Hostname-only policies continue to work unchanged; the resolver flips into Mode 2 (SAN-list authentication) whenever either DNS or URI list is populated.

## Additional Notes

Reviewed by Opus. Closes one of the open boxes in the v1.5 conformance epic.

Recommended follow-ups (non-blocking, raised in review):

- Lift the `splitSANsByType` `hasUnknown` flag into `computeConditions` so policies carrying a not-yet-supported SAN type also surface `Accepted=False, Reason=Invalid` in status, not just at the proxy. The proxy already fails closed via `poisonedBackendTLS`; this would make the misalignment visible in `kubectl describe`.
- URI canonicalisation: matching is exact-string per SPIFFE convention. A `SPIFFE://...` policy URI vs cert side `url.Parse(...).String()` lowercasing the scheme could trip a sloppy operator. Document in the limitations table or normalise both sides.
