### PR TITLE
ci(scripts): pin pytest version via requirements-reflow.txt

### DIFF
--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -5,12 +5,14 @@ on:
     paths:
       - scripts/reflow-paragraphs.py
       - scripts/reflow_paragraphs_test.py
+      - scripts/requirements-reflow.txt
       - .github/workflows/scripts.yaml
   push:
     branches: [master]
     paths:
       - scripts/reflow-paragraphs.py
       - scripts/reflow_paragraphs_test.py
+      - scripts/requirements-reflow.txt
       - .github/workflows/scripts.yaml
   workflow_dispatch:
 
@@ -29,7 +31,7 @@ jobs:
           python-version: "3.14.5"
 
       - name: Install pytest
-        run: pip install --quiet pytest
+        run: pip install --quiet --requirement scripts/requirements-reflow.txt
 
       - name: Run reflow paragraphs tests
         # 16 pytest cases pin the list-item-continuation and nested-list

--- a/scripts/requirements-reflow.txt
+++ b/scripts/requirements-reflow.txt
@@ -1,0 +1,7 @@
+# Dependencies for scripts/reflow-paragraphs.py and its pytest sibling.
+# Pinned so a Renovate-trackable diff lands on every version bump (the
+# reflow script itself uses only stdlib; pytest is the test-only dep).
+#
+# Used by the reflow job in .github/workflows/scripts.yaml.
+
+pytest==9.0.3


### PR DESCRIPTION
# Pull Request

## Summary

Closes #280 — `.github/workflows/scripts.yaml` installed pytest with bare `pip install --quiet pytest`, no version pin. The rest of the repo follows the "pin and let Renovate bump" pattern (`scripts/requirements-labels.txt` pins `pytest==9.0.3`), so a future pytest major would have landed in the reflow workflow silently while the labels workflow caught it via a reviewable PR.

## Changes

- Add `scripts/requirements-reflow.txt` pinning `pytest==9.0.3` (matches the labels suite — symmetric across the two pytest-using workflows).
- Switch `.github/workflows/scripts.yaml` install step to `pip install --quiet --requirement scripts/requirements-reflow.txt`.
- Extend the workflow's `paths:` triggers (both `pull_request` and `push`) to include `scripts/requirements-reflow.txt` so a Renovate pin-bump PR re-runs the verifying suite it bumped.

Renovate's `pip_requirements` manager is enabled implicitly via `config:recommended` in `renovate.json5`, so the new file is picked up automatically — no additional Renovate rule needed.

## Testing

- [x] All tests pass locally (`go test ./...`) — N/A (no Go changes)
- [x] Linters pass locally (`golangci-lint run`) — `actionlint .github/workflows/scripts.yaml` clean
- [x] Markdown linting passes (`markdownlint **/*.md`) — N/A (no markdown changes)
- [x] Manual testing completed (if applicable) — 16 pytest cases pass against the pinned pytest version

## Documentation

- [x] README updated (if needed) — N/A
- [x] Code comments added for complex logic — `scripts/requirements-reflow.txt` header explains why the pin exists
- [x] CLAUDE.md updated (if workflow/standards changed) — N/A

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced — #280

## Additional Notes

Smallest possible XS change to close the loose end raised during PR #279 round-2 review. Symmetric with the labels suite's pin so a future maintainer reading either workflow sees the same install pattern.
