### PR TITLE
test(tunnel): guard against vendored cloudflared upgrade-header constant drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ The project uses a fork of cloudflared: `github.com/lexfrei/cloudflared` (via `r
 - Patch: single commit adding `OverrideProxy` field to `orchestration/orchestrator.go`
 - **NEVER patch vendor directly** — always update the fork and re-vendor
 - When upgrading cloudflared version: rebase fork's master onto new upstream tag/commit, re-apply patch, update `replace` directive and pseudo-version in `go.mod`, then `go mod tidy && go mod vendor`
+- **Canary tests post-rebase**: `TestVendoredCloudflaredUpgradeConstantsPinned` (`internal/tunnel/origin_vendor_drift_test.go`) fails loudly if the WebSocket signalling header / token constants drift. If it fires, audit `internal/tunnel/origin.go` `GatewayOriginProxy.ProxyHTTP` and any sibling behavioural tests (notably `TestGatewayOriginProxy_ProxyHTTP_WebSocketReinjectsHeaders`) before re-pinning the constants.
 
 ### Configuration
 

--- a/internal/tunnel/origin_vendor_drift_test.go
+++ b/internal/tunnel/origin_vendor_drift_test.go
@@ -1,0 +1,57 @@
+package tunnel_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudflare/cloudflared/connection"
+)
+
+// TestVendoredCloudflaredUpgradeConstantsPinned guards against silent drift
+// in the vendored cloudflared fork's WebSocket signaling constants.
+//
+// `GatewayOriginProxy.ProxyHTTP` (`internal/tunnel/origin.go`) re-injects
+// the standard HTTP/1.1 `Connection: Upgrade` headers when cloudflared
+// signals a WebSocket request via the `isWebsocket bool` parameter — but
+// cloudflared itself determines that a request is a WebSocket upgrade by
+// inspecting the `Cf-Cloudflared-Proxy-Connection-Upgrade: websocket`
+// internal header that the Cloudflare edge sets when translating an
+// HTTP/1.1 upgrade request onto the HTTP/2 tunnel transport.
+//
+// If a future cloudflared bump renames either constant — e.g. a new fork
+// rebase or upstream change to the internal header name — our bridge's
+// re-injection silently stops firing on real WebSocket requests because
+// `connType` never resolves to `TypeWebsocket`. The breakage is end-to-end
+// invisible in unit tests (they pass headers in explicitly), so the
+// vendored value is the only signal a maintainer has at re-vendor time.
+//
+// This test fails loudly the moment `go mod vendor` brings in a renamed
+// constant, forcing whoever does the bump to update both the production
+// re-injection and any fake fixture that asserts against the same wire
+// values.
+func TestVendoredCloudflaredUpgradeConstantsPinned(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"Cf-Cloudflared-Proxy-Connection-Upgrade",
+		connection.InternalUpgradeHeader,
+		"vendored cloudflared `InternalUpgradeHeader` changed — "+
+			"GatewayOriginProxy bridge re-injection relies on cloudflared identifying "+
+			"the request as a WebSocket upgrade via this exact header name. "+
+			"If the value diverges, update `internal/tunnel/origin.go` "+
+			"`GatewayOriginProxy.ProxyHTTP` and re-audit the sibling behavioural pin "+
+			"`TestGatewayOriginProxy_ProxyHTTP_WebSocketReinjectsHeaders` "+
+			"(`internal/tunnel/origin_test.go`), then update this test.")
+
+	assert.Equal(t,
+		"websocket",
+		connection.WebsocketUpgrade,
+		"vendored cloudflared `WebsocketUpgrade` token changed — "+
+			"if the value diverges, the bridge's `isWebsocket` path will silently "+
+			"stop firing because cloudflared no longer classifies requests as "+
+			"`TypeWebsocket`. Audit `GatewayOriginProxy.ProxyHTTP` and re-audit "+
+			"the sibling behavioural pin "+
+			"`TestGatewayOriginProxy_ProxyHTTP_WebSocketReinjectsHeaders` "+
+			"(`internal/tunnel/origin_test.go`) before re-pinning this constant.")
+}


### PR DESCRIPTION
## Summary

`GatewayOriginProxy.ProxyHTTP` (`internal/tunnel/origin.go`) re-injects the standard HTTP/1.1 `Connection: Upgrade` headers only when cloudflared signals a WebSocket request through the `isWebsocket bool` parameter. cloudflared itself classifies the request as a WebSocket upgrade by reading the `Cf-Cloudflared-Proxy-Connection-Upgrade: websocket` internal header that the Cloudflare edge sets when translating an HTTP/1.1 upgrade onto the HTTP/2 tunnel transport.

If a future cloudflared bump renames either `connection.InternalUpgradeHeader` or `connection.WebsocketUpgrade`, the bridge silently stops firing because `connType` never resolves to `TypeWebsocket` on real WebSocket requests. Unit tests would not catch the breakage (they pass headers in explicitly) and the failure mode is end-to-end invisible until a production WebSocket request fails to upgrade.

Add a one-shot constant-equality canary that fails loudly the moment `go mod vendor` brings in a renamed constant, forcing whoever does the rebase to update `internal/tunnel/origin.go` and any sibling fixture that asserts the same wire values before re-pinning.

Closes #250.

## Changes

- `internal/tunnel/origin_vendor_drift_test.go` — new test `TestVendoredCloudflaredUpgradeConstantsPinned` asserting `connection.InternalUpgradeHeader == "Cf-Cloudflared-Proxy-Connection-Upgrade"` and `connection.WebsocketUpgrade == "websocket"`. Failure messages name the sibling behavioural pin (`TestGatewayOriginProxy_ProxyHTTP_WebSocketReinjectsHeaders`) so future cleanup is mechanical.
- `CLAUDE.md` — adds a bullet to the `Cloudflared Fork → Fork maintenance` section pointing the next re-vendor pass at the canary.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [ ] Manual testing completed — not applicable, test-only change

## Documentation

- [x] CLAUDE.md updated (Fork maintenance bullet)
- [x] No user-facing documentation changes required (test-only)
- [ ] Code comments — extensive docstring on the new test explaining the causal chain

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] No breaking changes — test-only addition
- [x] Related issue referenced — closes #250
