### PR TITLE
chore(labels): migrate repo labels to CNCF-style namespaced scheme

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Report a bug or unexpected behavior
 title: '[BUG] '
-labels: bug
+labels: kind/bug, triage/needs-triage
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Suggest an idea or enhancement for this project
 title: '[FEATURE] '
-labels: enhancement
+labels: kind/feature, triage/needs-triage
 assignees: ''
 ---
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,338 @@
+# cloudflare-tunnel-gateway-controller repository labels
+#
+# Label conventions follow the Kubernetes scheme:
+# https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md
+#
+# Synced into the repository by .github/workflows/labels.yaml
+# (EndBug/label-sync@v2). Edit this file via pull request -- UI changes
+# will be overwritten on the next sync.
+#
+# Constraints (enforced by the validate job in labels.yaml):
+#   - description <= 100 characters (GitHub REST API limit)
+#   - color is a 6-character hex string (no leading #)
+#   - label names are unique
+#   - aliases do not collide with top-level names
+#
+# Categories:
+#   kind/         issue or PR type
+#   priority/     urgency
+#   triage/       review state
+#   lifecycle/    issue or PR lifecycle
+#   area/         subsystem; extensible -- add when 3+ open issues exist
+#   do-not-merge/ PR merge blockers
+#   security/     security-finding severity and status
+#   size/         PR size (apply manually for now; no auto-labeler is wired up)
+#
+# `aliases:` lets EndBug/label-sync rename existing labels without losing
+# references on already-tagged issues and PRs.
+
+# ----------------------------------------------
+# kind/ -- issue or PR type
+# ----------------------------------------------
+
+- name: kind/bug
+  color: 'd73a4a'
+  description: Categorizes issue or PR as related to a bug
+  aliases: ['bug']
+
+- name: kind/feature
+  color: 'a2eeef'
+  description: Categorizes issue or PR as related to a new feature
+  aliases: ['enhancement']
+
+- name: kind/documentation
+  color: '0075ca'
+  description: Categorizes issue or PR as related to documentation
+  aliases: ['documentation']
+
+- name: kind/support
+  color: 'd876e3'
+  description: Categorizes issue as a support question
+  aliases: ['question']
+
+- name: kind/cleanup
+  color: 'c7def8'
+  description: Categorizes issue or PR as related to cleanup of code, process, or technical debt
+
+- name: kind/regression
+  color: 'e11d21'
+  description: Categorizes issue or PR as related to a regression from a prior release
+
+- name: kind/flake
+  color: 'f7c6c7'
+  description: Categorizes issue or PR as related to a flaky test
+
+- name: kind/failing-test
+  color: 'e11d21'
+  description: Categorizes issue or PR as related to a consistently or frequently failing test
+
+- name: kind/api-change
+  color: 'c7def8'
+  description: Categorizes issue or PR as related to adding, removing, or otherwise changing an API
+
+- name: kind/breaking-change
+  color: 'e11d21'
+  description: Indicates the change introduces a breaking API or behaviour change
+
+# ----------------------------------------------
+# priority/ -- urgency
+# ----------------------------------------------
+
+- name: priority/critical-urgent
+  color: 'e11d21'
+  description: Highest priority. Must be actively worked on as someone's top priority right now
+  aliases: ['priority/critical']
+
+- name: priority/important-soon
+  color: 'eb6420'
+  description: Must be staffed and worked on either currently, or very soon, ideally in time for the next release
+  aliases: ['priority/high']
+
+- name: priority/important-longterm
+  color: 'fbca04'
+  description: Important over the long term, but may not be staffed and/or may need multiple releases to complete
+  aliases: ['priority/medium']
+
+- name: priority/backlog
+  color: 'fef2c0'
+  description: General backlog priority. Lower than priority/important-longterm
+  aliases: ['priority/low']
+
+# ----------------------------------------------
+# triage/ -- review state
+# ----------------------------------------------
+
+- name: triage/needs-triage
+  color: 'ededed'
+  description: Indicates an issue needs triage by a maintainer
+  aliases: ['status/needs-triage']
+
+- name: triage/accepted
+  color: '0e8a16'
+  description: Indicates an issue is ready to be actively worked on
+  aliases: ['status/ready']
+
+- name: triage/needs-information
+  color: 'fbca04'
+  description: Indicates an issue needs more information in order to work on it
+  aliases: ['status/needs-info', 'status/needs-design']
+
+- name: triage/not-reproducible
+  color: 'fbca04'
+  description: Indicates an issue can not be reproduced as described
+
+- name: triage/duplicate
+  color: 'cfd3d7'
+  description: Indicates an issue is a duplicate of another issue
+  aliases: ['duplicate']
+
+- name: triage/unresolved
+  color: 'cfd3d7'
+  description: Indicates an issue that can not or will not be resolved
+  aliases: ['wontfix']
+
+# ----------------------------------------------
+# lifecycle/ -- issue or PR lifecycle
+# ----------------------------------------------
+
+- name: lifecycle/active
+  color: '1d76db'
+  description: Indicates that an issue or PR is actively being worked on by a contributor
+  aliases: ['status/in-progress', 'status/needs-review']
+
+- name: lifecycle/frozen
+  color: 'db5dd6'
+  description: Indicates that an issue or PR should not be auto-closed due to staleness
+
+- name: lifecycle/stale
+  color: 'dadada'
+  description: Denotes an issue or PR has remained open with no activity and has become stale
+
+- name: lifecycle/rotten
+  color: '795548'
+  description: Denotes an issue or PR that has aged beyond stale and will be auto-closed
+
+# ----------------------------------------------
+# area/ -- subsystem (extensible)
+# Add a new area/* when there are 3+ open issues on the topic.
+# ----------------------------------------------
+
+- name: area/controller
+  color: 'bfd4f2'
+  description: Kubernetes controller (internal/controller, GatewayReconciler, route binding)
+
+- name: area/proxy
+  color: 'bfd4f2'
+  description: Issues or PRs related to the in-process L7 reverse proxy (internal/proxy, filters, transport)
+
+- name: area/tunnel
+  color: 'bfd4f2'
+  description: cloudflared tunnel bridge (internal/tunnel, GatewayOriginProxy, vendored fork)
+
+- name: area/api
+  color: 'bfd4f2'
+  description: Issues or PRs related to the GatewayClassConfig CRD and API types (api/v1alpha1)
+
+- name: area/helm
+  color: 'bfd4f2'
+  description: Issues or PRs related to the Helm chart (charts/cloudflare-tunnel-gateway-controller)
+
+- name: area/ci
+  color: 'bfd4f2'
+  description: Issues or PRs related to CI workflows, GitHub Actions, release automation
+  aliases: ['ci']
+
+- name: area/docs
+  color: 'bfd4f2'
+  description: Issues or PRs related to docs site (mkdocs, docs/, README.md)
+
+- name: area/testing
+  color: 'bfd4f2'
+  description: Issues or PRs related to test infrastructure (test/, conformance, e2e, integration)
+  aliases: ['test']
+
+- name: area/dependencies
+  color: 'bfd4f2'
+  description: Issues or PRs related to vendored dependencies, go.mod, Renovate updates
+  aliases: ['dependencies']
+
+- name: area/uncategorized
+  color: 'fbca04'
+  description: Fallback when no area/* fits; pick a concrete area when triaging or expand the taxonomy
+
+# ----------------------------------------------
+# do-not-merge/ -- PR merge blockers (Prow convention)
+# ----------------------------------------------
+
+- name: do-not-merge/work-in-progress
+  color: 'e11d21'
+  description: Indicates that a PR should not merge because it is a work in progress
+
+- name: do-not-merge/hold
+  color: 'e11d21'
+  description: Indicates that a PR should not merge because someone has issued /hold
+  aliases: ['status/blocked']
+
+# ----------------------------------------------
+# security/ -- security-finding severity and status
+# ----------------------------------------------
+
+- name: security
+  color: 'aaaaaa'
+  description: Security-related issues and features
+
+- name: security/critical
+  color: 'd73a4a'
+  description: Critical security vulnerability
+
+- name: security/high
+  color: 'e99695'
+  description: High severity security finding
+
+- name: security/medium
+  color: 'f9c513'
+  description: Medium severity security finding
+
+- name: security/low
+  color: '0e8a16'
+  description: Low severity security finding
+
+- name: security/triage-needed
+  color: 'fbca04'
+  description: Needs security triage
+
+- name: security/confirmed
+  color: '1d76db'
+  description: Confirmed vulnerability
+
+- name: security/false-positive
+  color: 'c5def5'
+  description: Triaged as false positive
+
+- name: security/accepted-risk
+  color: 'bfd4f2'
+  description: Risk accepted with justification
+
+- name: security/in-progress
+  color: '0075ca'
+  description: Fix in progress
+
+- name: security/fixed
+  color: '0e8a16'
+  description: Fix released
+
+# ----------------------------------------------
+# Community / standalone labels
+# ----------------------------------------------
+
+- name: epic
+  color: 'a335ee'
+  description: A large development increment that brings definite value to users
+
+- name: community
+  color: '97458a'
+  description: Community contributions are welcome in this issue
+
+- name: help wanted
+  color: '008672'
+  description: Extra attention is needed
+
+- name: good first issue
+  color: '7057ff'
+  description: Good for newcomers
+
+- name: upstream-issue
+  color: 'aaaaaa'
+  description: Requires resolving an issue in an upstream project
+
+- name: automated
+  color: 'ededed'
+  description: Created by automation
+
+- name: lgtm
+  color: '238636'
+  description: This PR has been approved by a maintainer
+
+- name: ok-to-test
+  color: '00ff00'
+  description: Indicates a non-member PR is safe to run CI on
+
+- name: go
+  color: '16e2e2'
+  description: Pull requests that update Go code (legacy Dependabot label; Renovate does not re-apply)
+
+- name: python
+  color: '2b67c6'
+  description: Pull requests that update Python code (legacy Dependabot label; Renovate does not re-apply)
+
+- name: Container Available
+  color: 'ededed'
+  description: Container image built and pushed for this PR (auto-applied by .github/workflows/pr-privileged.yaml)
+
+# ----------------------------------------------
+# size/ -- PR size (apply manually for now; no auto-labeler workflow exists)
+# ----------------------------------------------
+
+- name: size/XS
+  color: '00ff00'
+  description: This PR changes 0-9 lines, ignoring generated files
+
+- name: size/S
+  color: '77b800'
+  description: This PR changes 10-29 lines, ignoring generated files
+
+- name: size/M
+  color: 'ebb800'
+  description: This PR changes 30-99 lines, ignoring generated files
+
+- name: size/L
+  color: 'eb9500'
+  description: This PR changes 100-499 lines, ignoring generated files
+
+- name: size/XL
+  color: 'ff823f'
+  description: This PR changes 500-999 lines, ignoring generated files
+
+- name: size/XXL
+  color: 'ffb8b8'
+  description: This PR changes 1000+ lines, ignoring generated files

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -1,0 +1,51 @@
+name: Labels
+
+on:
+  pull_request:
+    paths:
+      - .github/labels.yml
+      - .github/workflows/labels.yaml
+  push:
+    branches: [master]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/labels.yaml
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4 * * 1'  # Mondays at 04:17 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: labels-sync
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install validator dependencies
+        run: pip install --quiet --requirement scripts/requirements-labels.txt
+
+      - name: Unit-test the validator
+        run: python3 -m pytest scripts/validate_labels_test.py -v
+
+      - name: Validate labels.yml schema
+        run: python3 scripts/validate-labels.py
+
+  sync:
+    needs: validate
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ temp/
 *.log
 site/
 
+# Python
+__pycache__/
+*.pyc
+.pytest_cache/
+
 # Kubebuilder
 bin/
 testbin/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,52 +438,84 @@ Before creating a PR, verify all checklist items from `.github/pull_request_temp
 
 ## GitHub Issue Labels
 
-When creating issues, apply labels from these categories:
+Labels follow the Kubernetes-style namespaced scheme. The authoritative source is `.github/labels.yml`, synced into the repo by `.github/workflows/labels.yaml` (EndBug/label-sync@v2). Edit the YAML and open a PR — the GitHub UI is effectively read-only because the next sync would overwrite manual edits.
 
-### Type (required)
+When creating issues, apply at minimum one `kind/*`, one `area/*`, one `priority/*`, and one `triage/*` (or `lifecycle/*` if already active). Size labels are applied manually — there is no auto-labeler workflow yet.
 
-- `bug` — Something isn't working
-- `enhancement` — New feature or request
-- `documentation` — Documentation improvements
-- `test` — Test coverage
-- `ci` — CI/CD and automation
-- `security` — Security-related
+### kind/ — issue or PR type (required)
 
-### Area (required)
+- `kind/bug` — Something isn't working
+- `kind/feature` — New feature or request
+- `kind/documentation` — Documentation improvements
+- `kind/cleanup` — Tech debt, refactor, code or process cleanup
+- `kind/regression` — Regression from a prior release
+- `kind/flake` — Flaky test
+- `kind/failing-test` — Consistently or frequently failing test
+- `kind/api-change` — Adds, removes, or otherwise changes an API
+- `kind/breaking-change` — Breaking API or behaviour change
+- `kind/support` — Support question
 
-- `area/controller` — Controller code
+### area/ — subsystem (required; extensible)
+
+- `area/controller` — Kubernetes controller (`internal/controller`, GatewayReconciler, route binding)
+- `area/proxy` — In-process L7 reverse proxy (`internal/proxy`, filters, transport)
+- `area/tunnel` — cloudflared tunnel bridge (`internal/tunnel`, GatewayOriginProxy, vendored fork)
+- `area/api` — GatewayClassConfig CRD and API types (`api/v1alpha1`)
 - `area/helm` — Helm chart
-- `area/api` — CRD and API types
-- `area/docs` — Documentation
+- `area/ci` — CI workflows and release automation
+- `area/docs` — docs site (`mkdocs`, `docs/`, README.md)
+- `area/testing` — Test infrastructure (`test/`, conformance, e2e, integration)
+- `area/dependencies` — Vendored deps, `go.mod`, Renovate updates
+- `area/uncategorized` — Fallback when no concrete `area/*` fits; pick a real area during triage or expand the taxonomy
 
-### Priority (required)
+Add a new `area/*` when there are 3+ open issues on the topic.
 
-- `priority/critical` — Blocks release, needs immediate attention
-- `priority/high` — Important for milestone
-- `priority/medium` — Should be done for milestone
-- `priority/low` — Nice to have, can defer
+Standalone labels not enumerated above (`epic`, `community`, `help wanted`, `good first issue`, `upstream-issue`, `automated`, `lgtm`, `ok-to-test`, `go`, `python`, `Container Available`) live in `.github/labels.yml` — that file is the authoritative full catalog.
 
-### Status (required)
+### priority/ — urgency (required)
 
-- `status/needs-triage` — Requires analysis
-- `status/needs-design` — Requires design/RFC
-- `status/ready` — Ready to work on
-- `status/in-progress` — Currently being worked on
-- `status/blocked` — Blocked by dependency
-- `status/needs-info` — Waiting for clarification
-- `status/needs-review` — Waiting for review/feedback
+- `priority/critical-urgent` — Must be top priority right now
+- `priority/important-soon` — Currently being staffed, ideally in time for the next release
+- `priority/important-longterm` — Important long-term, may need multiple releases
+- `priority/backlog` — General backlog priority
 
-### Size (required)
+### triage/ — review state (required for new issues)
 
-- `size/XS` — < 1 hour
-- `size/S` — 1-4 hours
-- `size/M` — 1-2 days
-- `size/L` — 3-5 days
-- `size/XL` — > 1 week
+- `triage/needs-triage` — Needs maintainer triage
+- `triage/accepted` — Ready to be actively worked on
+- `triage/needs-information` — More information needed
+- `triage/not-reproducible` — Cannot be reproduced as described
+- `triage/duplicate` — Duplicate of another issue
+- `triage/unresolved` — Cannot or will not be resolved
+
+### lifecycle/ — once work starts
+
+- `lifecycle/active` — Actively being worked on by a contributor
+- `lifecycle/frozen` — Should not auto-close due to staleness
+- `lifecycle/stale` — Stale due to no activity
+- `lifecycle/rotten` — Aged beyond stale; will auto-close
+
+### do-not-merge/ — PR merge blockers (Prow convention)
+
+- `do-not-merge/work-in-progress` — PR is a work in progress
+- `do-not-merge/hold` — Someone issued `/hold`; also used for "blocked by dependency"
+
+### size/ — PR size (apply manually)
+
+- `size/XS` — 0-9 lines
+- `size/S` — 10-29 lines
+- `size/M` — 30-99 lines
+- `size/L` — 100-499 lines
+- `size/XL` — 500-999 lines
+- `size/XXL` — 1000+ lines
+
+### security/ — security finding severity and status
+
+`security`, `security/critical`, `security/high`, `security/medium`, `security/low`, `security/triage-needed`, `security/confirmed`, `security/false-positive`, `security/accepted-risk`, `security/in-progress`, `security/fixed`.
 
 ### Milestone
 
-Always assign a milestone when creating issues (e.g., `v1.0.0`).
+Always assign a milestone when creating issues. The current active milestone is `v3.0.0`; anything bound to an earlier release line goes in the corresponding `vX.Y.Z` milestone if one exists.
 
 ## Conformance Testing
 

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     "helpers:pinGitHubActionDigests"
   ],
   "labels": [
-    "dependencies"
+    "area/dependencies"
   ],
   "platformAutomerge": true,
   "automergeStrategy": "squash",

--- a/scripts/requirements-labels.txt
+++ b/scripts/requirements-labels.txt
@@ -1,0 +1,8 @@
+# Dependencies for the labels validator (scripts/validate-labels.py and its
+# pytest sibling). Pinned so a Renovate-trackable diff lands on every
+# version bump.
+#
+# Used by the validate job in .github/workflows/labels.yaml.
+
+PyYAML==6.0.3
+pytest==9.0.3

--- a/scripts/validate-labels.py
+++ b/scripts/validate-labels.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Validate .github/labels.yml schema for the labels sync workflow.
+
+Rules enforced (all hard failures via exit 1):
+
+1. description <= 100 chars (GitHub REST API limit)
+2. color is a 6-char hex string without leading #
+3. unique top-level names
+4. aliases do not collide with any top-level name
+5. aliases do not collide across labels (same legacy name cannot belong to two
+   different canonical owners; EndBug/label-sync's "last one wins" behaviour
+   is not a contract we want to ship)
+6. any description that names a .github/workflows/X.yaml file must point at
+   one that actually exists; catches the "auto-applied by X" class of doc
+   drift where a label outlives its backing workflow.
+7. within a single label's aliases list, no duplicate entries
+   (`aliases: ['x', 'x']` would silently overwrite each other in the
+   cross-label collision check at rule 5).
+
+Used by .github/workflows/labels.yaml's validate job. Extracted out of an
+inline heredoc so it can be covered by unit tests
+(scripts/validate_labels_test.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from typing import Iterable
+
+import yaml
+
+_WORKFLOW_REF_RE = re.compile(r'\.github/workflows/([\w.-]+\.ya?ml)')
+_HEX6_RE = re.compile(r'^[0-9A-Fa-f]{6}$')
+
+
+def validate(labels: list[dict], existing_workflows: Iterable[str]) -> list[str]:
+    """Apply all schema rules and return the list of error messages.
+
+    An empty list means the input is valid. Caller decides how to surface
+    errors (sys.exit, GitHub Actions ::error::, pytest assertion, etc.).
+    """
+    errors: list[str] = []
+    existing = set(existing_workflows)
+
+    # Rule 1: description length.
+    for label in labels:
+        desc = label.get('description', '') or ''
+        if len(desc) > 100:
+            errors.append(
+                f"{label['name']}: description {len(desc)} chars (max 100)"
+            )
+
+    # Rule 2: color format.
+    for label in labels:
+        color = label.get('color', '') or ''
+        if not _HEX6_RE.match(color):
+            errors.append(
+                f"{label['name']}: bad color {color!r} (must be 6-char hex without #)"
+            )
+
+    # Rule 3: unique top-level names.
+    names = [label['name'] for label in labels]
+    for dup in sorted({n for n in names if names.count(n) > 1}):
+        errors.append(f"duplicate name: {dup}")
+
+    # Rule 4: aliases do not collide with any top-level name.
+    name_set = set(names)
+    for label in labels:
+        for alias in label.get('aliases') or []:
+            if alias in name_set:
+                errors.append(
+                    f"alias {alias!r} (under {label['name']!r}) collides with a top-level name"
+                )
+
+    # Rule 5: aliases do not collide across labels.
+    alias_owner: dict[str, str] = {}
+    for label in labels:
+        for alias in label.get('aliases') or []:
+            if alias in alias_owner:
+                errors.append(
+                    f"alias {alias!r} listed under both {alias_owner[alias]!r} "
+                    f"and {label['name']!r} -- pick one canonical owner"
+                )
+            else:
+                alias_owner[alias] = label['name']
+
+    # Rule 7: no duplicate aliases inside a single label's list. Catches
+    # `aliases: ['x', 'x']` typos -- the second entry silently overwrites
+    # the first in alias_owner at rule 5, so rule 5 alone cannot see it.
+    for label in labels:
+        aliases = label.get('aliases') or []
+        if len(aliases) != len(set(aliases)):
+            seen: set[str] = set()
+            for alias in aliases:
+                if alias in seen:
+                    errors.append(
+                        f"{label['name']}: alias {alias!r} listed more than once"
+                    )
+                seen.add(alias)
+
+    # Rule 6: descriptions cannot reference workflow files that do not
+    # exist. Order in this function is "rule 7 first (works on aliases),
+    # then rule 6 (works on descriptions)" because the alias-cleanliness
+    # checks group naturally together; the docstring lists rules in
+    # numeric order, which matches the validate-time evaluation only
+    # incidentally. Keeping numeric and execution orders independent so
+    # rules can be reordered without renumbering test names.
+    for label in labels:
+        desc = label.get('description', '') or ''
+        for referenced in _WORKFLOW_REF_RE.findall(desc):
+            if referenced not in existing:
+                errors.append(
+                    f"{label['name']}: description references missing workflow "
+                    f".github/workflows/{referenced}"
+                )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--labels-file',
+        default='.github/labels.yml',
+        help='Path to labels.yml',
+    )
+    parser.add_argument(
+        '--workflow-dir',
+        default='.github/workflows',
+        help='Directory checked by rule 6 for referenced workflow files',
+    )
+    args = parser.parse_args()
+
+    with open(args.labels_file, encoding='utf-8') as handle:
+        labels = yaml.safe_load(handle)
+
+    existing_workflows: list[str] = []
+    if os.path.isdir(args.workflow_dir):
+        existing_workflows = os.listdir(args.workflow_dir)
+
+    errors = validate(labels, existing_workflows)
+
+    if errors:
+        for err in errors:
+            print(f"::error::{err}")
+        return 1
+
+    aliases_total = sum(len(label.get('aliases') or []) for label in labels)
+    print(f"labels.yml schema OK ({len(labels)} labels, {aliases_total} aliases)")
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/validate_labels_test.py
+++ b/scripts/validate_labels_test.py
@@ -1,0 +1,247 @@
+"""Unit tests for scripts/validate-labels.py.
+
+Each rule has both a happy-path case (valid input → no errors) and at least
+one failing case (invalid input → specific error message). Without these,
+a regression that breaks one of the rules would silently pass the validate
+job and let bad data through.
+
+Run with: python3 -m pytest scripts/validate_labels_test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+import yaml
+
+_VALIDATOR_PATH = pathlib.Path(__file__).parent / 'validate-labels.py'
+_spec = importlib.util.spec_from_file_location('validate_labels', _VALIDATOR_PATH)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+validate = _module.validate
+
+
+def _label(name: str, **kwargs) -> dict:
+    """Build a minimal valid label dict; tests override one field at a time."""
+    return {
+        'name': name,
+        'color': 'aaaaaa',
+        'description': 'short',
+        **kwargs,
+    }
+
+
+def test_happy_path_no_errors():
+    labels = [_label('kind/bug'), _label('priority/backlog')]
+    assert validate(labels, existing_workflows=[]) == []
+
+
+def test_rule1_description_too_long():
+    long_desc = 'x' * 101
+    labels = [_label('kind/bug', description=long_desc)]
+    errs = validate(labels, existing_workflows=[])
+    assert len(errs) == 1
+    assert 'description 101 chars' in errs[0]
+
+
+def test_rule1_description_exactly_100_ok():
+    labels = [_label('kind/bug', description='x' * 100)]
+    assert validate(labels, existing_workflows=[]) == []
+
+
+def test_rule2_color_missing_hex_chars():
+    labels = [_label('kind/bug', color='xyz123')]
+    errs = validate(labels, existing_workflows=[])
+    assert len(errs) == 1
+    assert 'bad color' in errs[0]
+
+
+def test_rule2_color_with_hash_prefix_rejected():
+    labels = [_label('kind/bug', color='#aaaaaa')]
+    errs = validate(labels, existing_workflows=[])
+    assert len(errs) == 1
+
+
+def test_rule3_duplicate_top_level_name():
+    labels = [_label('kind/bug'), _label('kind/bug', color='ffffff')]
+    errs = validate(labels, existing_workflows=[])
+    # Note: rule 3 reports duplicate once, but rule 4/5 may also flag a
+    # downstream effect; we only care that the duplicate is caught.
+    assert any('duplicate name: kind/bug' in e for e in errs)
+
+
+def test_rule4_alias_collides_with_top_level_name():
+    labels = [
+        _label('kind/bug', aliases=['kind/feature']),
+        _label('kind/feature'),
+    ]
+    errs = validate(labels, existing_workflows=[])
+    assert any('collides with a top-level name' in e for e in errs)
+
+
+def test_rule5_alias_double_owned_across_labels():
+    labels = [
+        _label('triage/needs-information', aliases=['status/needs-info']),
+        _label('triage/needs-triage', aliases=['status/needs-info']),
+    ]
+    errs = validate(labels, existing_workflows=[])
+    assert any(
+        "listed under both 'triage/needs-information'" in e
+        and "'triage/needs-triage'" in e
+        for e in errs
+    )
+
+
+def test_rule7_duplicate_alias_within_label():
+    """Catches `aliases: ['x', 'x']` typos that rule 5 cannot see (the second
+    entry silently overwrites in alias_owner)."""
+    labels = [
+        _label('kind/bug', aliases=['old-bug', 'old-bug']),
+    ]
+    errs = validate(labels, existing_workflows=[])
+    assert any("alias 'old-bug' listed more than once" in e for e in errs)
+
+
+def test_rule7_distinct_aliases_within_label_ok():
+    labels = [
+        _label('triage/needs-information', aliases=['status/needs-info', 'status/needs-design']),
+    ]
+    assert validate(labels, existing_workflows=[]) == []
+
+
+def test_rule6_description_names_missing_workflow():
+    labels = [
+        _label(
+            'kind/bug',
+            description='auto-applied by .github/workflows/pr-size.yaml',
+        ),
+    ]
+    errs = validate(labels, existing_workflows=['labels.yaml', 'pr.yaml'])
+    assert len(errs) == 1
+    assert 'references missing workflow .github/workflows/pr-size.yaml' in errs[0]
+
+
+def test_rule6_description_names_existing_workflow_ok():
+    labels = [
+        _label(
+            'Container Available',
+            description=(
+                'Container image built; auto-applied by '
+                '.github/workflows/pr-privileged.yaml'
+            ),
+        ),
+    ]
+    assert validate(labels, existing_workflows=['pr-privileged.yaml']) == []
+
+
+def test_rule6_description_with_yml_suffix_caught():
+    """Tests both .yml and .yaml are recognised by the regex."""
+    labels = [
+        _label(
+            'kind/bug',
+            description='auto-applied by .github/workflows/ghost.yml',
+        ),
+    ]
+    errs = validate(labels, existing_workflows=['real.yaml'])
+    assert any('ghost.yml' in e for e in errs)
+
+
+def test_multiple_rules_fire_simultaneously():
+    """A single label may break multiple rules; all should surface."""
+    labels = [
+        _label('kind/bug', color='xyz', description='x' * 200),
+    ]
+    errs = validate(labels, existing_workflows=[])
+    assert any('description 200 chars' in e for e in errs)
+    assert any('bad color' in e for e in errs)
+
+
+def test_empty_input_no_errors():
+    assert validate([], existing_workflows=[]) == []
+
+
+def test_real_labels_yml_consumers_reference_only_top_level_names():
+    """Pins the migration's biggest hazard: every place outside labels.yml
+    that names a label by string (issue templates, renovate.json, etc.)
+    must reference a TOP-LEVEL label name. Referencing an alias would
+    work today but break the moment the sync runs and the alias gets
+    merged away. Referencing a name absent from labels.yml entirely is
+    Renovate's special hazard -- it auto-creates the missing label with
+    default color and no description, silently undoing the migration.
+
+    Run from the repo root so the file paths resolve.
+    """
+    repo_root = pathlib.Path(__file__).parent.parent
+    labels_file = repo_root / '.github' / 'labels.yml'
+
+    with labels_file.open(encoding='utf-8') as handle:
+        labels = yaml.safe_load(handle)
+
+    top_level_names = {label['name'] for label in labels}
+
+    referenced: list[tuple[str, str]] = []  # (source, label_name)
+
+    # Issue templates: parse the YAML front-matter `labels: a, b` line.
+    template_dir = repo_root / '.github' / 'ISSUE_TEMPLATE'
+    if template_dir.is_dir():
+        for template in sorted(template_dir.glob('*.md')):
+            text = template.read_text(encoding='utf-8')
+            for line in text.splitlines():
+                if line.startswith('labels:'):
+                    names = [n.strip() for n in line.split(':', 1)[1].split(',')]
+                    for name in names:
+                        if name:
+                            referenced.append((str(template.relative_to(repo_root)), name))
+                    break
+
+    # renovate.json: top-level "labels": [...] array.
+    renovate_path = repo_root / 'renovate.json'
+    if renovate_path.exists():
+        import json
+        renovate_cfg = json.loads(renovate_path.read_text(encoding='utf-8'))
+        for name in renovate_cfg.get('labels', []):
+            referenced.append(('renovate.json', name))
+
+    # GitHub Actions workflows: scan for `labels: ['x', 'y']` literals and
+    # actions/github-script `labels:` keys (both wire the GitHub label
+    # API). pr-privileged.yaml is the production case today (Container
+    # Available), and any future workflow that auto-labels lands here
+    # too.
+    import re
+    label_literal_re = re.compile(
+        r"labels:\s*\[\s*(?P<names>[^\]]*)\s*\]",
+        re.IGNORECASE,
+    )
+    workflows_dir = repo_root / '.github' / 'workflows'
+    if workflows_dir.is_dir():
+        for workflow in sorted(workflows_dir.glob('*.yaml')):
+            text = workflow.read_text(encoding='utf-8')
+            for match in label_literal_re.finditer(text):
+                raw = match.group('names')
+                # Items may be single- or double-quoted; strip both.
+                for item in raw.split(','):
+                    name = item.strip().strip("'").strip('"').strip()
+                    if name:
+                        referenced.append(
+                            (str(workflow.relative_to(repo_root)), name),
+                        )
+
+    assert referenced, 'sanity: expected to find at least one external label reference'
+
+    drift = [
+        (src, name) for src, name in referenced if name not in top_level_names
+    ]
+
+    assert not drift, (
+        'label references in consumer files do not match a top-level '
+        f'label in .github/labels.yml: {drift}. Either rename the '
+        'reference to a current top-level label, or add the missing '
+        "label to labels.yml. Using an alias here is wrong because the "
+        'sync will merge it away on the next reconcile.'
+    )
+
+
+if __name__ == '__main__':
+    raise SystemExit(pytest.main([__file__, '-v']))


### PR DESCRIPTION
## Summary

Migrate the repo's GitHub label taxonomy to the Kubernetes/Prow CNCF-style namespaced scheme used across CNCF projects (mirrored after `cozystack/cozystack/.github/labels.yml`). Same shape: `kind/*`, `priority/*`, `triage/*`, `lifecycle/*`, `area/*`, `do-not-merge/*`, `security/*`, `size/*`.

`EndBug/label-sync@v2.3.3` (SHA-pinned) reconciles the repo from `.github/labels.yml` on every push to `master`, with a validate-only pass on PRs so a schema-breaking edit cannot reach master.

## Changes

- `.github/labels.yml` -- new file; 64 labels, 20 aliases. Mirrors the cozystack scheme, tuned for this repo's subsystems (area/proxy, area/tunnel, area/controller, area/api, area/helm, area/testing, area/ci, area/docs, area/dependencies, area/uncategorized).
- `.github/workflows/labels.yaml` -- new workflow; validate on PRs, sync on master push / weekly cron / workflow_dispatch. Action SHAs pinned per the repo's `helpers:pinGitHubActionDigests` convention.
- `scripts/validate-labels.py` -- extracted from a workflow-inline heredoc; 7 schema rules (description length, hex color, name uniqueness, alias non-collision with top-level, alias non-collision across labels, workflow-ref existence, no in-list duplicate aliases).
- `scripts/validate_labels_test.py` -- 16 pytest unit tests covering all 7 rules (happy + failure case per rule) AND a `test_real_labels_yml_consumers_reference_only_top_level_names` cross-file consistency check that scans `.github/ISSUE_TEMPLATE/*.md`, `renovate.json`, and `.github/workflows/*.yaml` for label references and fails if any reference an alias or a non-existent label. Negative-control verified.
- `scripts/requirements-labels.txt` -- pinned `PyYAML==6.0.3` and `pytest==9.0.3` for Renovate-trackable diffs.
- `.gitignore` -- adds `__pycache__/`, `*.pyc`, `.pytest_cache/`.
- `.github/ISSUE_TEMPLATE/bug_report.md` -- `labels: bug` → `labels: kind/bug, triage/needs-triage`.
- `.github/ISSUE_TEMPLATE/feature_request.md` -- `labels: enhancement` → `labels: kind/feature, triage/needs-triage`.
- `renovate.json` -- `"labels": ["dependencies"]` → `"labels": ["area/dependencies"]`. Renovate auto-creates missing labels, so without this fix the migration would have been silently undone on the next Renovate PR.
- `CLAUDE.md` -- "GitHub Issue Labels" section rewritten end-to-end to describe the new taxonomy, the kind/area/priority/triage matrix required for new issues, and the rule that `.github/labels.yml` is the authoritative source.

## Migration mapping

Aliases let `EndBug/label-sync` rename existing labels in place without losing references on already-tagged issues/PRs:

```
bug                  -> kind/bug
enhancement          -> kind/feature
documentation        -> kind/documentation
question             -> kind/support
duplicate            -> triage/duplicate
wontfix              -> triage/unresolved
test                 -> area/testing
ci                   -> area/ci
dependencies         -> area/dependencies
priority/critical    -> priority/critical-urgent
priority/high        -> priority/important-soon
priority/medium      -> priority/important-longterm
priority/low         -> priority/backlog
status/needs-triage  -> triage/needs-triage
status/ready         -> triage/accepted
status/needs-info    -> triage/needs-information
status/needs-design  -> triage/needs-information
status/in-progress   -> lifecycle/active
status/needs-review  -> lifecycle/active
status/blocked       -> do-not-merge/hold
```

### Deliberately NOT aliased

- `invalid` -- zero attachments; obscure enough to let die rather than misroute.
- `research` -- the one tagged item is an RFC and needs manual re-categorisation; the alias would have funnelled it into `kind/cleanup`, which does not match.

Both stay in place because `delete-other-labels: false` in the sync config -- they become harmless orphans until manually retired.

### Semantic-loss consolidations (intentional)

- `status/needs-info` AND `status/needs-design` both → `triage/needs-information`. The distinction "info from reporter vs design RFC" is collapsed.
- `status/in-progress` AND `status/needs-review` both → `lifecycle/active`. The distinction "active work vs awaiting reviewer" is collapsed.

Both are deliberate: the upstream Kubernetes scheme is genuinely thinner than the old taxonomy here.

## Follow-up

Open issues and PRs will be re-categorised in a follow-up pass against the new namespace via `/categorize`. The two `status/needs-design`-tagged items will need manual decision about whether they belong in `triage/needs-information` or a freshly-added `triage/needs-design`.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [x] Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller`)
- [x] Helm lint passes (`helm lint charts/cloudflare-tunnel-gateway-controller`)
- [x] Helm README is up to date (`helm-docs charts/cloudflare-tunnel-gateway-controller`)
- [x] Validator tests pass (`python3 -m pytest scripts/validate_labels_test.py` → 16/16)
- [x] Validator clean on real YAML (`python3 scripts/validate-labels.py` → `64 labels, 20 aliases`)
- [ ] Manual testing -- the sync workflow runs only on push to master and weekly cron; first reconciliation happens after merge

## Documentation

- [x] CLAUDE.md "GitHub Issue Labels" section rewritten
- [x] No README change required (label catalog is internal to the repo)
- [x] `.github/labels.yml` carries inline category comments

## Checklist

- [x] Commit message follows semantic format (`chore(labels): migrate repo labels to CNCF-style namespaced scheme`)
- [x] No secrets or credentials in code
- [x] Breaking change documented -- bookmarked links like `issues?q=label:priority/critical` will need updating to `priority/critical-urgent` after sync
- [x] Related issues -- none directly; opens follow-up work to `/categorize` each existing issue/PR
