### PR TITLE
ci: PR-chart pullPolicy=Always + wire reflow pytest into a workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -428,10 +428,21 @@ jobs:
           yq --inplace ".proxy.image.repository = \"${PROXY_IMAGE_REPO}\"" "${CHART_DIR}/values.yaml"
           yq --inplace ".proxy.image.tag = \"${IMAGE_TAG}\"" "${CHART_DIR}/values.yaml"
 
+          # PR charts publish a moving tag (pr-NNN-1d): same name, different
+          # digest on each push. The stable-release default (IfNotPresent)
+          # would keep the cached image on the node, so a rolling restart
+          # after a CI rebuild would NOT pull the new build. Flip both
+          # pullPolicy defaults to Always for PR charts only -- the source
+          # values.yaml is untouched on master, so stable releases keep
+          # IfNotPresent (production sanity).
+          yq --inplace ".image.pullPolicy = \"Always\"" "${CHART_DIR}/values.yaml"
+          yq --inplace ".proxy.image.pullPolicy = \"Always\"" "${CHART_DIR}/values.yaml"
+
           echo "Modified chart version: ${CHART_VERSION}"
           echo "Modified appVersion: ${APP_VERSION}"
           echo "Modified controller image: ${CONTROLLER_IMAGE_REPO}:${IMAGE_TAG}"
           echo "Modified proxy image:      ${PROXY_IMAGE_REPO}:${IMAGE_TAG}"
+          echo "Modified pullPolicy: Always (controller + proxy)"
 
       - name: Validate values.yaml image overrides
         run: |
@@ -443,8 +454,10 @@ jobs:
 
           controller_repo=$(yq --exit-status '.image.repository' "${CHART_DIR}/values.yaml")
           controller_tag=$(yq --exit-status '.image.tag' "${CHART_DIR}/values.yaml")
+          controller_pull=$(yq --exit-status '.image.pullPolicy' "${CHART_DIR}/values.yaml")
           proxy_repo=$(yq --exit-status '.proxy.image.repository' "${CHART_DIR}/values.yaml")
           proxy_tag=$(yq --exit-status '.proxy.image.tag' "${CHART_DIR}/values.yaml")
+          proxy_pull=$(yq --exit-status '.proxy.image.pullPolicy' "${CHART_DIR}/values.yaml")
 
           fail=0
           if [[ "${controller_repo}" != *-ctrl ]]; then
@@ -467,14 +480,22 @@ jobs:
             echo "ERROR: proxy.image.tag must equal ${EXPECTED_TAG}, got: ${proxy_tag}"
             fail=1
           fi
+          if [[ "${controller_pull}" != "Always" ]]; then
+            echo "ERROR: image.pullPolicy must equal Always for PR charts (so rolling restart picks up moving tag), got: ${controller_pull}"
+            fail=1
+          fi
+          if [[ "${proxy_pull}" != "Always" ]]; then
+            echo "ERROR: proxy.image.pullPolicy must equal Always for PR charts (so rolling restart picks up moving tag), got: ${proxy_pull}"
+            fail=1
+          fi
 
           if [[ ${fail} -ne 0 ]]; then
             exit 1
           fi
 
           echo "values.yaml image overrides verified:"
-          echo "  controller: ${controller_repo}:${controller_tag}"
-          echo "  proxy:      ${proxy_repo}:${proxy_tag}"
+          echo "  controller: ${controller_repo}:${controller_tag} (pullPolicy=${controller_pull})"
+          echo "  proxy:      ${proxy_repo}:${proxy_tag} (pullPolicy=${proxy_pull})"
 
       - name: Package chart
         run: |
@@ -484,7 +505,7 @@ jobs:
           helm package "${CHART_DIR}"
 
           # Show package info
-          ls -lh *.tgz
+          ls -lh -- *.tgz
 
       - name: Push chart to ttl.sh
         run: |

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -1,0 +1,41 @@
+name: Scripts
+
+on:
+  pull_request:
+    paths:
+      - scripts/reflow-paragraphs.py
+      - scripts/reflow_paragraphs_test.py
+      - .github/workflows/scripts.yaml
+  push:
+    branches: [master]
+    paths:
+      - scripts/reflow-paragraphs.py
+      - scripts/reflow_paragraphs_test.py
+      - .github/workflows/scripts.yaml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reflow:
+    name: Reflow paragraphs test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.14.5"
+
+      - name: Install pytest
+        run: pip install --quiet pytest
+
+      - name: Run reflow paragraphs tests
+        # 16 pytest cases pin the list-item-continuation and nested-list
+        # indent-preservation contracts. A regression to either would
+        # silently produce mid-bullet wraps the next time someone runs
+        # `python3 scripts/reflow-paragraphs.py docs/**.md`, violating the
+        # project's prose-wrap rule. The script is fire-and-forget but the
+        # suite guards future hand-edits.
+        run: python3 -m pytest scripts/reflow_paragraphs_test.py -v

--- a/charts/cloudflare-tunnel-gateway-controller/tests/deployment-proxy_test.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/tests/deployment-proxy_test.yaml
@@ -45,6 +45,32 @@ tests:
           path: spec.template.spec.containers[0].image
           pattern: "^ghcr\\.io/lexfrei/cloudflare-tunnel-gateway-controller-proxy:"
 
+  - it: should default to IfNotPresent pull policy
+    # Stable-release default. The PR-chart build flips this to Always via a
+    # workflow-side yq override so iteration picks up new pr-NNN-1d digests.
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "IfNotPresent"
+
+  - it: should set custom proxy pull policy
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token-secret
+        image:
+          pullPolicy: "Always"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Always"
+
   - it: should mount tunnel token from secret
     set:
       proxy:

--- a/charts/cloudflare-tunnel-gateway-controller/tests/deployment_test.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/tests/deployment_test.yaml
@@ -220,6 +220,16 @@ tests:
           path: spec.template.spec.containers[0].image
           pattern: ":v1.2.3$"
 
+  - it: should default to IfNotPresent pull policy
+    # Stable-release default: production rollouts should NOT re-pull the same
+    # tag on every restart. The PR-chart build flips this to Always via a
+    # workflow-side yq override so iteration picks up new pr-NNN-1d digests.
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "IfNotPresent"
+
   - it: should set custom pull policy
     set:
       image:


### PR DESCRIPTION
# Pull Request

## Summary

Two scoped CI cleanups bundled into one PR per the batched-delivery policy.

Closes #247 — PR charts publish a moving tag (`pr-NNN-1d`): same name, different digest on each push. The stable-release default `IfNotPresent` keeps the cached image on the node, so a rolling restart after CI rebuild does NOT pull the new build. Maintainer flow currently needs a temporary `imagePullPolicy: Always` override on the consuming chart values; that override has to be added before testing and reverted afterwards. Fix moves the flip into the chart-publish workflow so PR consumers get `Always` automatically while stable releases keep `IfNotPresent`.

Closes #278 — `scripts/reflow_paragraphs_test.py` (16 cases) landed in #277 pinning list-item-continuation and nested-list-indent contracts of `scripts/reflow-paragraphs.py`, but no CI ran it. Add a focused workflow triggered on changes to the reflow script or its test file.

## Changes

- Patch `.github/workflows/pr.yaml`'s `build-chart` yq block to set `image.pullPolicy = "Always"` and `proxy.image.pullPolicy = "Always"` for PR-chart builds only. The source `values.yaml` on master is untouched.
- Extend the existing "Validate values.yaml image overrides" assertion block with `controller_pull` / `proxy_pull` checks so a future workflow regression fails the job instead of silently shipping a non-rotating chart.
- Add helm-unittest cases pinning the stable `IfNotPresent` default for both controller and proxy deployments — guards production behaviour against an accidental edit to `values.yaml`.
- Fold in a drive-by shellcheck SC2035 fix in the same `build-chart` job's "Package chart" step (`ls -lh *.tgz` -> `ls -lh -- *.tgz`) per the "own the neighborhood" rule.
- Add `.github/workflows/scripts.yaml` running `python3 -m pytest scripts/reflow_paragraphs_test.py -v` on push/PR when the reflow script or its test file changes. Action versions SHA-pinned per the project's `helpers:pinGitHubActionDigests` Renovate preset.

## Testing

- [x] All tests pass locally (`go test ./...`) — N/A (no Go changes)
- [x] Linters pass locally (`golangci-lint run`) — N/A (no Go changes); `actionlint` clean on both touched workflow files (one pre-existing SC2155 in an unrelated `security` job remains, explicitly out of scope)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable) — `helm unittest` 199 cases pass; `helm lint` clean; 16 pytest cases pass

## Documentation

- [x] README updated (if needed) — N/A
- [x] Code comments added for complex logic — yq override block carries the rationale for the stable-vs-PR split
- [x] CLAUDE.md updated (if workflow/standards changed) — N/A

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced — #247, #278

## Additional Notes

After this lands, the maintainer-side `lexfrei/k8s` flow described in the project memory no longer needs the temporary `imagePullPolicy: Always` overlay — PR charts ship with the override baked in. Stable releases (`release.yaml` does NOT share `build-chart`) continue to default to `IfNotPresent` so production rollouts retain their current behaviour.
