### PR TITLE
test(e2e): opt-in retain cluster resources on failure

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -305,6 +305,7 @@ go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/... \
 | `E2E_NAMESPACE` | `CONFORMANCE_NAMESPACE` | `cloudflare-tunnel-system` | Controller namespace |
 | `E2E_TEST_NAMESPACE` | `CONFORMANCE_TEST_NAMESPACE` | `e2e-test` | Test resources namespace |
 | `E2E_GATEWAY_NAME` | `CONFORMANCE_GATEWAY_NAME` | `e2e-gateway` | Gateway resource name |
+| `E2E_SKIP_CLEANUP_ON_FAILURE` | (none) | unset | When non-empty, retains test resources (HTTPRoutes, Services) after a failed test for post-mortem `kubectl` inspection. CI leaves it unset so resources never accumulate. **Caveat: pair this with `-run TestName/SubtestName` to isolate the failing case.** The cleanup helpers wipe the entire test namespace, so in a full-suite run a passing sibling that comes after the failing subtest will delete its retained state -- only the last failing subtest after the final passing sibling actually survives. Retention is also scoped to a single `go test` run; the initial `deleteAllRoutes` at the start of `TestHTTPRouteConformance` wipes leftover state from a previous invocation, so `kubectl`-inspect happens between runs, not across them. |
 
 ### E2E Test Coverage (24 tests)
 

--- a/test/e2e/cleanup_retain_test.go
+++ b/test/e2e/cleanup_retain_test.go
@@ -1,0 +1,87 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+)
+
+// skipCleanupEnvVar is the opt-in env knob: when set to any non-empty
+// value AND the test failed, cleanup helpers in this package return
+// early instead of deleting the test resources. Lets a maintainer keep
+// the cluster state around for post-mortem inspection (`kubectl get
+// httproute -A`, proxy log inspection, etc.) without manually fishing
+// the right `--skip-cleanup` flag into every test.
+//
+// Scope of retention -- per-subtest predicate, NOT per-subtest
+// resource isolation. Each `t.Run` receives a fresh `*testing.T`
+// whose `Failed()` reports only that subtest's own failures, never
+// a sibling's (pinned by runDeferObservationHelper). So the
+// PREDICATE fires per-failing-subtest. But the CLEANUP it gates --
+// deleteAllRoutes -- is a blanket namespace wipe: it deletes every
+// HTTPRoute in cfg.TestNamespace regardless of which subtest
+// created it.
+//
+// Operational consequence in a full-suite run:
+//
+//  1. Subtest A fails. A's defer skips (predicate=true). A's
+//     routes stay in the namespace.
+//  2. Subtest B runs next, creates its own routes, passes.
+//  3. B's defer runs (predicate=false because B passed) and
+//     deleteAllRoutes wipes the entire namespace -- including
+//     A's retained routes.
+//
+// Only state from the LAST failing subtest after the final passing
+// sibling survives the run. In other words, the env var is mostly
+// useful when paired with `-run TestName/SubtestName` so the
+// failing subtest is the only one that touches the namespace.
+// Running the full suite with the env set and expecting to inspect
+// an early failure's state is the trap; use `-run` to avoid it.
+//
+// (Issue #265 tracks the larger refactor: scoping deleteAllRoutes
+// to a subtest-owned label set so siblings can't wipe each other's
+// state. Documenting the limitation here is the conservative fix.)
+//
+// Cross-invocation. Retention is scoped to a single `go test`
+// process. The next invocation's clean-slate `deleteAllRoutes` at
+// the top of `TestHTTPRouteConformance` runs with the parent's
+// `t.Failed() == false` and wipes anything left over -- intentional,
+// so a follow-up run starts from a known state once the operator has
+// finished inspecting. `kubectl` against the retained state must
+// happen between the failing run and the next `go test` invocation.
+//
+// Documented in docs/development/testing.md under "E2E Environment
+// Variables"; that doc row is asserted by TestEnvVarDocumented in
+// this file so the knob can't silently drop out of the docs.
+const skipCleanupEnvVar = "E2E_SKIP_CLEANUP_ON_FAILURE"
+
+// shouldSkipCleanupOnFailure is the pure predicate behind
+// skipCleanupOnFailure. Extracted so it can be unit-tested without
+// having to artificially fail the surrounding test (which would also
+// taint the harness state). Returns true only when BOTH conditions
+// hold: the test recorded a failure AND the opt-in env var is set.
+//
+// Defaulting cleanup to "always run unless explicitly opted out"
+// keeps CI from accumulating dangling cluster resources on flaky
+// runs while still letting a developer who's actively debugging
+// preserve the failed state.
+func shouldSkipCleanupOnFailure(failed bool, skipFailEnv string) bool {
+	return failed && skipFailEnv != ""
+}
+
+// skipCleanupOnFailure inspects the current test's failure status and
+// the opt-in env var and reports whether the caller should retain
+// resources for post-mortem. Logs the decision when retaining so the
+// reason shows up in the test output next to the failure itself.
+func skipCleanupOnFailure(t *testing.T) bool {
+	t.Helper()
+
+	if !shouldSkipCleanupOnFailure(t.Failed(), os.Getenv(skipCleanupEnvVar)) {
+		return false
+	}
+
+	t.Logf("test failed and %s is set -- retaining resources for post-mortem inspection", skipCleanupEnvVar)
+
+	return true
+}

--- a/test/e2e/cleanup_retain_unit_test.go
+++ b/test/e2e/cleanup_retain_unit_test.go
@@ -1,0 +1,269 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestShouldSkipCleanupOnFailure pins the truth table of the cleanup-skip
+// predicate. The two-input AND is small enough that the temptation is to
+// inline it; this test exists so that flipping the polarity (e.g. "skip
+// on success" by accident, or "skip whenever the env is set even on
+// green runs") gets caught immediately. CI accumulating dangling
+// HTTPRoutes across runs would be a silent multi-hour debugging trap;
+// the fast feedback here is cheap insurance.
+func TestShouldSkipCleanupOnFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		failed   bool
+		envValue string
+		want     bool
+	}{
+		{
+			name:     "green run with env unset cleans up",
+			failed:   false,
+			envValue: "",
+			want:     false,
+		},
+		{
+			name:     "green run with env set still cleans up",
+			failed:   false,
+			envValue: "1",
+			want:     false,
+		},
+		{
+			name:     "red run with env unset cleans up (CI default)",
+			failed:   true,
+			envValue: "",
+			want:     false,
+		},
+		{
+			name:     "red run with env set retains for post-mortem",
+			failed:   true,
+			envValue: "1",
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := shouldSkipCleanupOnFailure(tt.failed, tt.envValue)
+			if got != tt.want {
+				t.Fatalf("shouldSkipCleanupOnFailure(failed=%v, env=%q) = %v, want %v",
+					tt.failed, tt.envValue, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEnvVarDocumented pins the cross-link between the constant and
+// docs/development/testing.md. A maintainer who hits a flaky run looks
+// at the testing-doc env-var table first; if the knob isn't listed
+// there it might as well not exist for the operator. Renaming or
+// dropping the constant without also updating the doc would silently
+// break that contract.
+//
+// Asserts two things: (a) the file contains an `### E2E Environment
+// Variables` heading, (b) the env var literal appears as the first
+// cell of a markdown table row beneath that heading (`| NAME |`
+// shape). A stray prose mention of the env var name elsewhere in the
+// doc would not satisfy the second check -- that's intentional: a
+// loose substring test would silently let the table row disappear.
+//
+// The path is resolved relative to this test file's package
+// (test/e2e), which always sits two levels below the docs directory.
+func TestEnvVarDocumented(t *testing.T) {
+	t.Parallel()
+
+	const (
+		docsPath    = "../../docs/development/testing.md"
+		sectionHead = "### E2E Environment Variables"
+	)
+
+	data, err := os.ReadFile(docsPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", docsPath, err)
+	}
+
+	content := string(data)
+
+	sectionIdx := strings.Index(content, sectionHead)
+	if sectionIdx < 0 {
+		t.Fatalf("%q heading not found in %s; the E2E env-var table moved or was deleted",
+			sectionHead, docsPath)
+	}
+
+	// Bound the search to the section that follows the heading -- the
+	// next heading at the same or higher level ends the slice.
+	tail := content[sectionIdx+len(sectionHead):]
+	if end := strings.Index(tail, "\n### "); end >= 0 {
+		tail = tail[:end]
+	}
+
+	cellMarker := "| `" + skipCleanupEnvVar + "` |"
+	if !strings.Contains(tail, cellMarker) {
+		t.Fatalf("env var %q is not present as a table row (looked for %q) under %q in %s",
+			skipCleanupEnvVar, cellMarker, sectionHead, docsPath)
+	}
+
+	// The per-subtest predicate gates a namespace-wide wipe, so a
+	// passing sibling running AFTER the failing subtest deletes the
+	// retained state. The doc row must call this out -- otherwise an
+	// operator running the full suite will think the env knob is
+	// broken when state silently disappears between failure and
+	// inspection. Pin the `-run` recommendation literally so a
+	// rewrite that drops it gets caught.
+	const isolationHint = "`-run TestName/SubtestName` to isolate"
+	if !strings.Contains(tail, isolationHint) {
+		t.Fatalf("docs row for %q must mention %q so operators know to isolate failing subtests; %s missing the caveat",
+			skipCleanupEnvVar, isolationHint, docsPath)
+	}
+}
+
+// deferObservationHelperEnv directs the test binary into the
+// subprocess-helper branch of TestSkipCleanupOnFailure_DeferredObservation.
+// The helper deliberately marks a child *testing.T as failed and writes
+// its observations to stdout, so the parent can pin the contract without
+// the parent process itself reporting a failed test.
+const deferObservationHelperEnv = "E2E_DEFER_OBSERVATION_HELPER"
+
+// TestSkipCleanupOnFailure_DeferredObservation pins the production
+// contract that `defer skipCleanupOnFailure(t)` placed in a real
+// subtest correctly observes the sticky failure bit. The pure-predicate
+// test above exercises the AND, but the real-world surface is "Go
+// runtime + *testing.T + defer + require/t.Fail" -- a refactor that,
+// say, evaluates t.Failed() at registration time instead of at the
+// defer's fire moment would silently break the suite without this
+// test.
+//
+// Uses the subprocess re-entry pattern documented in CLAUDE.md: the
+// child process runs the same test name with deferObservationHelperEnv
+// set, executes the helper branch, and exits with whatever code the
+// deliberately-failing subtest produced. The parent ignores that exit
+// code and asserts only on the captured stdout markers, so this test
+// is itself a clean pass even though it contains a forced failure.
+// tparallel is intentionally disabled for this test: the subtests
+// `passing-child` and `failing-child` must run sequentially. Capturing
+// passing-child's observation before failing-child marks the parent
+// failed is what proves the env-gated retain isn't accidentally
+// triggered on a green subtest -- making them parallel would race the
+// observation and break the contract this test pins.
+//
+//nolint:tparallel // sequential execution is load-bearing; see above
+func TestSkipCleanupOnFailure_DeferredObservation(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv(deferObservationHelperEnv) != "" {
+		runDeferObservationHelper(t)
+
+		return
+	}
+
+	// 60s gives a cold-start CI runner room while still bounding a
+	// genuine hang. Locally the subprocess finishes in ~10ms.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0],
+		"-test.run=TestSkipCleanupOnFailure_DeferredObservation/",
+		"-test.v")
+	cmd.Env = append(os.Environ(),
+		deferObservationHelperEnv+"=1",
+		skipCleanupEnvVar+"=1")
+
+	// CombinedOutput returns a non-nil error because the child's
+	// failing-child subtest deliberately fails, producing a non-zero
+	// exit code. The exit code is the whole point of this test, so
+	// we ignore the error and assert only on the captured markers.
+	out, _ := cmd.CombinedOutput()
+	output := string(out)
+
+	if !strings.Contains(output, "DEFER_OBSERVED_PASSING=false") {
+		t.Fatalf("expected deferred cleanup on a passing subtest NOT to skip "+
+			"(env set but t.Failed()==false); helper output:\n%s", output)
+	}
+
+	if !strings.Contains(output, "DEFER_OBSERVED_FAILING=true") {
+		t.Fatalf("expected deferred cleanup on a failing subtest to skip "+
+			"(env set AND t.Failed()==true); helper output:\n%s", output)
+	}
+
+	// Regression guard for the no-sibling-cascade invariant: each
+	// t.Run gets a fresh *testing.T whose Failed() reports only that
+	// subtest's failures, never an earlier sibling's. A refactor that
+	// flipped the predicate to walk to the parent would make this
+	// observation flip to true and break the documented "retention is
+	// per-failing-subtest" contract without any other test catching
+	// it.
+	if !strings.Contains(output, "DEFER_OBSERVED_AFTER_FAILING_SIBLING=false") {
+		t.Fatalf("expected a passing subtest running AFTER a failing sibling to NOT skip "+
+			"cleanup (siblings don't inherit failure); helper output:\n%s", output)
+	}
+}
+
+// runDeferObservationHelper is the child-process branch. It runs
+// three sibling subtests in order:
+//
+//  1. passing-child -- proves a green subtest's defer does NOT skip
+//     even with the env set.
+//  2. failing-child -- proves a red subtest's defer DOES skip with
+//     the env set.
+//  3. passing-after-failing-sibling -- proves siblings don't
+//     inherit failure: even though (2) failed the parent, a fresh
+//     sibling t.Run gets t.Failed() == false in its own *T and
+//     cleans up normally.
+//
+// Each defer captures its observation via skipCleanupOnFailure into
+// a closure variable, then the helper writes a "KEY=value" marker
+// to stdout for the parent to grep. Output is centralised in
+// writeObservation so the print form is in one place.
+func runDeferObservationHelper(t *testing.T) {
+	t.Helper()
+
+	var observedPassing bool
+
+	t.Run("passing-child", func(t *testing.T) {
+		defer func() { observedPassing = skipCleanupOnFailure(t) }()
+		// Intentionally do nothing; the subtest passes.
+	})
+
+	writeObservation("DEFER_OBSERVED_PASSING", observedPassing)
+
+	var observedFailing bool
+
+	t.Run("failing-child", func(t *testing.T) {
+		defer func() { observedFailing = skipCleanupOnFailure(t) }()
+		// t.Fail (not t.Fatal) marks failure without aborting the
+		// closure, so the defer still runs against the failed bit.
+		t.Fail()
+	})
+
+	writeObservation("DEFER_OBSERVED_FAILING", observedFailing)
+
+	var observedAfterFailingSibling bool
+
+	t.Run("passing-after-failing-sibling", func(t *testing.T) {
+		defer func() { observedAfterFailingSibling = skipCleanupOnFailure(t) }()
+		// Intentionally do nothing; siblings don't inherit failure.
+	})
+
+	writeObservation("DEFER_OBSERVED_AFTER_FAILING_SIBLING", observedAfterFailingSibling)
+}
+
+// writeObservation writes a single `KEY=value` marker line to the
+// child process's stdout. Centralised so the marker print form
+// lives in one place and the call sites stay short.
+func writeObservation(key string, value bool) {
+	_, _ = fmt.Fprintf(os.Stdout, "%s=%v\n", key, value)
+}

--- a/test/e2e/e2e_backend_protocol_websocket_test.go
+++ b/test/e2e/e2e_backend_protocol_websocket_test.go
@@ -186,8 +186,17 @@ func setupWSBackendService(
 
 // teardownWSBackendService removes the Service created by
 // setupWSBackendService. Best-effort: a missing service is not an error.
+//
+// Honours skipCleanupOnFailure: if the test failed AND the opt-in env var
+// is set, returns early without touching the cluster so a maintainer can
+// inspect the state at the point of failure. See cleanup_retain_test.go
+// for the rationale and the env var name.
 func teardownWSBackendService(t *testing.T, k8sClient client.Client, namespace, serviceName string) {
 	t.Helper()
+
+	if skipCleanupOnFailure(t) {
+		return
+	}
 
 	ctx := context.Background()
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace}}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -159,8 +159,17 @@ func waitForBackend(
 }
 
 // deleteAllRoutes removes all HTTPRoutes in the test namespace and waits for proxy to update.
+//
+// Honours skipCleanupOnFailure: if the test failed AND the opt-in env var
+// is set, returns early without touching the cluster so a maintainer can
+// inspect the state at the point of failure. See cleanup_retain_test.go
+// for the rationale and the env var name.
 func deleteAllRoutes(t *testing.T, k8sClient client.Client, cfg testConfig) {
 	t.Helper()
+
+	if skipCleanupOnFailure(t) {
+		return
+	}
 
 	ctx := context.Background()
 	routeList := &gatewayv1.HTTPRouteList{}


### PR DESCRIPTION
## Summary

E2E tests today always wipe their cluster resources at teardown, including on failure. Debugging a failing test means either re-running and hoping it fails the same way, or adding ad-hoc `sleep`s before the `defer` to peek at the cluster. Both are slow and lossy.

Adds opt-in `E2E_SKIP_CLEANUP_ON_FAILURE`: when set and the test failed, the e2e cleanup helpers (`deleteAllRoutes`, `teardownWSBackendService`) return early so a maintainer can inspect the actual state at the point of failure (`kubectl get httproute -A`, proxy logs, etc.) before the next run wipes it. CI defaults remain green-clean — the env is unset, so cleanup always runs.

Closes #248.

## Changes

- `test/e2e/cleanup_retain_test.go` — pure predicate `shouldSkipCleanupOnFailure(failed, env)` plus the `*testing.T` wrapper `skipCleanupOnFailure(t)` that returns true only when the test recorded a failure AND the env knob is non-empty.
- `test/e2e/e2e_test.go` + `test/e2e/e2e_backend_protocol_websocket_test.go` — `deleteAllRoutes` and `teardownWSBackendService` gain the guard at function entry.
- `test/e2e/cleanup_retain_unit_test.go`:
  - 4-case truth-table unit test for the pure predicate (`green×unset`, `green×set`, `red×unset`, `red×set`).
  - `TestEnvVarDocumented` pins both the table-cell shape `` | `E2E_SKIP_CLEANUP_ON_FAILURE` | `` AND the literal `` `-run TestName/SubtestName` to isolate `` substring under the `### E2E Environment Variables` section -- a doc rewrite that drops either fails the test.
  - `TestSkipCleanupOnFailure_DeferredObservation` uses the subprocess re-entry pattern to pin the production contract that `defer skipCleanupOnFailure(t)` correctly observes the sticky failure bit through real Go runtime + `*testing.T` + `defer`. Three subtests cover the matrix: passing, failing, and passing-after-failing-sibling (proves no sibling cascade).
- `docs/development/testing.md` — new row in the E2E Environment Variables table opening with the `-run` caveat and the namespace-wipe-by-passing-sibling failure mode.

Issue #265 tracks the larger follow-up to scope `deleteAllRoutes` to subtest-owned resources via a label set so the caveat becomes unnecessary.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [x] Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller`)
- [x] Helm lint passes (`helm lint charts/cloudflare-tunnel-gateway-controller`)
- [x] Helm README is up to date (`helm-docs charts/cloudflare-tunnel-gateway-controller`)
- [ ] Manual testing completed -- not applicable, e2e tooling change only

The subprocess helper was end-to-end verified on the prebuilt e2e test binary: with `E2E_DEFER_OBSERVATION_HELPER=1 E2E_SKIP_CLEANUP_ON_FAILURE=1`, the child writes `DEFER_OBSERVED_PASSING=false`, `DEFER_OBSERVED_FAILING=true`, `DEFER_OBSERVED_AFTER_FAILING_SIBLING=false`, exits non-zero (forced-fail subtest), and the parent assertion passes.

## Documentation

- [x] `docs/development/testing.md` — E2E Environment Variables table row added
- [x] Code comments document the per-subtest predicate vs namespace-wide wipe distinction
- [x] No README change required (env knob is e2e-developer-facing only)
- [x] No CLAUDE.md change required

## Checklist

- [x] Commit message follows semantic format (`test(e2e): opt-in retain cluster resources on failure`)
- [x] No secrets or credentials in code
- [x] No breaking changes -- test-only addition, opt-in
- [x] Related issues referenced -- closes #248, follow-up #265
