### PR TITLE
refactor(proxy): consolidate copyHeader helpers into a single shared function

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -643,11 +643,20 @@ func isHTTPUpgradeRequest(req *http.Request) bool {
 
 // writeRedirectResponse writes a short-circuit redirect response.
 func writeRedirectResponse(writer http.ResponseWriter, resp *http.Response) {
-	for key, values := range resp.Header {
+	copyHeaderValues(writer.Header(), resp.Header)
+	writer.WriteHeader(resp.StatusCode)
+}
+
+// copyHeaderValues performs a shallow copy of src into dst, preserving
+// multi-value headers. Single shared helper for the package — used by
+// both the redirect short-circuit path here and the WebSocket upgrade
+// path in handler_websocket.go. Mirrors stdlib's internal `copyHeader`
+// (`net/http/httputil/reverseproxy.go`) without taking a `httputil`
+// import dependency in this file.
+func copyHeaderValues(dst, src http.Header) {
+	for key, values := range src {
 		for _, value := range values {
-			writer.Header().Add(key, value)
+			dst.Add(key, value)
 		}
 	}
-
-	writer.WriteHeader(resp.StatusCode)
 }

--- a/internal/proxy/handler_websocket.go
+++ b/internal/proxy/handler_websocket.go
@@ -291,15 +291,3 @@ func backendUpgradeTLSConfig(backendURL *url.URL, backendTLS *BackendTLSConfig) 
 
 	return buildBackendTLSConfig(backendTLS, rootCAs), nil
 }
-
-// copyHeaderValues performs a shallow copy of src into dst, preserving
-// multi-value headers. Used in the WS upgrade path; mirrors stdlib's
-// internal copyHeader without forcing a httputil dependency from this
-// file.
-func copyHeaderValues(dst, src http.Header) {
-	for key, values := range src {
-		for _, value := range values {
-			dst.Add(key, value)
-		}
-	}
-}


### PR DESCRIPTION
## Summary

Pure DRY consolidation of two identical header-copy helpers in `internal/proxy/`. `handler_websocket.go` defined `copyHeaderValues`; `writeRedirectResponse` in `handler.go` open-coded the same nested-loop pattern in place. Move the helper to `handler.go` and call it from all three sites. The behavioural surface is unchanged — only the duplication is gone.

Closes #249.

## Changes

- `internal/proxy/handler.go` — adds `copyHeaderValues`; `writeRedirectResponse` calls it instead of inlining the nested-loop pattern.
- `internal/proxy/handler_websocket.go` — drops the local helper definition; the two call sites continue to use the (now package-shared) name.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [ ] Manual testing completed — not applicable, refactor-only change

The helper's behaviour is already covered by the existing `TestRequestRedirect_*` suite (redirect short-circuit path) and by the WebSocket integration / tunnel-fake suite (`TestHandler_BackendProtocolWebSocket_*` family). Both continue to pass without modification.

## Documentation

- [x] No user-facing documentation changes required
- [x] Helper docstring updated to reflect the package-wide scope (used by both redirect short-circuit and WS upgrade paths)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] No breaking changes — refactor-only
- [x] Related issue referenced — closes #249
