### PR TITLE
chore: reflow docs prose + cover cmd/proxy ws-options env plumbing

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -240,34 +240,70 @@ func envOrDefault(key, defaultValue string) string {
 	return defaultValue
 }
 
-// wsHandlerOptions reads PROXY_WS_DIAL_TIMEOUT and
-// PROXY_WS_HANDSHAKE_TIMEOUT from the environment and turns them into
-// proxy.HandlerOption values for NewHandler. Unset / unparseable /
-// non-positive values are silently ignored (the proxy.With* helpers
-// gate on >0), so the package default (30s) stays in place. Logs a
-// WARN on parse failure so a typo'd env var doesn't silently fall back
-// to the default with no diagnostic.
-func wsHandlerOptions(logger *slog.Logger) []proxy.HandlerOption {
-	var opts []proxy.HandlerOption
+// parseWSEnvDurations reads PROXY_WS_DIAL_TIMEOUT and
+// PROXY_WS_HANDSHAKE_TIMEOUT from the environment and parses them as
+// time.Duration. Returns zero for unset / empty / unparseable values
+// so a downstream proxy.With* helper (which gates on > 0) treats them
+// as "no override". Logs a WARN on parse failure so a typo'd env var
+// doesn't silently fall back to the default with no diagnostic.
+//
+// Split from wsHandlerOptions so the env-var-to-duration translation
+// can be unit-tested directly without the HandlerOption indirection;
+// callers that need the proxy plumbing use wsHandlerOptions, which
+// composes this helper with the proxy.With* constructors.
+func parseWSEnvDurations(logger *slog.Logger) (time.Duration, time.Duration) {
+	dialTimeout := parseEnvDuration(logger, "PROXY_WS_DIAL_TIMEOUT")
+	handshakeTimeout := parseEnvDuration(logger, "PROXY_WS_HANDSHAKE_TIMEOUT")
 
-	if raw := os.Getenv("PROXY_WS_DIAL_TIMEOUT"); raw != "" {
-		parsed, err := time.ParseDuration(raw)
-		if err != nil {
-			logger.Warn("PROXY_WS_DIAL_TIMEOUT failed to parse -- keeping default 30s",
-				"value", raw, "error", err)
-		} else {
-			opts = append(opts, proxy.WithWSDialTimeout(parsed))
-		}
+	return dialTimeout, handshakeTimeout
+}
+
+// parseEnvDuration is the per-env-var primitive: zero on unset / empty
+// / parse failure, parsed duration otherwise. Note that negative
+// durations parse successfully (time.ParseDuration accepts "-5s") and
+// pass through as-is; the downstream > 0 gate in wsHandlerOptions
+// drops them so the proxy defaults still apply. WARN on parse failure
+// names both the env var and the offending value.
+//
+// "WARN + zero" rather than fail-loud is deliberate for these tunables:
+// the proxy MUST start with the package defaults if the operator's
+// override is malformed (a misconfigured timeout shouldn't kill the
+// whole tunnel). The WARN ensures the typo doesn't hide; the
+// downstream zero-fallback in wsHandlerOptions ensures the
+// previously-working behaviour stays the same. For non-tunable env
+// vars (credentials, tunnel ID), a parse failure should fail-loud --
+// don't copy this swallow pattern there.
+func parseEnvDuration(logger *slog.Logger, name string) time.Duration {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return 0
 	}
 
-	if raw := os.Getenv("PROXY_WS_HANDSHAKE_TIMEOUT"); raw != "" {
-		parsed, err := time.ParseDuration(raw)
-		if err != nil {
-			logger.Warn("PROXY_WS_HANDSHAKE_TIMEOUT failed to parse -- keeping default 30s",
-				"value", raw, "error", err)
-		} else {
-			opts = append(opts, proxy.WithWSHandshakeReadTimeout(parsed))
-		}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		logger.Warn(name+" failed to parse -- keeping default",
+			"value", raw, "error", err)
+
+		return 0
+	}
+
+	return parsed
+}
+
+// wsHandlerOptions composes parseWSEnvDurations with the proxy.With*
+// option constructors. Zero durations (unset / unparseable env vars)
+// flow through as no-op options because the With* helpers drop them.
+func wsHandlerOptions(logger *slog.Logger) []proxy.HandlerOption {
+	dialTimeout, handshakeTimeout := parseWSEnvDurations(logger)
+
+	var opts []proxy.HandlerOption
+
+	if dialTimeout > 0 {
+		opts = append(opts, proxy.WithWSDialTimeout(dialTimeout))
+	}
+
+	if handshakeTimeout > 0 {
+		opts = append(opts, proxy.WithWSHandshakeReadTimeout(handshakeTimeout))
 	}
 
 	return opts

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,4 +88,172 @@ func TestConstants(t *testing.T) {
 
 	assert.Equal(t, ":8081", defaultConfigAddr)
 	assert.Equal(t, ":8080", defaultProxyAddr)
+}
+
+// TestParseWSEnvDurations_Matrix pins the env-var-to-duration
+// translation in parseWSEnvDurations: three branches per env var
+// (unset / unparseable / parseable). Without this, a future edit
+// that swaps PROXY_WS_DIAL_TIMEOUT and PROXY_WS_HANDSHAKE_TIMEOUT,
+// typos one of them, or wires the dial result to the handshake env
+// would silently fall through to the 30s package default with no
+// test catching it.
+//
+// Parsing tested directly (not through the wsHandlerOptions ->
+// proxy.NewHandler -> EffectiveWS*ForTest chain) because the
+// EffectiveWS*ForTest helpers live in internal/proxy/export_test.go
+// and are invisible to cmd/proxy. The downstream wsHandlerOptions
+// composition is mechanical: zero -> no opt, > 0 -> With* opt; the
+// proxy package's TestNewHandler_WSTimeoutOptions exhaustively pins
+// that translation. Testing the env-parse boundary here closes the
+// gap end-to-end.
+func TestParseWSEnvDurations_Matrix(t *testing.T) {
+	tests := []struct {
+		name              string
+		dialEnv           string
+		handshakeEnv      string
+		setDialEnv        bool
+		setHandshakeEnv   bool
+		wantDial          time.Duration
+		wantHandshakeRead time.Duration
+		wantWarn          bool
+	}{
+		{
+			name:              "both env vars unset returns zeros",
+			wantDial:          0,
+			wantHandshakeRead: 0,
+		},
+		{
+			name:              "parseable dial env returns the parsed duration",
+			dialEnv:           "5s",
+			setDialEnv:        true,
+			wantDial:          5 * time.Second,
+			wantHandshakeRead: 0,
+		},
+		{
+			name:              "parseable handshake env returns the parsed duration",
+			handshakeEnv:      "7s",
+			setHandshakeEnv:   true,
+			wantDial:          0,
+			wantHandshakeRead: 7 * time.Second,
+		},
+		{
+			name:              "both parseable values returned independently",
+			dialEnv:           "2s",
+			handshakeEnv:      "3s",
+			setDialEnv:        true,
+			setHandshakeEnv:   true,
+			wantDial:          2 * time.Second,
+			wantHandshakeRead: 3 * time.Second,
+		},
+		{
+			name:              "unparseable dial env returns zero and warns",
+			dialEnv:           "bogus",
+			setDialEnv:        true,
+			wantDial:          0,
+			wantHandshakeRead: 0,
+			wantWarn:          true,
+		},
+		{
+			name:              "unparseable handshake env returns zero and warns",
+			handshakeEnv:      "also-bogus",
+			setHandshakeEnv:   true,
+			wantDial:          0,
+			wantHandshakeRead: 0,
+			wantWarn:          true,
+		},
+		{
+			name:              "empty string is treated as unset",
+			dialEnv:           "",
+			setDialEnv:        true,
+			wantDial:          0,
+			wantHandshakeRead: 0,
+		},
+		{
+			// time.ParseDuration accepts negative durations, so parseEnvDuration
+			// returns them as-is. The > 0 gate in wsHandlerOptions then drops
+			// the resulting option so the proxy defaults stick. Pinning the
+			// parse-side behaviour here keeps the gate's purpose visible -- if
+			// someone widens the gate to >= 0, this case still passes the
+			// parsing step and the matching TestWSHandlerOptions_OptionCount
+			// case ("negative dial => no opts") catches the dropped guard.
+			name:              "negative dial is parseable and passes through",
+			dialEnv:           "-5s",
+			setDialEnv:        true,
+			wantDial:          -5 * time.Second,
+			wantHandshakeRead: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Parallel skipped: t.Setenv mutates process env, must run sequentially.
+			if tt.setDialEnv {
+				t.Setenv("PROXY_WS_DIAL_TIMEOUT", tt.dialEnv)
+			} else {
+				_ = os.Unsetenv("PROXY_WS_DIAL_TIMEOUT")
+			}
+
+			if tt.setHandshakeEnv {
+				t.Setenv("PROXY_WS_HANDSHAKE_TIMEOUT", tt.handshakeEnv)
+			} else {
+				_ = os.Unsetenv("PROXY_WS_HANDSHAKE_TIMEOUT")
+			}
+
+			var logBuf bytes.Buffer
+
+			logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+			dial, handshake := parseWSEnvDurations(logger)
+
+			assert.Equal(t, tt.wantDial, dial,
+				"dial duration must match expectation for env=%q", tt.dialEnv)
+			assert.Equal(t, tt.wantHandshakeRead, handshake,
+				"handshake duration must match expectation for env=%q", tt.handshakeEnv)
+
+			if tt.wantWarn {
+				assert.Contains(t, logBuf.String(), "failed to parse",
+					"unparseable env var must surface a WARN")
+			} else {
+				assert.NotContains(t, logBuf.String(), "failed to parse",
+					"parseable / unset env vars must NOT warn")
+			}
+		})
+	}
+}
+
+// TestWSHandlerOptions_OptionCount pins the composition shape: every
+// zero duration from parseWSEnvDurations drops to no option (so
+// downstream proxy defaults stick), every positive duration emits one
+// option. Catches a future regression that double-appends or drops
+// the > 0 gate.
+func TestWSHandlerOptions_OptionCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		dialEnv       string
+		handshakeEnv  string
+		wantOptionLen int
+	}{
+		{name: "no envs => no opts", wantOptionLen: 0},
+		{name: "dial only", dialEnv: "1s", wantOptionLen: 1},
+		{name: "handshake only", handshakeEnv: "1s", wantOptionLen: 1},
+		{name: "both", dialEnv: "1s", handshakeEnv: "1s", wantOptionLen: 2},
+		{name: "unparseable dial => no opts", dialEnv: "bogus", wantOptionLen: 0},
+		// Negative duration parses cleanly but trips the > 0 gate in
+		// wsHandlerOptions, so no option is emitted. Pins the guard so a
+		// future "ge 0" widening fails here loudly instead of leaking a
+		// negative timeout into proxy.NewHandler.
+		{name: "negative dial => no opts", dialEnv: "-5s", wantOptionLen: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PROXY_WS_DIAL_TIMEOUT", tt.dialEnv)
+			t.Setenv("PROXY_WS_HANDSHAKE_TIMEOUT", tt.handshakeEnv)
+
+			logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+			opts := wsHandlerOptions(logger)
+			assert.Len(t, opts, tt.wantOptionLen)
+		})
+	}
 }

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,13 +1,10 @@
 # Architecture
 
-This document describes the internal architecture of the Cloudflare Tunnel
-Gateway Controller.
+This document describes the internal architecture of the Cloudflare Tunnel Gateway Controller.
 
 ## High-Level Overview
 
-The controller implements the Kubernetes Gateway API to configure Cloudflare
-Tunnel ingress rules. It watches Gateway and HTTPRoute resources and translates
-them into Cloudflare Tunnel configuration via the Cloudflare API.
+The controller implements the Kubernetes Gateway API to configure Cloudflare Tunnel ingress rules. It watches Gateway and HTTPRoute resources and translates them into Cloudflare Tunnel configuration via the Cloudflare API.
 
 ```mermaid
 flowchart TB
@@ -75,8 +72,7 @@ internal/
 
 ### GatewayClassConfig
 
-Cluster-scoped Custom Resource Definition (CRD) that provides tunnel
-configuration:
+Cluster-scoped Custom Resource Definition (CRD) that provides tunnel configuration:
 
 - **API Group**: `cf.k8s.lex.la/v1alpha1`
 - **Referenced by**: GatewayClass via `spec.parametersRef`
@@ -234,8 +230,7 @@ flowchart TB
 
 The controller follows these error handling patterns:
 
-1. **Retryable Errors**: Return `ctrl.Result{Requeue: true}` for transient
-   failures
+1. **Retryable Errors**: Return `ctrl.Result{Requeue: true}` for transient failures
 2. **Permanent Errors**: Log error and update resource status condition
 3. **API Errors**: Wrapped with context using `cockroachdb/errors`
 4. **Not Found**: Silently ignore (resource was deleted)
@@ -275,11 +270,7 @@ flowchart LR
 
 ## L7 Proxy Data Plane
 
-An in-process L7 proxy is embedded inside cloudflared via the
-`OverrideProxy` hook (using a [fork of cloudflared](https://github.com/lexfrei/cloudflared)).
-All tunnel traffic is intercepted by the proxy, which applies Gateway API
-routing rules before forwarding to backends. This removes most Cloudflare
-Tunnel ingress API limitations.
+An in-process L7 proxy is embedded inside cloudflared via the `OverrideProxy` hook (using a [fork of cloudflared](https://github.com/lexfrei/cloudflared)). All tunnel traffic is intercepted by the proxy, which applies Gateway API routing rules before forwarding to backends. This removes most Cloudflare Tunnel ingress API limitations.
 
 ```mermaid
 flowchart TB

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,12 +1,10 @@
 # Contributing
 
-Thank you for your interest in contributing to the Cloudflare Tunnel Gateway
-Controller!
+Thank you for your interest in contributing to the Cloudflare Tunnel Gateway Controller!
 
 ## Code of Conduct
 
-Be respectful and constructive in all interactions. We welcome contributors
-of all experience levels.
+Be respectful and constructive in all interactions. We welcome contributors of all experience levels.
 
 ## How to Contribute
 
@@ -88,9 +86,7 @@ chore(deps): update controller-runtime to v0.22.4
 
 ### Testing PR Changes
 
-Each PR automatically builds test artifacts. Links to test container images
-and Helm chart are posted as a comment on the PR, allowing you to test
-changes before merging.
+Each PR automatically builds test artifacts. Links to test container images and Helm chart are posted as a comment on the PR, allowing you to test changes before merging.
 
 ### PR Checklist
 
@@ -193,5 +189,4 @@ Releases are automated via GitHub Actions:
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under
-the BSD 3-Clause License.
+By contributing, you agree that your contributions will be licensed under the BSD 3-Clause License.

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,7 +1,6 @@
 # Development
 
-This section covers development setup, architecture, and contribution guidelines
-for the Cloudflare Tunnel Gateway Controller.
+This section covers development setup, architecture, and contribution guidelines for the Cloudflare Tunnel Gateway Controller.
 
 ## Overview
 

--- a/docs/development/proxy-architecture.md
+++ b/docs/development/proxy-architecture.md
@@ -4,9 +4,7 @@ This document describes the internal architecture of the L7 proxy data plane.
 
 ## Overview
 
-The proxy sits between cloudflared tunnel transport and backend Kubernetes
-services. It implements full Gateway API HTTPRoute routing locally, removing
-the limitations of Cloudflare's tunnel ingress API.
+The proxy sits between cloudflared tunnel transport and backend Kubernetes services. It implements full Gateway API HTTPRoute routing locally, removing the limitations of Cloudflare's tunnel ingress API.
 
 ```mermaid
 flowchart LR
@@ -83,8 +81,7 @@ sequenceDiagram
 
 ## Routing Table
 
-The router uses `atomic.Pointer[routingTable]` for lock-free reads during
-config updates:
+The router uses `atomic.Pointer[routingTable]` for lock-free reads during config updates:
 
 - **Exact hosts**: `map[string][]*compiledRule` for O(1) hostname lookup
 - **Wildcard hosts**: `[]wildcardEntry` for `*.example.com` patterns
@@ -112,8 +109,7 @@ Controller  ──PUT /config──▶  Proxy Config API
                               lock-free reads ◀── request goroutines
 ```
 
-Config versioning prevents stale updates. Each push includes a monotonically
-increasing version number; the proxy rejects versions older than current.
+Config versioning prevents stale updates. Each push includes a monotonically increasing version number; the proxy rejects versions older than current.
 
 ## Filters
 
@@ -146,20 +142,13 @@ Weighted random selection using cumulative weight sums:
 - Parse tunnel token (base64 JSON)
 - Build edge TLS configs (Cloudflare root CAs + system pool)
 - Create protocol selector (auto: QUIC preferred)
-- **In-process mode** (default): Set `OverrideProxy` on supervisor config to
-  route all requests directly to `proxy.Handler`, bypassing ingress rules entirely
-- **Standalone mode**: Build catch-all ingress to `http://localhost:PROXY_PORT`
-  so cloudflared forwards traffic to the local proxy HTTP server
+- **In-process mode** (default): Set `OverrideProxy` on supervisor config to route all requests directly to `proxy.Handler`, bypassing ingress rules entirely
+- **Standalone mode**: Build catch-all ingress to `http://localhost:PROXY_PORT` so cloudflared forwards traffic to the local proxy HTTP server
 - Start `supervisor.StartTunnelDaemon`
 
 ## Tunnel-Mode Response Writer Semantics
 
-When the proxy runs in in-process mode (production default), the
-`http.ResponseWriter` `proxy.Handler.ServeHTTP` receives is
-`cloudflared.connection.http2RespWriter`, NOT a stdlib HTTP/1.1 writer.
-The two have materially different contracts; missing the gap shipped a
-production-only WebSocket regression that two rounds of pre-merge code
-review failed to catch.
+When the proxy runs in in-process mode (production default), the `http.ResponseWriter` `proxy.Handler.ServeHTTP` receives is `cloudflared.connection.http2RespWriter`, NOT a stdlib HTTP/1.1 writer. The two have materially different contracts; missing the gap shipped a production-only WebSocket regression that two rounds of pre-merge code review failed to catch.
 
 | Behaviour | `httptest.NewServer` (HTTP/1.1) | `cloudflared.connection.http2RespWriter` |
 | --- | --- | --- |
@@ -169,70 +158,29 @@ review failed to catch.
 
 Practical consequences:
 
-- `httputil.ReverseProxy.handleUpgradeResponse` calls `Hijack` BEFORE
-  `WriteHeader`. Over HTTP/2 that fails; `ReverseProxy`'s default error
-  handler then writes 502 and the client sees a 502 (or a Cloudflare
-  edge-rewritten 403). This is the bug that motivated the custom
-  `proxyWebSocketUpgrade` path in `handler_websocket.go`.
-- Writing a status, hijacking, and bidirectionally piping bytes is the
-  correct shape for WebSocket and any future upgrade flow over the
-  tunnel; do NOT route them through `httputil.ReverseProxy`.
+- `httputil.ReverseProxy.handleUpgradeResponse` calls `Hijack` BEFORE `WriteHeader`. Over HTTP/2 that fails; `ReverseProxy`'s default error handler then writes 502 and the client sees a 502 (or a Cloudflare edge-rewritten 403). This is the bug that motivated the custom `proxyWebSocketUpgrade` path in `handler_websocket.go`.
+- Writing a status, hijacking, and bidirectionally piping bytes is the correct shape for WebSocket and any future upgrade flow over the tunnel; do NOT route them through `httputil.ReverseProxy`.
 
 ### Required test fixture for tunnel-mode paths
 
-Any proxy code that reads, writes, or hijacks the response MUST be
-covered by a test that runs through `fakeCloudflaredRespWriter`
-(`internal/proxy/handler_tunnelfake_test.go`), in addition to any
-existing `httptest.NewServer`-based coverage. The fake enforces the
-HTTP/2 contract above and reproduces production failures
-deterministically:
+Any proxy code that reads, writes, or hijacks the response MUST be covered by a test that runs through `fakeCloudflaredRespWriter` (`internal/proxy/handler_tunnelfake_test.go`), in addition to any existing `httptest.NewServer`-based coverage. The fake enforces the HTTP/2 contract above and reproduces production failures deterministically:
 
 - `Hijack` rejects unless `statusWritten == true`.
 - `WriteHeader(101)` is recorded as 200.
-- `WriteHeader` after `Hijack` is a silent no-op (mirroring
-  cloudflared's warn-and-return).
+- `WriteHeader` after `Hijack` is a silent no-op (mirroring cloudflared's warn-and-return).
 - Second `Hijack` returns `http.ErrHijacked`.
 
-Use the fake from the start of design — not as a last-mile add-on
-during local CI gates. If a test passes against `httptest.NewServer`
-and you have no fake-fixture coverage of the same code path, treat the
-green test as inconclusive for production behaviour.
+Use the fake from the start of design — not as a last-mile add-on during local CI gates. If a test passes against `httptest.NewServer` and you have no fake-fixture coverage of the same code path, treat the green test as inconclusive for production behaviour.
 
 ### Re-vendoring discipline
 
-When bumping the `lexfrei/cloudflared` fork (see CLAUDE.md `Cloudflared
-Fork`), re-verify each contract row in the table above against the new
-vendored sources. The fake's behaviour is pinned to the snapshot of
-cloudflared at fake-authoring time; an upstream rename or semantic
-change is silent until detected by hand. Tests that string-match the
-cloudflared error message ALSO won't catch drift because they assert
-against the fake's own copy of the string.
+When bumping the `lexfrei/cloudflared` fork (see CLAUDE.md `Cloudflared Fork`), re-verify each contract row in the table above against the new vendored sources. The fake's behaviour is pinned to the snapshot of cloudflared at fake-authoring time; an upstream rename or semantic change is silent until detected by hand. Tests that string-match the cloudflared error message ALSO won't catch drift because they assert against the fake's own copy of the string.
 
-Fix-up points to re-verify on every cloudflared rebase — at least one
-per contract row in the table above, in the same order:
+Fix-up points to re-verify on every cloudflared rebase — at least one per contract row in the table above, in the same order:
 
-- **Hijack precondition** — `fakeCloudflaredRespWriter.Hijack` and the
-  `errFakeStatusNotWritten` constant in
-  `internal/proxy/handler_tunnelfake_test.go`. The fake's error message
-  is pinned to the snapshot of cloudflared at fake-authoring time; if
-  upstream renames the message, update both the constant and any
-  assertion that string-matches against it.
-- **101 → 200 translation** — `fakeCloudflaredRespWriter.WriteHeader`
-  mirrors `cloudflared.connection.http2RespWriter.WriteRespHeaders`.
-  Both must keep collapsing `http.StatusSwitchingProtocols` to
-  `http.StatusOK`; if cloudflared changes the translation rule (e.g.
-  adds a different sentinel for Extended CONNECT WebSocket), update
-  the fake to match.
-- **WriteHeader after Hijack** — the silent-no-op branch in the fake's
-  `WriteHeader` (cloudflared logs a warning and returns; the fake
-  drops the warning). Re-verify the upstream still no-ops; if it
-  starts panicking or writing a second status, mirror the new
-  behaviour.
-- **Second `Hijack` returns `ErrHijacked`** — the fake's `hijacked`
-  flag short-circuits with the stdlib `http.ErrHijacked` sentinel.
-  Re-verify cloudflared still returns the same sentinel (and not a
-  custom error) for the second-call case.
+- **Hijack precondition** — `fakeCloudflaredRespWriter.Hijack` and the `errFakeStatusNotWritten` constant in `internal/proxy/handler_tunnelfake_test.go`. The fake's error message is pinned to the snapshot of cloudflared at fake-authoring time; if upstream renames the message, update both the constant and any assertion that string-matches against it.
+- **101 → 200 translation** — `fakeCloudflaredRespWriter.WriteHeader` mirrors `cloudflared.connection.http2RespWriter.WriteRespHeaders`. Both must keep collapsing `http.StatusSwitchingProtocols` to `http.StatusOK`; if cloudflared changes the translation rule (e.g. adds a different sentinel for Extended CONNECT WebSocket), update the fake to match.
+- **WriteHeader after Hijack** — the silent-no-op branch in the fake's `WriteHeader` (cloudflared logs a warning and returns; the fake drops the warning). Re-verify the upstream still no-ops; if it starts panicking or writing a second status, mirror the new behaviour.
+- **Second `Hijack` returns `ErrHijacked`** — the fake's `hijacked` flag short-circuits with the stdlib `http.ErrHijacked` sentinel. Re-verify cloudflared still returns the same sentinel (and not a custom error) for the second-call case.
 
-Treat the table as the authoritative contract and the list above as a
-mechanical checklist; if upstream adds a new contract row, the table,
-the fake, and this checklist all need a matching update.
+Treat the table as the authoritative contract and the list above as a mechanical checklist; if upstream adds a new contract row, the table, the fake, and this checklist all need a matching update.

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -1,7 +1,6 @@
 # Development Setup
 
-This guide covers setting up a development environment for the Cloudflare Tunnel
-Gateway Controller.
+This guide covers setting up a development environment for the Cloudflare Tunnel Gateway Controller.
 
 ## Prerequisites
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,7 +1,6 @@
 # Testing
 
-This guide covers testing standards and practices for the Cloudflare Tunnel
-Gateway Controller.
+This guide covers testing standards and practices for the Cloudflare Tunnel Gateway Controller.
 
 ## Running Tests
 
@@ -272,9 +271,7 @@ Tests run automatically in CI:
 
 ## Gateway API Conformance Tests
 
-Conformance tests validate that the controller implements the Gateway API
-specification correctly. These tests require a real Kubernetes cluster with
-a working Cloudflare Tunnel.
+Conformance tests validate that the controller implements the Gateway API specification correctly. These tests require a real Kubernetes cluster with a working Cloudflare Tunnel.
 
 ### Prerequisites
 
@@ -312,16 +309,12 @@ go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/... \
 Tests cover both Cloudflare Tunnel and L7 proxy features:
 
 - **Core (4):** SimpleSameNamespace, PathPrefixMatching, ExactPathMatching, MatchingAcrossRoutes
-- **Extended (18):** HeaderMatching, MethodMatching, QueryParamMatching, Weight,
-  RequestHeaderModifier, ResponseHeaderModifier, RequestRedirect, RegexPathMatching,
-  RegexHeaderMatching, RegexQueryParamMatching, PathMatchOrder, URLRewritePath,
-  URLRewriteHost, RequestMirror, RedirectPort, RedirectPath, CombinedMatching, MultipleMatchesOR
+- **Extended (18):** HeaderMatching, MethodMatching, QueryParamMatching, Weight, RequestHeaderModifier, ResponseHeaderModifier, RequestRedirect, RegexPathMatching, RegexHeaderMatching, RegexQueryParamMatching, PathMatchOrder, URLRewritePath, URLRewriteHost, RequestMirror, RedirectPort, RedirectPath, CombinedMatching, MultipleMatchesOR
 - **Gateway (2):** AcceptedCondition, ObservedGenerationBump
 
 ### Official Gateway API Conformance Suite
 
-The project integrates the official `sigs.k8s.io/gateway-api/conformance` suite
-with a custom `TunnelRoundTripper` that routes requests through Cloudflare edge.
+The project integrates the official `sigs.k8s.io/gateway-api/conformance` suite with a custom `TunnelRoundTripper` that routes requests through Cloudflare edge.
 
 ```bash
 # Run conformance tests (requires deployed controller + tunnel)

--- a/docs/gateway-api/grpcroute.md
+++ b/docs/gateway-api/grpcroute.md
@@ -1,7 +1,6 @@
 # GRPCRoute
 
-GRPCRoute enables routing gRPC traffic through Cloudflare Tunnel with
-service and method-level matching.
+GRPCRoute enables routing gRPC traffic through Cloudflare Tunnel with service and method-level matching.
 
 ## Basic Example
 
@@ -90,8 +89,7 @@ spec:
 
 ## Method Matching
 
-gRPC methods are mapped to HTTP/2 paths using the standard format
-`/package.Service/Method`.
+gRPC methods are mapped to HTTP/2 paths using the standard format `/package.Service/Method`.
 
 | Match Type | Example | Cloudflare Rule |
 |------------|---------|-----------------|
@@ -161,8 +159,7 @@ spec:
 
 ## Backend Selection with Weights
 
-When multiple backends are specified, the backend with the highest weight
-is selected:
+When multiple backends are specified, the backend with the highest weight is selected:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -240,11 +237,9 @@ kubectl get grpcroute my-grpc-route --output jsonpath='{.status.parents[*].condi
 
 ### Traffic Splitting
 
-The controller does NOT implement traffic splitting. When multiple backends
-have weights, the highest weight backend receives 100% of traffic.
+The controller does NOT implement traffic splitting. When multiple backends have weights, the highest weight backend receives 100% of traffic.
 
-For actual traffic splitting, deploy a gRPC-aware load balancer (e.g., Envoy)
-and point the GRPCRoute to it.
+For actual traffic splitting, deploy a gRPC-aware load balancer (e.g., Envoy) and point the GRPCRoute to it.
 
 ## Troubleshooting
 

--- a/docs/gateway-api/httproute.md
+++ b/docs/gateway-api/httproute.md
@@ -1,7 +1,6 @@
 # HTTPRoute
 
-HTTPRoute is the primary resource for configuring HTTP routing through
-Cloudflare Tunnel.
+HTTPRoute is the primary resource for configuring HTTP routing through Cloudflare Tunnel.
 
 ## Feature Support
 
@@ -136,8 +135,7 @@ spec:
 
 ## Backend Selection with Weights
 
-When multiple backends are specified, the backend with the highest weight
-is selected:
+When multiple backends are specified, the backend with the highest weight is selected:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -248,8 +246,7 @@ spec:
           port: 443
 ```
 
-The controller resolves ExternalName Services and routes traffic directly
-to the external hostname (`api.external.com:443` in this example).
+The controller resolves ExternalName Services and routes traffic directly to the external hostname (`api.external.com:443` in this example).
 
 !!! note "Port and Scheme"
 
@@ -341,8 +338,7 @@ Common causes:
 
 ### Cross-Namespace Reference Denied
 
-Ensure ReferenceGrant exists in the target namespace and allows your
-route's namespace.
+Ensure ReferenceGrant exists in the target namespace and allows your route's namespace.
 
 ```bash
 kubectl get referencegrant --namespace backend-namespace

--- a/docs/gateway-api/index.md
+++ b/docs/gateway-api/index.md
@@ -1,14 +1,10 @@
 # Gateway API
 
-This section documents the Gateway API implementation in the Cloudflare Tunnel
-Gateway Controller.
+This section documents the Gateway API implementation in the Cloudflare Tunnel Gateway Controller.
 
 ## Overview
 
-The controller implements the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/)
-to configure Cloudflare Tunnel ingress rules. It watches Gateway and Route
-resources and translates them into Cloudflare Tunnel configuration via the
-Cloudflare API.
+The controller implements the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) to configure Cloudflare Tunnel ingress rules. It watches Gateway and Route resources and translates them into Cloudflare Tunnel configuration via the Cloudflare API.
 
 ## Supported Resources
 

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -1,7 +1,6 @@
 # Limitations
 
-This document describes the known limitations of the Cloudflare Tunnel Gateway
-Controller and provides workarounds where applicable.
+This document describes the known limitations of the Cloudflare Tunnel Gateway Controller and provides workarounds where applicable.
 
 ## Cloudflare Tunnel API Constraints
 
@@ -10,8 +9,7 @@ Controller and provides workarounds where applicable.
     are fully supported. The proxy handles routing in-process, bypassing
     Cloudflare Tunnel ingress API limitations.
 
-The following features require the L7 proxy and are **not** available when
-running with only the Cloudflare Tunnel API:
+The following features require the L7 proxy and are **not** available when running with only the Cloudflare Tunnel API:
 
 | Feature | Without L7 proxy | With L7 proxy |
 | --- | --- | --- |
@@ -29,21 +27,18 @@ running with only the Cloudflare Tunnel API:
 
 ## Cloudflare Tunnel Path Matching Limitations
 
-Cloudflare Tunnel has specific path matching behavior that differs from Gateway
-API expectations:
+Cloudflare Tunnel has specific path matching behavior that differs from Gateway API expectations:
 
 ### No True Exact Path Match
 
-Cloudflare Tunnel does **not** support true exact path matching. A path rule
-without a wildcard (e.g., `/api`) will still match subpaths like `/api/v1`.
+Cloudflare Tunnel does **not** support true exact path matching. A path rule without a wildcard (e.g., `/api`) will still match subpaths like `/api/v1`.
 
 **Example:** If you configure:
 
 - `/api` (Exact) → backend-a
 - `/api` (PathPrefix) → backend-b
 
-Both `/api` and `/api/v1` will route to backend-a because Cloudflare treats
-all paths as prefixes internally.
+Both `/api` and `/api/v1` will route to backend-a because Cloudflare treats all paths as prefixes internally.
 
 **Workaround:** Use different base paths for different backends:
 
@@ -55,9 +50,7 @@ all paths as prefixes internally.
 
 ### Paths with Common Prefixes
 
-Paths sharing a common prefix may exhibit unexpected routing behavior. For
-example, `/multi-v1`, `/multi-v2`, and `/multi-v3` might all route to the
-first matching backend.
+Paths sharing a common prefix may exhibit unexpected routing behavior. For example, `/multi-v1`, `/multi-v2`, and `/multi-v3` might all route to the first matching backend.
 
 **Workaround:** Use distinct path prefixes:
 
@@ -94,28 +87,22 @@ This ensures predictable routing despite Cloudflare's limitations.
 
 ## Traffic Splitting and Load Balancing
 
-**Design Decision:** This controller intentionally does not implement traffic
-splitting or weighted load balancing between multiple backends.
+**Design Decision:** This controller intentionally does not implement traffic splitting or weighted load balancing between multiple backends.
 
 ### Why No Traffic Splitting?
 
-Cloudflare Tunnel ingress rules accept only a single service URL per rule.
-To support Gateway API's `backendRefs` with weights, the controller would
-need to:
+Cloudflare Tunnel ingress rules accept only a single service URL per rule. To support Gateway API's `backendRefs` with weights, the controller would need to:
 
 1. Create and manage intermediate Kubernetes Services
 2. Watch and synchronize Endpoints from all referenced services
 3. Handle cross-namespace references and RBAC
 4. Manage lifecycle of controller-created resources
 
-This approach introduces significant complexity, potential for orphaned
-resources, and creates an opaque traffic path that is difficult for users
-to debug.
+This approach introduces significant complexity, potential for orphaned resources, and creates an opaque traffic path that is difficult for users to debug.
 
 ### Our Approach
 
-Provide the tunnel a single, stable entrypoint. The controller selects the
-backend with the highest weight and sends 100% of traffic to it.
+Provide the tunnel a single, stable entrypoint. The controller selects the backend with the highest weight and sends 100% of traffic to it.
 
 ### Workarounds
 
@@ -138,8 +125,7 @@ spec:
 
 **Weighted traffic splitting or canary:**
 
-Deploy a dedicated load balancer (Traefik, Envoy, Nginx, HAProxy) and point
-the HTTPRoute to it:
+Deploy a dedicated load balancer (Traefik, Envoy, Nginx, HAProxy) and point the HTTPRoute to it:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -158,13 +144,11 @@ spec:
           port: 80
 ```
 
-This keeps the controller simple and predictable, and gives you full control
-over load balancing behavior.
+This keeps the controller simple and predictable, and gives you full control over load balancing behavior.
 
 ## SSL Certificate Limitations
 
-Cloudflare's free [Universal SSL](https://developers.cloudflare.com/ssl/edge-certificates/universal-ssl/limitations/)
-certificates only cover root and first-level subdomains:
+Cloudflare's free [Universal SSL](https://developers.cloudflare.com/ssl/edge-certificates/universal-ssl/limitations/) certificates only cover root and first-level subdomains:
 
 | Hostname | Covered | Notes |
 |----------|---------|-------|
@@ -178,14 +162,12 @@ certificates only cover root and first-level subdomains:
 
 For multi-level subdomains, you need:
 
-- [Advanced Certificate Manager](https://developers.cloudflare.com/ssl/edge-certificates/advanced-certificate-manager/)
-  ($10/month)
+- [Advanced Certificate Manager](https://developers.cloudflare.com/ssl/edge-certificates/advanced-certificate-manager/) ($10/month)
 - Business or Enterprise plan
 
 ## Gateway Listener Configuration
 
-Gateway listeners follow Gateway API specification. Some fields are ignored
-because Cloudflare Tunnel manages them at the edge:
+Gateway listeners follow Gateway API specification. Some fields are ignored because Cloudflare Tunnel manages them at the edge:
 
 | Field | Status | Notes |
 |-------|--------|-------|
@@ -195,14 +177,11 @@ because Cloudflare Tunnel manages them at the edge:
 | `tls` | Ignored | Cloudflare manages TLS |
 | `allowedRoutes` | Supported | Namespace (Same/All/Selector) and kind filtering |
 
-This is because Cloudflare Tunnel terminates TLS at Cloudflare's edge, not
-in the cluster. However, `hostname` and `allowedRoutes` are validated per
-Gateway API specification.
+This is because Cloudflare Tunnel terminates TLS at Cloudflare's edge, not in the cluster. However, `hostname` and `allowedRoutes` are validated per Gateway API specification.
 
 ## Backend Protocol (`Service.spec.ports[].appProtocol`)
 
-The L7 proxy reads the backend Service port's `appProtocol` to pick the upstream
-transport. The supported Kubernetes-defined values:
+The L7 proxy reads the backend Service port's `appProtocol` to pick the upstream transport. The supported Kubernetes-defined values:
 
 | `appProtocol` | Supported | Notes |
 | --- | --- | --- |
@@ -212,25 +191,11 @@ transport. The supported Kubernetes-defined values:
 | `kubernetes.io/wss` | Yes | Requires a `BackendTLSPolicy` targeting the Service (same precondition as `appProtocol: https`); without one the proxy logs a WARN and falls back to plaintext, which the backend will refuse |
 | any other value | No | Logged with a warning at conversion time; proxy falls back to default HTTP/1.1 |
 
-The upstream conformance test `HTTPRouteBackendProtocolWebSocket` is not
-testable through Cloudflare Tunnel: it dials the Gateway address directly via
-`golang.org/x/net/websocket.Dial` with no RoundTripper hook, and our Gateway
-address is `<tunnel-id>.cfargotunnel.com` whose AAAA records point at
-Cloudflare's ULA (`fd10::/8`), which is unreachable from any test runner.
-Same structural limitation as the gRPC conformance tests documented above.
-`test/e2e/e2e_backend_protocol_websocket_test.go` is the substitute proof —
-it runs an end-to-end WebSocket round trip against the real tunnel hostname.
+The upstream conformance test `HTTPRouteBackendProtocolWebSocket` is not testable through Cloudflare Tunnel: it dials the Gateway address directly via `golang.org/x/net/websocket.Dial` with no RoundTripper hook, and our Gateway address is `<tunnel-id>.cfargotunnel.com` whose AAAA records point at Cloudflare's ULA (`fd10::/8`), which is unreachable from any test runner. Same structural limitation as the gRPC conformance tests documented above. `test/e2e/e2e_backend_protocol_websocket_test.go` is the substitute proof — it runs an end-to-end WebSocket round trip against the real tunnel hostname.
 
 ### Interaction with `appProtocol: kubernetes.io/ws`
 
-When a backend Service carries both `appProtocol: kubernetes.io/ws` AND a
-`BackendTLSPolicy` targeting the same Service, the TLS policy wins:
-`resolveBackendTLS` rewrites the URL to `https://`, the proxy completes a
-TLS handshake, and the WebSocket upgrade runs over TLS regardless of the
-cleartext appProtocol hint. A WARN surfaces the suppressed `ws` hint so
-operators can either drop the BackendTLSPolicy (if they actually wanted
-cleartext WebSocket) or flip the hint to `kubernetes.io/wss` (if they
-wanted the TLS-protected variant all along).
+When a backend Service carries both `appProtocol: kubernetes.io/ws` AND a `BackendTLSPolicy` targeting the same Service, the TLS policy wins: `resolveBackendTLS` rewrites the URL to `https://`, the proxy completes a TLS handshake, and the WebSocket upgrade runs over TLS regardless of the cleartext appProtocol hint. A WARN surfaces the suppressed `ws` hint so operators can either drop the BackendTLSPolicy (if they actually wanted cleartext WebSocket) or flip the hint to `kubernetes.io/wss` (if they wanted the TLS-protected variant all along).
 
 ### `ResponseHeaderModifier` MUST preserve WebSocket handshake headers
 
@@ -242,68 +207,23 @@ Same guidance applies symmetrically to `Set` overriding these headers with a non
 
 ### Interaction with `spec.rules[].timeouts`
 
-`timeouts.request` and `timeouts.backendRequest` are enforced as **header-only
-deadlines** on the backend transport (`http.Transport.ResponseHeaderTimeout`),
-not as full-request context deadlines. The deadline bounds only the wait
-for backend response headers; once headers arrive, the body streams
-freely. Both Gateway API knobs collapse onto the same transport-level
-header timeout because this proxy has no retry logic — a single backend
-attempt is the whole request. When both knobs are set the stricter
-(`min(Request, Backend)`) value wins.
+`timeouts.request` and `timeouts.backendRequest` are enforced as **header-only deadlines** on the backend transport (`http.Transport.ResponseHeaderTimeout`), not as full-request context deadlines. The deadline bounds only the wait for backend response headers; once headers arrive, the body streams freely. Both Gateway API knobs collapse onto the same transport-level header timeout because this proxy has no retry logic — a single backend attempt is the whole request. When both knobs are set the stricter (`min(Request, Backend)`) value wins.
 
-This is a deliberate spec interpretation. The spec is underspecified on
-whether `timeouts.request` should kill an in-flight streaming response
-(Server-Sent Events, chunked transfer, large file downloads, gRPC
-server-streaming). A context-based deadline cancels the body read
-mid-stream and truncates the response at the timeout boundary, which is
-hostile to any streaming workload. The header-only deadline avoids that
-while still catching slow-to-respond backends in the dial-and-headers
-phase — exactly where timeouts are operationally useful.
+This is a deliberate spec interpretation. The spec is underspecified on whether `timeouts.request` should kill an in-flight streaming response (Server-Sent Events, chunked transfer, large file downloads, gRPC server-streaming). A context-based deadline cancels the body read mid-stream and truncates the response at the timeout boundary, which is hostile to any streaming workload. The header-only deadline avoids that while still catching slow-to-respond backends in the dial-and-headers phase — exactly where timeouts are operationally useful.
 
-Backends that take longer than the deadline to send response headers
-get a 504 Gateway Timeout to the client (the transport's
-`ResponseHeaderTimeout` error is mapped to 504 in `errorHandler`,
-parallel to the existing 504 for `context.DeadlineExceeded`).
+Backends that take longer than the deadline to send response headers get a 504 Gateway Timeout to the client (the transport's `ResponseHeaderTimeout` error is mapped to 504 in `errorHandler`, parallel to the existing 504 for `context.DeadlineExceeded`).
 
-Symmetric consequence on request uploads: per the stdlib godoc,
-`ResponseHeaderTimeout` starts measuring only _after_ the request body
-is fully written. A streaming or very large request upload (chunked
-PUT, multipart, gRPC client-streaming) is therefore NOT bounded by
-`timeouts.request` either. Operators who expected `timeouts.request`
-to act as an upload budget should know that the deadline starts only
-when the upload completes and the wait for response headers begins.
-The transport's connect timeout (dial / TLS handshake) still bounds
-the establishment phase.
+Symmetric consequence on request uploads: per the stdlib godoc, `ResponseHeaderTimeout` starts measuring only _after_ the request body is fully written. A streaming or very large request upload (chunked PUT, multipart, gRPC client-streaming) is therefore NOT bounded by `timeouts.request` either. Operators who expected `timeouts.request` to act as an upload budget should know that the deadline starts only when the upload completes and the wait for response headers begins. The transport's connect timeout (dial / TLS handshake) still bounds the establishment phase.
 
-The same shift removes the slow-loris-upload protection the old
-context-based deadline incidentally provided: a malicious client that
-drip-feeds request body bytes will keep the proxy → backend conn
-open as long as it sends at least one byte before the underlying TCP
-read timeout. The Cloudflare edge in front of the tunnel has its own
-upload deadlines, so the operational risk in production is bounded
-by edge policy rather than by `timeouts.request`. Per-rule
-upload-phase deadlines are out of scope for this knob and would need
-a separate mechanism (e.g. a wrapping `io.Reader` with its own
-inter-byte deadline) if ever required.
+The same shift removes the slow-loris-upload protection the old context-based deadline incidentally provided: a malicious client that drip-feeds request body bytes will keep the proxy → backend conn open as long as it sends at least one byte before the underlying TCP read timeout. The Cloudflare edge in front of the tunnel has its own upload deadlines, so the operational risk in production is bounded by edge policy rather than by `timeouts.request`. Per-rule upload-phase deadlines are out of scope for this knob and would need a separate mechanism (e.g. a wrapping `io.Reader` with its own inter-byte deadline) if ever required.
 
-WebSocket routes are naturally exempt: WS upgrades flow through the
-dedicated `proxyWebSocketUpgrade` path (because cloudflared's HTTP/2
-response writer cannot be hijacked the way stdlib `httputil.ReverseProxy`
-expects), and that path bypasses the cached transport entirely. Once
-the upgrade completes, two `io.Copy` goroutines pipe bytes
-bidirectionally between the hijacked client conn and the backend conn;
-they run until either side closes its conn.
+WebSocket routes are naturally exempt: WS upgrades flow through the dedicated `proxyWebSocketUpgrade` path (because cloudflared's HTTP/2 response writer cannot be hijacked the way stdlib `httputil.ReverseProxy` expects), and that path bypasses the cached transport entirely. Once the upgrade completes, two `io.Copy` goroutines pipe bytes bidirectionally between the hijacked client conn and the backend conn; they run until either side closes its conn.
 
-The `BackendProtocol: H2C` path uses `golang.org/x/net/http2.Transport`,
-which does not expose a `ResponseHeaderTimeout` knob. Per-rule timeouts
-therefore do not bound the header phase for h2c backends today; the
-h2c dialer's own connect timeout still catches a fully dead backend.
-Tracked as a follow-up.
+The `BackendProtocol: H2C` path uses `golang.org/x/net/http2.Transport`, which does not expose a `ResponseHeaderTimeout` knob. Per-rule timeouts therefore do not bound the header phase for h2c backends today; the h2c dialer's own connect timeout still catches a fully dead backend. Tracked as a follow-up.
 
 ## Backend mTLS (BackendTLSPolicy)
 
-The L7 proxy supports Gateway API `BackendTLSPolicy` for proxy → backend TLS,
-with the following minimum-viable scope:
+The L7 proxy supports Gateway API `BackendTLSPolicy` for proxy → backend TLS, with the following minimum-viable scope:
 
 | Behaviour | Status | Notes |
 | --- | --- | --- |
@@ -321,86 +241,38 @@ with the following minimum-viable scope:
 | `GatewayBackendClientCertificate` (mutual TLS) | Yes | The Gateway's `spec.tls.backend.clientCertificateRef` (Standard channel) loads a `kubernetes.io/tls` Secret and the proxy presents the keypair during backend TLS handshakes. Cross-namespace refs require ReferenceGrant. The client cert is attached **only** when the target Service has a `BackendTLSPolicy` — sending a cert over plaintext is meaningless. When an HTTPRoute attaches to multiple Gateways, the first parentRef managed by this controller that has a resolvable client cert wins; foreign-controller parents and parents without a cert are skipped, not blocking. The conformance test does not exercise this multi-parent edge case |
 | HTTPS-listener Re-encrypt (frontend TLS termination + backend TLS) | No | Cloudflare terminates TLS at the edge, so HTTPS listeners aren't supported (see the HTTPRoute HTTPS Listener limitation). The upstream `BackendTLSPolicy` parent test is skipped for the same reason |
 
-Policy status (`Accepted` / `ResolvedRefs`) is maintained per-Gateway-ancestor.
-Edits to the CA `ConfigMap` (creation, content patch, or deletion) re-trigger
-status reconciliation. The `Status.Ancestors` slice is capped at the spec's
-limit of 16 entries; entries are sorted deterministically by
-`{namespace, name}` so the truncated set stays stable across reconciles.
-`LastTransitionTime` is maintained via `meta.SetStatusCondition`, so it
-only flips when `Status`, `Reason`, or `Message` actually changes.
+Policy status (`Accepted` / `ResolvedRefs`) is maintained per-Gateway-ancestor. Edits to the CA `ConfigMap` (creation, content patch, or deletion) re-trigger status reconciliation. The `Status.Ancestors` slice is capped at the spec's limit of 16 entries; entries are sorted deterministically by `{namespace, name}` so the truncated set stays stable across reconciles. `LastTransitionTime` is maintained via `meta.SetStatusCondition`, so it only flips when `Status`, `Reason`, or `Message` actually changes.
 
 ### Fail-closed enforcement
 
-When a `BackendTLSPolicy` targets a Service but cannot be enforced — the CA
-`ConfigMap` is missing or unreadable, `ca.crt` is empty, or the bundle is
-malformed PEM — the proxy receives a poisoned TLS config (empty CA pool) and
-the next request to that Service fails with HTTP 502. It is NOT silently
-downgraded to plaintext. The operator's stated intent ("this hop MUST be
-authenticated TLS") is preserved. Monitor the policy's `Accepted` condition
-to detect the failure mode (`Reason=NoValidCACertificate`).
+When a `BackendTLSPolicy` targets a Service but cannot be enforced — the CA `ConfigMap` is missing or unreadable, `ca.crt` is empty, or the bundle is malformed PEM — the proxy receives a poisoned TLS config (empty CA pool) and the next request to that Service fails with HTTP 502. It is NOT silently downgraded to plaintext. The operator's stated intent ("this hop MUST be authenticated TLS") is preserved. Monitor the policy's `Accepted` condition to detect the failure mode (`Reason=NoValidCACertificate`).
 
 ### Interaction with `appProtocol: kubernetes.io/h2c`
 
-When a backend Service carries both `appProtocol: kubernetes.io/h2c` AND a
-`BackendTLSPolicy` targets it, the policy wins: the proxy dials TLS (HTTPS,
-with HTTP/2 negotiated via ALPN). h2c is by definition cleartext HTTP/2 and
-cannot coexist with backend TLS; the h2c marker is silently ignored on that
-hop. If you genuinely want HTTP/2 over TLS, omit the `appProtocol` hint and
-let ALPN negotiate it during the handshake.
+When a backend Service carries both `appProtocol: kubernetes.io/h2c` AND a `BackendTLSPolicy` targets it, the policy wins: the proxy dials TLS (HTTPS, with HTTP/2 negotiated via ALPN). h2c is by definition cleartext HTTP/2 and cannot coexist with backend TLS; the h2c marker is silently ignored on that hop. If you genuinely want HTTP/2 over TLS, omit the `appProtocol` hint and let ALPN negotiate it during the handshake.
 
 ### Gateway client cert rotation has a propagation lag
 
-The controller's existing Secret watch only matches the GatewayClassConfig's
-`cloudflareCredentialsSecretRef` and `tunnelTokenSecretRef`. A rotation of the
-`Secret` referenced by `spec.tls.backend.clientCertificateRef` (or by a
-listener's `certificateRefs`) does NOT enqueue the Gateway on its own — the
-proxy continues to dial backends with the previous keypair until some
-unrelated event (HTTPRoute create/update, BackendTLSPolicy change, periodic
-resync, controller restart) drives the next reconcile. On that reconcile the
-new keypair is loaded, the converter stamps it onto every affected
-`BackendTLSConfig`, and the per-cert transport-pool hash evicts the stale
-transport on the next config push.
+The controller's existing Secret watch only matches the GatewayClassConfig's `cloudflareCredentialsSecretRef` and `tunnelTokenSecretRef`. A rotation of the `Secret` referenced by `spec.tls.backend.clientCertificateRef` (or by a listener's `certificateRefs`) does NOT enqueue the Gateway on its own — the proxy continues to dial backends with the previous keypair until some unrelated event (HTTPRoute create/update, BackendTLSPolicy change, periodic resync, controller restart) drives the next reconcile. On that reconcile the new keypair is loaded, the converter stamps it onto every affected `BackendTLSConfig`, and the per-cert transport-pool hash evicts the stale transport on the next config push.
 
-In active clusters the propagation window is short, but operators that
-rotate certs more frequently than other Gateway-namespace events occur will
-observe stale-cert traffic until the next reconcile fires. Active hot-reload
-on a Secret-only change is a tracked follow-up — extending
-`ConfigMapper.MapSecretToRequests` to also match Gateway-level
-`clientCertificateRef` Secrets is the planned fix.
+In active clusters the propagation window is short, but operators that rotate certs more frequently than other Gateway-namespace events occur will observe stale-cert traffic until the next reconcile fires. Active hot-reload on a Secret-only change is a tracked follow-up — extending `ConfigMapper.MapSecretToRequests` to also match Gateway-level `clientCertificateRef` Secrets is the planned fix.
 
 ### RequestMirror filter does not honour BackendTLSPolicy
 
-The Gateway API `RequestMirror` filter sends a fire-and-forget copy of the
-request to a secondary backend through a side-channel HTTP client that does
-NOT share the proxy's TLS-aware transport pool. If a `BackendTLSPolicy`
-targets the mirror destination Service, the mirrored copy is sent in
-plaintext — the primary leg still respects the policy, but the mirror leg
-silently bypasses it.
+The Gateway API `RequestMirror` filter sends a fire-and-forget copy of the request to a secondary backend through a side-channel HTTP client that does NOT share the proxy's TLS-aware transport pool. If a `BackendTLSPolicy` targets the mirror destination Service, the mirrored copy is sent in plaintext — the primary leg still respects the policy, but the mirror leg silently bypasses it.
 
-The converter surfaces a WARN log when a mirror destination has a matching
-policy so operators don't ship a silent bypass. A TLS-aware mirror dial path
-is a tracked follow-up; until then, if the mirror destination MUST receive
-TLS, route mirror traffic through a separate Service without a policy or use
-weighted `backendRefs` instead of the mirror filter.
+The converter surfaces a WARN log when a mirror destination has a matching policy so operators don't ship a silent bypass. A TLS-aware mirror dial path is a tracked follow-up; until then, if the mirror destination MUST receive TLS, route mirror traffic through a separate Service without a policy or use weighted `backendRefs` instead of the mirror filter.
 
 ### Interaction with `appProtocol: https` / `HTTPS`
 
-`appProtocol: https` (or `HTTPS`) is treated as a hint that the backend
-expects TLS — but the proxy cannot dial TLS on its own without a CA to
-verify against. The behaviour:
+`appProtocol: https` (or `HTTPS`) is treated as a hint that the backend expects TLS — but the proxy cannot dial TLS on its own without a CA to verify against. The behaviour:
 
-- With a matching `BackendTLSPolicy`: the policy provides the CA, the proxy
-  dials TLS, and the request goes through normally. The `appProtocol` hint
-  is redundant but accepted silently.
-- Without a matching `BackendTLSPolicy`: the proxy logs a WARN and falls
-  back to plaintext HTTP/1.1. The misconfiguration is visible in logs so
-  operators don't ship a broken TLS expectation. Attach a `BackendTLSPolicy`
-  to upgrade the hop to authenticated TLS.
+- With a matching `BackendTLSPolicy`: the policy provides the CA, the proxy dials TLS, and the request goes through normally. The `appProtocol` hint is redundant but accepted silently.
+- Without a matching `BackendTLSPolicy`: the proxy logs a WARN and falls back to plaintext HTTP/1.1. The misconfiguration is visible in logs so operators don't ship a broken TLS expectation. Attach a `BackendTLSPolicy` to upgrade the hop to authenticated TLS.
 
 ## HTTP CORS filter (`HTTPRouteCORS`)
 
-The L7 proxy honours the Gateway API `HTTPCORSFilter` for both CORS preflight
-(OPTIONS + `Access-Control-Request-Method`) and simple cross-origin requests.
+The L7 proxy honours the Gateway API `HTTPCORSFilter` for both CORS preflight (OPTIONS + `Access-Control-Request-Method`) and simple cross-origin requests.
 
 | Behaviour | Status | Notes |
 | --- | --- | --- |
@@ -414,14 +286,7 @@ The L7 proxy honours the Gateway API `HTTPCORSFilter` for both CORS preflight
 | `exposeHeaders` | Yes | Joined with a comma+space separator and stamped on both preflight and simple responses. With `allowCredentials: true` and `exposeHeaders: ["*"]` the header is omitted entirely (spec forbids `*` with credentials) |
 | `maxAge` | Yes | Emitted as `Access-Control-Max-Age`. Defaults to 5 seconds when the policy carries 0 (matches the CRD default; applied at emit time so the controller doesn't need to mirror CRD-default logic) |
 
-Preflight handling: a matched OPTIONS preflight short-circuits with HTTP 204
-and the negotiated CORS headers — the backend is never hit. A preflight from
-a non-matched Origin still returns 204 but with no CORS headers, so the
-browser fails the cross-origin request on the client side. Simple
-cross-origin requests pass through to the backend and receive
-`Access-Control-Allow-Origin` (and credentials/expose headers when
-applicable) stamped on the way back; same-origin requests (no `Origin`
-header) are untouched.
+Preflight handling: a matched OPTIONS preflight short-circuits with HTTP 204 and the negotiated CORS headers — the backend is never hit. A preflight from a non-matched Origin still returns 204 but with no CORS headers, so the browser fails the cross-origin request on the client side. Simple cross-origin requests pass through to the backend and receive `Access-Control-Allow-Origin` (and credentials/expose headers when applicable) stamped on the way back; same-origin requests (no `Origin` header) are untouched.
 
 ## Route Types Not Supported
 
@@ -435,14 +300,12 @@ header) are untouched.
 
 For non-HTTP traffic:
 
-1. Use [Cloudflare Spectrum](https://www.cloudflare.com/products/cloudflare-spectrum/)
-   (separate product)
+1. Use [Cloudflare Spectrum](https://www.cloudflare.com/products/cloudflare-spectrum/) (separate product)
 2. Use a different ingress solution (LoadBalancer, NodePort)
 
 ## Full Sync Behavior
 
-Any change to an HTTPRoute or GRPCRoute triggers a full configuration sync
-to Cloudflare Tunnel. This means:
+Any change to an HTTPRoute or GRPCRoute triggers a full configuration sync to Cloudflare Tunnel. This means:
 
 1. Controller lists all HTTPRoutes and GRPCRoutes
 2. Filters by GatewayClass
@@ -471,8 +334,7 @@ Routes are processed in order:
 2. Longer prefix paths before shorter
 3. Alphabetically by hostname
 
-If routes conflict, the first match wins. The controller does not merge
-rules from different routes.
+If routes conflict, the first match wins. The controller does not merge rules from different routes.
 
 ### Example Conflict
 
@@ -496,13 +358,11 @@ rules:
       - name: api-v2
 ```
 
-Route B's `/api/v2` matches first (longer path), then Route A's `/api`
-matches remaining traffic.
+Route B's `/api/v2` matches first (longer path), then Route A's `/api` matches remaining traffic.
 
 ## No Multi-Cluster Support
 
-The controller only routes to Services within the same Kubernetes cluster.
-Cross-cluster routing is not supported.
+The controller only routes to Services within the same Kubernetes cluster. Cross-cluster routing is not supported.
 
 ### Workaround
 

--- a/docs/gateway-api/referencegrant.md
+++ b/docs/gateway-api/referencegrant.md
@@ -1,18 +1,12 @@
 # ReferenceGrant
 
-ReferenceGrant enables cross-namespace backend references in HTTPRoute and
-GRPCRoute resources. This is a security feature that requires explicit
-permission for a Route in one namespace to reference a Service in another
-namespace.
+ReferenceGrant enables cross-namespace backend references in HTTPRoute and GRPCRoute resources. This is a security feature that requires explicit permission for a Route in one namespace to reference a Service in another namespace.
 
 ## How It Works
 
-1. ReferenceGrant must be created in the **target namespace** (where the
-   Service is)
-2. It grants permission to routes in the **source namespace** to reference
-   Services in the target namespace
-3. Without a ReferenceGrant, cross-namespace backend references are denied
-   with `ResolvedRefs=False` status
+1. ReferenceGrant must be created in the **target namespace** (where the Service is)
+2. It grants permission to routes in the **source namespace** to reference Services in the target namespace
+3. Without a ReferenceGrant, cross-namespace backend references are denied with `ResolvedRefs=False` status
 
 ```mermaid
 flowchart LR

--- a/docs/gateway-api/supported-resources.md
+++ b/docs/gateway-api/supported-resources.md
@@ -1,7 +1,6 @@
 # Supported Resources
 
-This document details the feature support matrix for each Gateway API resource
-type in the Cloudflare Tunnel Gateway Controller.
+This document details the feature support matrix for each Gateway API resource type in the Cloudflare Tunnel Gateway Controller.
 
 ## Resource Overview
 
@@ -26,9 +25,7 @@ type in the Cloudflare Tunnel Gateway Controller.
 
 ## Gateway
 
-The Gateway resource is fully processed. Listeners are used for route binding,
-status reporting, and validation. TLS termination is handled by Cloudflare edge,
-but TLS certificate references are validated (including ReferenceGrant checks).
+The Gateway resource is fully processed. Listeners are used for route binding, status reporting, and validation. TLS termination is handled by Cloudflare edge, but TLS certificate references are validated (including ReferenceGrant checks).
 
 | Field | Supported | Notes |
 | --- | --- | --- |
@@ -55,8 +52,7 @@ but TLS certificate references are validated (including ReferenceGrant checks).
 
 ## HTTPRoute
 
-The L7 proxy enables full Gateway API HTTPRoute support. Without the proxy,
-only path-based routing through the Cloudflare Tunnel API is available.
+The L7 proxy enables full Gateway API HTTPRoute support. Without the proxy, only path-based routing through the Cloudflare Tunnel API is available.
 
 | Field | Supported | Notes |
 | --- | --- | --- |
@@ -84,8 +80,7 @@ only path-based routing through the Cloudflare Tunnel API is available.
 
 ### Backend Protocol (`appProtocol`)
 
-When an HTTPRoute references a Service whose target port sets `appProtocol`, the
-L7 proxy selects the upstream transport accordingly:
+When an HTTPRoute references a Service whose target port sets `appProtocol`, the L7 proxy selects the upstream transport accordingly:
 
 | `Service.spec.ports[].appProtocol` | Supported | Notes |
 | --- | --- | --- |
@@ -144,8 +139,7 @@ The following HTTPRoute filters are supported with the L7 proxy enabled:
 
 ## ReferenceGrant
 
-ReferenceGrant enables cross-namespace backend references in HTTPRoute and
-GRPCRoute resources.
+ReferenceGrant enables cross-namespace backend references in HTTPRoute and GRPCRoute resources.
 
 | Field | Supported | Notes |
 | --- | --- | --- |
@@ -177,8 +171,7 @@ See [ReferenceGrant](referencegrant.md) for detailed examples.
 
 ## gRPC Method Matching
 
-gRPC methods are mapped to HTTP/2 paths using the standard format
-`/package.Service/Method`.
+gRPC methods are mapped to HTTP/2 paths using the standard format `/package.Service/Method`.
 
 | Match Type | Example | Cloudflare Rule |
 | --- | --- | --- |

--- a/scripts/reflow-paragraphs.py
+++ b/scripts/reflow-paragraphs.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Reflow hard-wrapped paragraphs in markdown to one line per paragraph.
+
+Skips: fenced code blocks, indented code blocks (4+ space indent), headings,
+blockquotes, HTML tags, table rows, horizontal rules.
+
+List items are treated specially: a bullet plus any subsequent
+shallow-indented (1-3 space) non-blank lines collapse onto ONE line so the
+list-item continuation does not lose its association with the bullet.
+
+A "paragraph" is a run of consecutive prose lines bracketed by blank lines (or
+structural elements above). Within a paragraph, adjacent lines are joined with
+a single space.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+FENCE = re.compile(r'^\s*```')
+HEADING = re.compile(r'^#{1,6}\s')
+LIST_BULLET = re.compile(r'^\s*[-*+]\s')
+LIST_NUMBERED = re.compile(r'^\s*\d+\.\s')
+BLOCKQUOTE = re.compile(r'^\s*>')
+HR = re.compile(r'^\s*(?:-{3,}|\*{3,}|_{3,})\s*$')
+TABLE_ROW = re.compile(r'^\s*\|')
+HTML_BLOCK = re.compile(r'^\s*<(?:!--|/?[a-zA-Z])')
+INDENTED_CODE = re.compile(r'^    ')  # 4-space indent => code per CommonMark
+SHALLOW_INDENT = re.compile(r'^[ ]{1,3}\S')  # 1-3 space indent => list continuation
+
+
+def is_list_item(line: str) -> bool:
+    return bool(LIST_BULLET.match(line) or LIST_NUMBERED.match(line))
+
+
+def is_structural(line: str) -> bool:
+    """Lines that must stay as-is and break a paragraph."""
+    if not line.strip():
+        return True
+    if HEADING.match(line):
+        return True
+    if BLOCKQUOTE.match(line):
+        return True
+    if HR.match(line):
+        return True
+    if TABLE_ROW.match(line):
+        return True
+    if HTML_BLOCK.match(line):
+        return True
+    if INDENTED_CODE.match(line):
+        return True
+    return False
+
+
+def reflow(text: str) -> str:
+    out: list[str] = []
+    paragraph: list[str] = []
+    list_buffer: list[str] = []
+    in_fence = False
+
+    def flush_paragraph():
+        if paragraph:
+            out.append(' '.join(line.strip() for line in paragraph))
+            paragraph.clear()
+
+    def flush_list():
+        if list_buffer:
+            # Preserve the bullet line's leading indent so nested bullets
+            # stay nested. Only continuation lines are .strip()-ed and
+            # joined onto the bullet's tail.
+            first = list_buffer[0].rstrip()
+            rest = [line.strip() for line in list_buffer[1:]]
+            if rest:
+                out.append(first + ' ' + ' '.join(rest))
+            else:
+                out.append(first)
+            list_buffer.clear()
+
+    for line in text.splitlines():
+        if FENCE.match(line):
+            flush_paragraph()
+            flush_list()
+            out.append(line)
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            out.append(line)
+            continue
+        if is_list_item(line):
+            flush_paragraph()
+            flush_list()
+            list_buffer.append(line)
+            continue
+        # While a list item is open, ANY indented non-blank line is a
+        # continuation of THAT bullet -- even if the indent is 4+ spaces
+        # (which is_structural would otherwise classify as code). This
+        # is what lets nested-bullet continuations aligned to the inner
+        # bullet text (typically column 5 or deeper) stay attached.
+        if list_buffer and line and line[0] == ' ' and line.strip():
+            list_buffer.append(line)
+            continue
+        # Shallow-indented (1-3 space) line outside a list: continuation
+        # of the current paragraph.
+        if SHALLOW_INDENT.match(line):
+            paragraph.append(line)
+            continue
+        if is_structural(line):
+            flush_paragraph()
+            flush_list()
+            out.append(line)
+            continue
+        # Plain prose line at column 0: continues the current paragraph but
+        # closes any open list block.
+        flush_list()
+        paragraph.append(line)
+
+    flush_paragraph()
+    flush_list()
+
+    result = '\n'.join(out)
+    if text.endswith('\n'):
+        result += '\n'
+    return result
+
+
+def main() -> int:
+    for path in sys.argv[1:]:
+        with open(path, encoding='utf-8') as fh:
+            original = fh.read()
+        reflowed = reflow(original)
+        if reflowed != original:
+            with open(path, 'w', encoding='utf-8') as fh:
+                fh.write(reflowed)
+            print(f'reflowed: {path}')
+        else:
+            print(f'unchanged: {path}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/reflow_paragraphs_test.py
+++ b/scripts/reflow_paragraphs_test.py
@@ -1,0 +1,209 @@
+"""Unit tests for scripts/reflow-paragraphs.py.
+
+Pins the reflow rules + the list-item-continuation regression: the first
+docs/development/ reflow pass stripped the indent off shallow-indented
+list-item continuation lines, producing mid-bullet wraps that violate
+the project's prose-wrap rule. This test fixture exercises the exact
+shape that broke so a future edit to the reflow logic that re-introduces
+the bug fails here.
+
+Run with: python3 -m pytest scripts/reflow_paragraphs_test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_SCRIPT_PATH = pathlib.Path(__file__).parent / 'reflow-paragraphs.py'
+_spec = importlib.util.spec_from_file_location('reflow_paragraphs', _SCRIPT_PATH)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+reflow = _module.reflow
+
+
+def test_single_paragraph_collapses_to_one_line():
+    src = 'This is one paragraph\nspread across\nthree lines.\n'
+    assert reflow(src) == 'This is one paragraph spread across three lines.\n'
+
+
+def test_two_paragraphs_separated_by_blank_line():
+    src = 'First paragraph\nline two.\n\nSecond paragraph\nline two.\n'
+    expected = 'First paragraph line two.\n\nSecond paragraph line two.\n'
+    assert reflow(src) == expected
+
+
+def test_headings_are_paragraph_breaks():
+    src = '# Heading\nFirst line\nsecond line.\n'
+    expected = '# Heading\nFirst line second line.\n'
+    assert reflow(src) == expected
+
+
+def test_fenced_code_block_is_preserved_verbatim():
+    src = (
+        'Some prose\nwrapped.\n\n'
+        '```go\nfunc Foo() {\n    return\n}\n```\n\n'
+        'More prose\nwrapped.\n'
+    )
+    expected = (
+        'Some prose wrapped.\n\n'
+        '```go\nfunc Foo() {\n    return\n}\n```\n\n'
+        'More prose wrapped.\n'
+    )
+    assert reflow(src) == expected
+
+
+def test_indented_code_block_is_preserved():
+    # 4-space indent = CommonMark indented code; must NOT be reflowed.
+    src = 'Intro paragraph\nwrapped.\n\n    code line one\n    code line two\n'
+    expected = 'Intro paragraph wrapped.\n\n    code line one\n    code line two\n'
+    assert reflow(src) == expected
+
+
+def test_list_items_stay_separate():
+    src = '- first bullet\n- second bullet\n- third bullet\n'
+    # Each bullet is its own list paragraph -> stays on its own line.
+    assert reflow(src) == src
+
+
+def test_list_item_continuation_joins_onto_bullet_line():
+    """The regression that motivated the script fix.
+
+    Original docs had list items with shallow-indented (2-space)
+    continuation lines:
+
+        - **Mode**: Set X on Y to
+          do something with Z
+
+    The first reflow pass stripped the 2-space indent and emitted:
+
+        - **Mode**: Set X on Y to
+        do something with Z
+
+    Which is the forbidden mid-bullet wrap form. The correct behaviour
+    flattens the continuation onto the bullet line.
+    """
+    src = (
+        '- **Mode**: Set X on Y to\n'
+        '  do something with Z\n'
+        '- **Other**: shorter bullet\n'
+    )
+    expected = (
+        '- **Mode**: Set X on Y to do something with Z\n'
+        '- **Other**: shorter bullet\n'
+    )
+    assert reflow(src) == expected
+
+
+def test_list_item_with_multiple_continuation_lines():
+    src = (
+        '- **Mode**: line one\n'
+        '  line two\n'
+        '  line three\n'
+    )
+    expected = '- **Mode**: line one line two line three\n'
+    assert reflow(src) == expected
+
+
+def test_numbered_list_continuation_also_joins():
+    src = (
+        '1. **First**: line one\n'
+        '   line two\n'
+        '2. **Second**: short\n'
+    )
+    expected = (
+        '1. **First**: line one line two\n'
+        '2. **Second**: short\n'
+    )
+    assert reflow(src) == expected
+
+
+def test_blank_line_after_list_item_closes_the_list():
+    src = (
+        '- bullet text\n'
+        '  continuation\n'
+        '\n'
+        'New paragraph\n'
+        'wrapped.\n'
+    )
+    expected = (
+        '- bullet text continuation\n'
+        '\n'
+        'New paragraph wrapped.\n'
+    )
+    assert reflow(src) == expected
+
+
+def test_table_rows_preserved_verbatim():
+    src = (
+        'intro\nwrapped.\n\n'
+        '| col1 | col2 |\n'
+        '| --- | --- |\n'
+        '| a | b |\n'
+    )
+    expected = (
+        'intro wrapped.\n\n'
+        '| col1 | col2 |\n'
+        '| --- | --- |\n'
+        '| a | b |\n'
+    )
+    assert reflow(src) == expected
+
+
+def test_blockquote_preserved():
+    src = '> quoted line one\n> quoted line two\n\nprose\nwrapped.\n'
+    expected = '> quoted line one\n> quoted line two\n\nprose wrapped.\n'
+    assert reflow(src) == expected
+
+
+def test_empty_input_returns_empty():
+    assert reflow('') == ''
+
+
+def test_nested_list_preserves_indent():
+    """Nested bullets must keep their leading indent so the renderer
+    keeps the nesting. An earlier reflow pass .strip()-ed the bullet
+    line as well as continuations, collapsing nested bullets to col 0
+    and breaking the nesting (markdownlint flagged it as MD032 because
+    the dedented inner list lost its blank-line separator).
+    """
+    src = (
+        '1. Outer item:\n'
+        '   - inner bullet a\n'
+        '   - inner bullet b\n'
+        '2. Next outer item:\n'
+        '   - inner of second\n'
+    )
+    # Inner bullets keep their 3-space indent; outer numbered list items
+    # stay flush left. Continuation joining within inner bullets is
+    # NOT exercised here -- this test is about the structural preserve.
+    assert reflow(src) == src
+
+
+def test_nested_list_with_continuations():
+    """Nested bullet with a continuation line gets joined ONTO the
+    nested bullet (preserving the bullet's indent), not flattened to
+    the outer list's indent.
+    """
+    src = (
+        '1. Outer:\n'
+        '   - inner bullet starts here\n'
+        '     and continues on the next line\n'
+    )
+    expected = (
+        '1. Outer:\n'
+        '   - inner bullet starts here and continues on the next line\n'
+    )
+    assert reflow(src) == expected
+
+
+def test_idempotent_on_already_reflowed_text():
+    """Running reflow on its own output must not change anything."""
+    src = '# Heading\n\nFirst paragraph already on one line.\n\n- bullet one\n- bullet two\n'
+    assert reflow(reflow(src)) == reflow(src)
+
+
+if __name__ == '__main__':
+    raise SystemExit(pytest.main([__file__, '-v']))


### PR DESCRIPTION
# Pull Request

## Summary

Two scoped follow-ups bundled into one PR per the batched-delivery policy.

Closes #261 — reflow hard-wrapped paragraphs across `docs/development/` (6 files) and `docs/gateway-api/` (6 files) to single-line-per-paragraph per the project's prose-wrap rule, and vendor `scripts/reflow-paragraphs.py` + 16-case pytest suite so future passes can be re-run idempotently and the list-item-continuation regression that broke the first attempt is pinned.

Closes #275 — add direct test coverage for `cmd/proxy`'s env-var-to-`HandlerOption` plumbing. The `wsHandlerOptions` plumbing for `PROXY_WS_DIAL_TIMEOUT` / `PROXY_WS_HANDSHAKE_TIMEOUT` was uncovered: a future edit that swapped or typo'd the two env vars would silently fall through to the 30s default. Split `wsHandlerOptions` into three testable functions and add `TestParseWSEnvDurations_Matrix` (8 cases) + `TestWSHandlerOptions_OptionCount` (6 cases).

## Changes

- Reflow 12 markdown files under `docs/development/` and `docs/gateway-api/` to one-line-per-paragraph. Zero semantic change — only line-break placement moves.
- Vendor `scripts/reflow-paragraphs.py` and `scripts/reflow_paragraphs_test.py` (16 pytest cases including critical regressions for list-item continuation and nested-list indent preservation).
- Split `cmd/proxy/main.go`'s `wsHandlerOptions` into `parseEnvDuration` (per-env primitive), `parseWSEnvDurations` (both env vars), and `wsHandlerOptions` (option composition) so the env-parse boundary is testable without the `proxy.NewHandler` chain.
- Add 14 new Go tests in `cmd/proxy/main_test.go` covering both happy paths, parse failures (WARN-and-zero), empty-string-as-unset, and negative-duration-parses-but-drops-on-gate.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable) — `mkdocs build --strict` clean; reflow script idempotent (rerun reports `unchanged` for all touched files).

## Documentation

- [x] README updated (if needed) — N/A
- [x] Code comments added for complex logic — `parseEnvDuration` carries the "WARN + zero" rationale; `parseWSEnvDurations` documents the split-for-testability reason
- [x] CLAUDE.md updated (if workflow/standards changed) — N/A

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced — #261, #275

## Additional Notes

Reflow scope is intentionally limited to `docs/development/` and `docs/gateway-api/` (the directories called out in #261). Other doc sections (`docs/configuration/`, `docs/guides/`, `docs/operations/`, `docs/getting-started/`) remain hard-wrapped and will be handled in a follow-up sweep if needed.

The pytest suite is currently a local-only guard — not wired into CI. The reflow script is a one-shot tool, so the suite's role is to catch a future hand-edit to `reflow-paragraphs.py` regressing the list-item handling. Pre-commit hook or CI workflow can be added later if the script becomes load-bearing.
