### PR TITLE
feat(conformance): support HTTPRouteNamedRouteRule and HTTPRouteDestinationPortMatching gates

### DIFF
--- a/docs/gateway-api/supported-resources.md
+++ b/docs/gateway-api/supported-resources.md
@@ -66,6 +66,7 @@ only path-based routing through the Cloudflare Tunnel API is available.
 | `spec.parentRefs[].port` | Yes | Listener port (optional) |
 | `spec.hostnames` | Yes | Wildcard `*` supported |
 | `spec.rules` | Yes | Routing rules |
+| `spec.rules[].name` | Yes | Metadata only; preserved on the spec but not consulted during matching |
 | `spec.rules[].matches` | Yes | Full matching with L7 proxy |
 | `spec.rules[].matches[].path` | Yes | PathPrefix, Exact; RegularExpression requires L7 proxy |
 | `spec.rules[].matches[].headers` | Yes | Requires L7 proxy |
@@ -123,8 +124,10 @@ The following HTTPRoute filters are supported with the L7 proxy enabled:
 | `spec.parentRefs[].name` | Yes | Gateway name |
 | `spec.parentRefs[].namespace` | Yes | Gateway namespace |
 | `spec.parentRefs[].sectionName` | Yes | Listener name (optional) |
+| `spec.parentRefs[].port` | Yes | Listener port (optional) |
 | `spec.hostnames` | Yes | Wildcard `*` supported |
 | `spec.rules` | Yes | Routing rules |
+| `spec.rules[].name` | Yes | Metadata only; preserved on the spec but not consulted during matching |
 | `spec.rules[].matches` | Yes | Service/method matching |
 | `spec.rules[].matches[].method.service` | Yes | gRPC service name |
 | `spec.rules[].matches[].method.method` | Yes | gRPC method name |

--- a/docs/reference/crd-reference.md
+++ b/docs/reference/crd-reference.md
@@ -199,9 +199,14 @@ spec:
 | Condition | Status | Reason | Description |
 |-----------|--------|--------|-------------|
 | `Accepted` | `True` | `Accepted` | Route accepted and synced |
-| `Accepted` | `False` | `NoMatchingParent` | Sync to Cloudflare failed |
+| `Accepted` | `False` | `NoMatchingParent` | No listener matched the parentRef's `sectionName` or `port`; also fires when hostname is the failure reason and the parentRef pinned a `sectionName` or `port` |
+| `Accepted` | `False` | `NoMatchingListenerHostname` | Route hostnames do not intersect with any listener hostname (no `sectionName`/`port` pin on the parentRef) |
+| `Accepted` | `False` | `NotAllowedByListeners` | Route namespace or kind not allowed by listener |
+| `Accepted` | `False` | `Pending` | Sync to the Cloudflare Tunnel API failed; reconcile will retry. Proxy-push failures are best-effort: they are logged and counted via the `proxy_push` sync-error metric but do **not** flip `Accepted` to False / Reason=`Pending` |
 | `ResolvedRefs` | `True` | `ResolvedRefs` | Backend references resolved |
 | `ResolvedRefs` | `False` | `RefNotPermitted` | Cross-namespace reference denied |
+| `ResolvedRefs` | `False` | `BackendNotFound` | Backend Service not found |
+| `ResolvedRefs` | `False` | `InvalidKind` | Backend ref group/kind is not a core Service |
 
 ## API Versions
 

--- a/internal/controller/route_status_test.go
+++ b/internal/controller/route_status_test.go
@@ -1,13 +1,22 @@
 package controller
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/routebinding"
 )
+
+// errCloudflareSync stands in for a transient Cloudflare Tunnel API failure
+// returned by RouteSyncer.SyncAllRoutes. Defined as a package-level sentinel so
+// route-status pin tests can wrap it instead of allocating ad-hoc dynamic
+// errors (err113).
+var errCloudflareSync = errors.New("cloudflare API 500")
 
 func TestBuildParentStatus_IncludesPort(t *testing.T) {
 	t.Parallel()
@@ -43,4 +52,103 @@ func TestBuildParentStatus_NilPort(t *testing.T) {
 	)
 
 	assert.Nil(t, status.ParentRef.Port)
+}
+
+// TestBuildParentStatus_NoMatchingParent_ConformancePin pins the parent-status
+// surface required by the upstream conformance test
+// HTTPRouteInvalidParentRefNotMatchingListenerPort: when the binding validator
+// rejects a parentRef because no listener matched the requested port, the
+// Accepted condition on the resulting parent status must be False with
+// Reason=NoMatchingParent and ObservedGeneration mirroring the route. The
+// ParentRef block must still echo the rejected Port so observers can correlate
+// the failure with the offending parentRef.
+func TestBuildParentStatus_NoMatchingParent_ConformancePin(t *testing.T) {
+	t.Parallel()
+
+	port := gatewayv1.PortNumber(81)
+	ref := gatewayv1.ParentReference{
+		Name: "same-namespace",
+		Port: &port,
+	}
+
+	bindingInfo := routeBindingInfo{
+		bindingResults: map[int]routebinding.BindingResult{
+			0: {
+				Accepted: false,
+				Reason:   gatewayv1.RouteReasonNoMatchingParent,
+				Message:  "No matching listener found",
+			},
+		},
+	}
+
+	status := buildParentStatus(
+		ref, "gateway-conformance-infra", "test-controller", 7,
+		metav1.Now(), bindingInfo, 0, nil, nil,
+	)
+
+	require.NotNil(t, status.ParentRef.Port)
+	assert.Equal(t, port, *status.ParentRef.Port)
+
+	var accepted *metav1.Condition
+
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == string(gatewayv1.RouteConditionAccepted) {
+			accepted = &status.Conditions[i]
+
+			break
+		}
+	}
+
+	require.NotNil(t, accepted, "Accepted condition must be present")
+	assert.Equal(t, metav1.ConditionFalse, accepted.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonNoMatchingParent), accepted.Reason)
+	assert.Equal(t, int64(7), accepted.ObservedGeneration)
+}
+
+// TestBuildAcceptedCondition_OnlySyncErrorTriggersPending pins the contract
+// between buildAcceptedCondition and the syncer: only failures from
+// RouteSyncer.SyncAllRoutes (Cloudflare Tunnel API errors) are propagated
+// into syncErr and demote Accepted to Reason=Pending. Proxy-push failures
+// are best-effort — syncAndUpdateStatusCommon logs them and bumps the
+// proxy_push sync-error metric but never wires them into syncErr. The test
+// guards the docs claim in docs/reference/crd-reference.md that Accepted
+// stays True when only the proxy push fails.
+func TestBuildAcceptedCondition_OnlySyncErrorTriggersPending(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.Now()
+
+	// Healthy sync, healthy binding → Accepted=True.
+	cond := buildAcceptedCondition(1, now, routeBindingInfo{}, 0, nil)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonAccepted), cond.Reason)
+
+	// Cloudflare sync failure → Accepted=False, Reason=Pending.
+	cond = buildAcceptedCondition(1, now, routeBindingInfo{}, 0, errCloudflareSync)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonPending), cond.Reason)
+	assert.Equal(t, errCloudflareSync.Error(), cond.Message)
+
+	// Binding rejection without sync error → Accepted=False, Reason from
+	// the binding result (NoMatchingParent / NoMatchingListenerHostname / etc.).
+	// Confirms the function takes the binding result into account only when
+	// the syncer succeeded, matching the precedence in route_status.go.
+	bindingInfo := routeBindingInfo{
+		bindingResults: map[int]routebinding.BindingResult{
+			0: {
+				Accepted: false,
+				Reason:   gatewayv1.RouteReasonNoMatchingParent,
+				Message:  "No matching listener found",
+			},
+		},
+	}
+	cond = buildAcceptedCondition(1, now, bindingInfo, 0, nil)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonNoMatchingParent), cond.Reason)
+
+	// syncErr wins over a rejected binding: when Cloudflare sync fails we
+	// surface the sync error first so operators see the actionable cause.
+	cond = buildAcceptedCondition(1, now, bindingInfo, 0, errCloudflareSync)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonPending), cond.Reason)
 }

--- a/internal/ingress/grpc_builder_test.go
+++ b/internal/ingress/grpc_builder_test.go
@@ -979,3 +979,78 @@ func TestGRPCBuild_NilClient_FallbackBehavior(t *testing.T) {
 	assert.Equal(t, "http://grpc-service.default.svc.cluster.local:50051", buildResult.Rules[0].Service.Value)
 	assert.Empty(t, buildResult.FailedRefs)
 }
+
+// TestGRPCBuild_NamedAndUnnamedRules_BothRoutable pins the build behaviour
+// exercised by the upstream conformance test GRPCRouteNamedRule: a GRPCRoute
+// with two rules — one carrying a rule Name, one without — must produce two
+// independently matchable ingress entries. The rule Name field is metadata
+// only and must not interfere with method-based dispatch.
+func TestGRPCBuild_NamedAndUnnamedRules_BothRoutable(t *testing.T) {
+	t.Parallel()
+
+	builder := ingress.NewGRPCBuilder("cluster.local", nil, nil, nil, nil)
+	ruleName := gatewayv1.SectionName("named-rule")
+	// Service / method names mirror the upstream fixture
+	// grpcroute-named-rule.yaml verbatim so the pin literally reflects
+	// the conformance fixture instead of an analogous-but-different shape.
+	service := "gateway_api_conformance.echo_basic.grpcecho.GrpcEcho"
+	namedMethod := "Echo"
+	unnamedMethod := "EchoTwo"
+	routes := []gatewayv1.GRPCRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "grpc-named-rules", Namespace: "gateway-conformance-infra"},
+			Spec: gatewayv1.GRPCRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"grpc.example.com"},
+				Rules: []gatewayv1.GRPCRouteRule{
+					{
+						Name: &ruleName,
+						Matches: []gatewayv1.GRPCRouteMatch{
+							{
+								Method: &gatewayv1.GRPCMethodMatch{
+									Service: &service,
+									Method:  &namedMethod,
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.GRPCBackendRef{
+							newGRPCBackendRef("grpc-infra-backend-v1", nil, int32Ptr(8080)),
+						},
+					},
+					{
+						Matches: []gatewayv1.GRPCRouteMatch{
+							{
+								Method: &gatewayv1.GRPCMethodMatch{
+									Service: &service,
+									Method:  &unnamedMethod,
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.GRPCBackendRef{
+							newGRPCBackendRef("grpc-infra-backend-v2", nil, int32Ptr(8080)),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	buildResult := builder.Build(context.Background(), routes)
+
+	// Both rules must keep their distinct method paths and resolved backends —
+	// the Name field on one rule must not alter the output of the other.
+	require.Len(t, buildResult.Rules, 2)
+
+	pathToService := map[string]string{}
+	for _, rule := range buildResult.Rules {
+		pathToService[rule.Path.Value] = rule.Service.Value
+	}
+
+	assert.Equal(t,
+		"http://grpc-infra-backend-v1.gateway-conformance-infra.svc.cluster.local:8080",
+		pathToService["/gateway_api_conformance.echo_basic.grpcecho.GrpcEcho/Echo"],
+	)
+	assert.Equal(t,
+		"http://grpc-infra-backend-v2.gateway-conformance-infra.svc.cluster.local:8080",
+		pathToService["/gateway_api_conformance.echo_basic.grpcecho.GrpcEcho/EchoTwo"],
+	)
+}

--- a/internal/proxy/converter_test.go
+++ b/internal/proxy/converter_test.go
@@ -74,6 +74,66 @@ func TestConvertHTTPRoutes_Basic(t *testing.T) {
 	assert.Contains(t, cfg.Rules[1].Hostnames, "example.com")
 }
 
+// TestConvertHTTPRoutes_NamedAndUnnamedRules_BothRoutable pins the routing
+// behaviour exercised by the upstream conformance test HTTPRouteNamedRule.
+// Resource names, paths, and backend service names mirror the upstream
+// fixture httproute-named-rule.yaml verbatim. The route's hostnames are
+// left unset (matching the fixture) so the converter must produce two
+// independently matchable proxy rules purely from path matchers. The rule
+// Name field is metadata only and must not interfere with path-based
+// dispatch.
+func TestConvertHTTPRoutes_NamedAndUnnamedRules_BothRoutable(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	ruleName := gatewayv1.SectionName("named-rule")
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "http-named-rules", Namespace: "gateway-conformance-infra"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Name: &ruleName,
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/named")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							backendRef("infra-backend-v1", 8080, 1),
+						},
+					},
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/unnamed")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							backendRef("infra-backend-v2", 8080, 1),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 2)
+
+	// Both rules must keep their distinct path matchers and resolved backends —
+	// the Name field on one rule must not alter the output of the other.
+	require.Len(t, cfg.Rules[0].Matches, 1)
+	require.NotNil(t, cfg.Rules[0].Matches[0].Path)
+	assert.Equal(t, "/named", cfg.Rules[0].Matches[0].Path.Value)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Contains(t, cfg.Rules[0].Backends[0].URL, "infra-backend-v1")
+
+	require.Len(t, cfg.Rules[1].Matches, 1)
+	require.NotNil(t, cfg.Rules[1].Matches[0].Path)
+	assert.Equal(t, "/unnamed", cfg.Rules[1].Matches[0].Path.Value)
+	require.Len(t, cfg.Rules[1].Backends, 1)
+	assert.Contains(t, cfg.Rules[1].Backends[0].URL, "infra-backend-v2")
+}
+
 func TestConvertHTTPRoutes_BackendProtocolH2C(t *testing.T) {
 	t.Parallel()
 

--- a/internal/routebinding/binding_test.go
+++ b/internal/routebinding/binding_test.go
@@ -400,6 +400,10 @@ func TestValidateBinding(t *testing.T) {
 			expectedMatched:  nil,
 		},
 		{
+			// This case also pins the upstream conformance fixture
+			// httproute-invalid-parentref-not-matching-listener-port.yaml:
+			// single listener on port 80, parentRef.port=81, no sectionName.
+			// Spec requires Accepted=False with Reason=NoMatchingParent.
 			name: "route with Port only (no SectionName) rejected when no listener matches port",
 			gateway: &gatewayv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -36,7 +36,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		features.SupportReferenceGrant,
 		features.SupportGRPCRoute,
 
-		// Extended HTTPRoute (all via v2 proxy)
+		// Extended HTTPRoute (Standard channel feature gates; v1 CRD fields)
 		features.SupportHTTPRouteQueryParamMatching,
 		features.SupportHTTPRouteMethodMatching,
 		features.SupportHTTPRouteResponseHeaderModification,
@@ -56,6 +56,24 @@ func TestGatewayAPIConformance(t *testing.T) {
 		features.SupportBackendTLSPolicy,
 		features.SupportBackendTLSPolicySANValidation,
 		features.SupportHTTPRouteCORS,
+		features.SupportHTTPRouteNamedRouteRule,
+
+		// Extended GRPCRoute (Standard channel feature gates; v1 CRD fields).
+		// The matching conformance tests are listed in SkipTests below because
+		// the upstream gRPC suite dials *.cfargotunnel.com directly and the
+		// Cloudflare ULA address space is not externally routable. The feature
+		// flag stays here so the conformance report reflects what the proxy
+		// itself supports.
+		features.SupportGRPCRouteNamedRouteRule,
+
+		// Extended HTTPRoute (Experimental channel feature gates; v1 CRD fields).
+		// DestinationPortMatching is gated as Experimental in upstream but the
+		// underlying ParentRef.Port field is in Standard v1 — the gate covers
+		// rejecting Accepted=False/NoMatchingParent when a parentRef.port does
+		// not match any Listener.Port on the referenced Gateway, which works on
+		// any v1 cluster regardless of CRD channel.
+		features.SupportHTTPRouteDestinationPortMatching,
+
 		// NOTE: 303/307/308 redirect status codes work correctly in the proxy,
 		// but Cloudflare edge rewrites Location scheme to HTTPS, so conformance
 		// tests that verify http:// scheme in redirects will always fail.
@@ -90,17 +108,12 @@ func TestGatewayAPIConformance(t *testing.T) {
 		// (no custom dialer hook), and *.cfargotunnel.com is not routable — same
 		// structural limitation as the gRPC tests below. Left exempt.
 		features.SupportHTTPRouteBackendProtocolWebSocket,
-		features.SupportHTTPRouteNamedRouteRule,
-		features.SupportHTTPRouteDestinationPortMatching,
 
 		// Redirect status codes: proxy implements them, but Cloudflare edge
 		// rewrites Location scheme to HTTPS — conformance tests fail.
 		features.SupportHTTPRoute303RedirectStatusCode,
 		features.SupportHTTPRoute307RedirectStatusCode,
 		features.SupportHTTPRoute308RedirectStatusCode,
-
-		// GRPCRoute extended
-		features.SupportGRPCRouteNamedRouteRule,
 	)
 
 	// --- Skip tests ---
@@ -207,6 +220,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		"GRPCExactMethodMatching",
 		"GRPCRouteHeaderMatching",
 		"GRPCRouteWeight",
+		"GRPCRouteNamedRule",
 	}
 
 	// --- Timeouts ---


### PR DESCRIPTION
# Pull Request

## Summary

Enable three upstream Gateway API v1.5 conformance feature gates whose behaviour was already implemented in the controller and proxy: `HTTPRouteNamedRouteRule`, `GRPCRouteNamedRouteRule`, and `HTTPRouteDestinationPortMatching`. Pin each gate with focused unit tests that mirror the upstream conformance fixtures, and correct the `RouteParentStatus` reason table in the CRD reference so it matches the implementation.

## Changes

- Move the three feature gates from `ExemptFeatures` to `SupportedFeatures` in `test/conformance/conformance_test.go`, with section comments that separate Standard channel gates from the Experimental-gated `HTTPRouteDestinationPortMatching` (whose underlying `ParentRef.Port` field is in Standard v1, so it runs on clusters with the Standard CRD bundle).
- Add `GRPCRouteNamedRule` to the gRPC SkipTests block (the conformance gRPC client dials `*.cfargotunnel.com` directly and the Cloudflare ULA isn't routable from outside the CF network — same structural limitation as `GRPCExactMethodMatching`, `GRPCRouteHeaderMatching`, `GRPCRouteWeight`). The feature flag stays on so the conformance report reflects what the proxy actually supports.
- Add four unit-level pin tests, each mirroring the upstream fixture verbatim where it matters (service/method/path/port identifiers):
  - `TestConvertHTTPRoutes_NamedAndUnnamedRules_BothRoutable` — proxy converter
  - `TestGRPCBuild_NamedAndUnnamedRules_BothRoutable` — Cloudflare ingress builder
  - `TestBuildParentStatus_NoMatchingParent_ConformancePin` — controller status surface
  - `TestBuildAcceptedCondition_OnlySyncErrorTriggersPending` — pin that proxy-push failures are best-effort
- Add a conformance-fixture provenance comment to the existing `binding_test.go` port-mismatch case.
- Document `spec.rules[].name` on both HTTPRoute and GRPCRoute tables in `docs/gateway-api/supported-resources.md`, and add the missing `spec.parentRefs[].port` row on the GRPCRoute table.
- Correct the `Accepted=False/NoMatchingParent` row in `docs/reference/crd-reference.md` (was incorrectly described as "Sync to Cloudflare failed"), and expand the table with `NoMatchingListenerHostname`, `NotAllowedByListeners`, `Pending`, `BackendNotFound`, `InvalidKind`.

No production code is touched — the gates already pass on the existing implementation. The maintainer-side conformance run exercises `HTTPRouteNamedRule` and `HTTPRouteInvalidParentRefNotMatchingListenerPort` against the real tunnel as the binding check for this PR.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [ ] Manual testing completed — pending maintainer-side conformance run

## Documentation

- [x] README updated (if needed) — N/A, no user-facing flag/CRD changes
- [x] Code comments added for complex logic — section comments in `conformance_test.go` separating Standard/Experimental gates; pin-test docstrings explain the upstream-fixture link
- [x] CLAUDE.md updated (if workflow/standards changed) — N/A

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced (if any) — Gateway API conformance epic

## Additional Notes

`HTTPRouteNamedRule` is marked `Provisional: true` upstream; the conformance suite runs Provisional tests by default (`SkipProvisionalTests` flag defaults to `false`).

`HTTPRouteDestinationPortMatching` is gated as Experimental in the upstream features package, but the underlying `ParentReference.Port` field is in Standard v1 — the gate covers controller-side handling of port-mismatched parentRefs, which works on any cluster running Standard CRDs.
