### PR TITLE
fix(ci): override controller and proxy images independently in build-chart

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -411,20 +411,70 @@ jobs:
           CHART_DIR="charts/cloudflare-tunnel-gateway-controller"
           CHART_VERSION="0.0.0-pr.${PR_NUMBER}-1d"
           APP_VERSION="pr-${PR_NUMBER}-1d"
-          IMAGE_REPO="ttl.sh/cf-tunnel-gateway-ctrl"
+          CONTROLLER_IMAGE_REPO="ttl.sh/cf-tunnel-gateway-ctrl"
+          PROXY_IMAGE_REPO="ttl.sh/cf-tunnel-gateway-proxy"
           IMAGE_TAG="pr-${PR_NUMBER}-1d"
 
           # Update Chart.yaml
           sed -i "s/^version: .*/version: ${CHART_VERSION}/" "${CHART_DIR}/Chart.yaml"
           sed -i "s/^appVersion: .*/appVersion: \"${APP_VERSION}\"/" "${CHART_DIR}/Chart.yaml"
 
-          # Update values.yaml
-          sed -i "s|repository: .*|repository: ${IMAGE_REPO}|" "${CHART_DIR}/values.yaml"
-          sed -i "s/tag: .*/tag: \"${IMAGE_TAG}\"/" "${CHART_DIR}/values.yaml"
+          # Update values.yaml — controller and proxy images are independent.
+          # A greedy `sed s|repository: .*|...|` would rewrite both blocks to the
+          # controller image and the proxy pod would crash-loop on the wrong binary.
+          # Use yq to target each YAML path explicitly.
+          yq --inplace ".image.repository = \"${CONTROLLER_IMAGE_REPO}\"" "${CHART_DIR}/values.yaml"
+          yq --inplace ".image.tag = \"${IMAGE_TAG}\"" "${CHART_DIR}/values.yaml"
+          yq --inplace ".proxy.image.repository = \"${PROXY_IMAGE_REPO}\"" "${CHART_DIR}/values.yaml"
+          yq --inplace ".proxy.image.tag = \"${IMAGE_TAG}\"" "${CHART_DIR}/values.yaml"
 
           echo "Modified chart version: ${CHART_VERSION}"
           echo "Modified appVersion: ${APP_VERSION}"
-          echo "Modified image: ${IMAGE_REPO}:${IMAGE_TAG}"
+          echo "Modified controller image: ${CONTROLLER_IMAGE_REPO}:${IMAGE_TAG}"
+          echo "Modified proxy image:      ${PROXY_IMAGE_REPO}:${IMAGE_TAG}"
+
+      - name: Validate values.yaml image overrides
+        run: |
+          set -euo pipefail
+
+          CHART_DIR="charts/cloudflare-tunnel-gateway-controller"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          EXPECTED_TAG="pr-${PR_NUMBER}-1d"
+
+          controller_repo=$(yq --exit-status '.image.repository' "${CHART_DIR}/values.yaml")
+          controller_tag=$(yq --exit-status '.image.tag' "${CHART_DIR}/values.yaml")
+          proxy_repo=$(yq --exit-status '.proxy.image.repository' "${CHART_DIR}/values.yaml")
+          proxy_tag=$(yq --exit-status '.proxy.image.tag' "${CHART_DIR}/values.yaml")
+
+          fail=0
+          if [[ "${controller_repo}" != *-ctrl ]]; then
+            echo "ERROR: image.repository must end in -ctrl, got: ${controller_repo}"
+            fail=1
+          fi
+          if [[ "${proxy_repo}" != *-proxy ]]; then
+            echo "ERROR: proxy.image.repository must end in -proxy, got: ${proxy_repo}"
+            fail=1
+          fi
+          if [[ "${controller_repo}" == "${proxy_repo}" ]]; then
+            echo "ERROR: image.repository and proxy.image.repository collapsed to the same value (greedy sed regression)"
+            fail=1
+          fi
+          if [[ "${controller_tag}" != "${EXPECTED_TAG}" ]]; then
+            echo "ERROR: image.tag must equal ${EXPECTED_TAG}, got: ${controller_tag}"
+            fail=1
+          fi
+          if [[ "${proxy_tag}" != "${EXPECTED_TAG}" ]]; then
+            echo "ERROR: proxy.image.tag must equal ${EXPECTED_TAG}, got: ${proxy_tag}"
+            fail=1
+          fi
+
+          if [[ ${fail} -ne 0 ]]; then
+            exit 1
+          fi
+
+          echo "values.yaml image overrides verified:"
+          echo "  controller: ${controller_repo}:${controller_tag}"
+          echo "  proxy:      ${proxy_repo}:${proxy_tag}"
 
       - name: Package chart
         run: |


### PR DESCRIPTION
## Summary

The `build-chart` job in `.github/workflows/pr.yaml` rewrote `values.yaml` with a greedy `sed s|repository: .*|...|`, which matched both the controller `image.repository` and the proxy `proxy.image.repository` and collapsed them onto the same controller image. A chart installed from the resulting `oci://ttl.sh` artifact ran the controller binary inside the proxy pod, which crash-looped on missing RBAC.

Switch to `yq` with explicit YAML paths so each image is overridden on its own, and guard the step with a follow-up validation that fails the job if the two repositories ever collapse again or if either tag does not match the expected `pr-<N>-1d` form.

Addresses #242.

## Changes

- Replace greedy `sed` in `build-chart` with `yq --inplace` against `.image.repository`, `.image.tag`, `.proxy.image.repository`, `.proxy.image.tag`.
- Add a `Validate values.yaml image overrides` step that fails the job if `image.repository` does not end in `-ctrl`, `proxy.image.repository` does not end in `-proxy`, the two repositories collapse to the same value, or either tag differs from the expected `pr-<N>-1d`.

## Testing

- [ ] All tests pass locally (`go test ./...`) — N/A, CI-only change
- [ ] Linters pass locally (`golangci-lint run`) — N/A, CI-only change
- [ ] Markdown linting passes (`markdownlint **/*.md`) — N/A, no markdown changes
- [x] Manual testing completed (if applicable)

Verified locally with `nektos/act` against a trimmed copy of the workflow on image `catthehacker/ubuntu:act-latest`:

- Positive run: the `Validate` step prints `values.yaml image overrides verified` with `controller: ttl.sh/cf-tunnel-gateway-ctrl:pr-999999-1d` and `proxy: ttl.sh/cf-tunnel-gateway-proxy:pr-999999-1d`.
- Negative run (re-introducing the old greedy `sed`): the `Validate` step fails the job with `ERROR: proxy.image.repository must end in -proxy` and `ERROR: image.repository and proxy.image.repository collapsed to the same value`.

## Documentation

- [ ] README updated (if needed) — not needed
- [x] Code comments added for complex logic — inline comment in the workflow explaining why `yq` replaces the prior `sed`
- [ ] CLAUDE.md updated (if workflow/standards changed) — workflow standards unchanged

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced (if any) — #242

## Additional Notes

After this lands, downstream ArgoCD setups can point directly at the per-PR chart (`oci://ttl.sh/cloudflare-tunnel-gateway-controller --version 0.0.0-pr.<N>-1d`) without overlaying images on the stable chart and without an out-of-band ClusterRole patch to cover RBAC additions that have not yet shipped in the stable chart.
