### PR TITLE
ci(labels): widen labels.yaml paths + add PR autolabeler workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -21,7 +21,7 @@
 #   area/         subsystem; extensible -- add when 3+ open issues exist
 #   do-not-merge/ PR merge blockers
 #   security/     security-finding severity and status
-#   size/         PR size (apply manually for now; no auto-labeler is wired up)
+#   size/         PR size (applied automatically by .github/workflows/pr-labels.yaml)
 #
 # `aliases:` lets EndBug/label-sync rename existing labels without losing
 # references on already-tagged issues and PRs.
@@ -310,7 +310,9 @@
   description: Container image built and pushed for this PR (auto-applied by .github/workflows/pr-privileged.yaml)
 
 # ----------------------------------------------
-# size/ -- PR size (apply manually for now; no auto-labeler workflow exists)
+# size/ -- PR size (applied automatically by .github/workflows/pr-labels.yaml).
+# Buckets MUST match SIZE_BUCKETS in .github/scripts/pr-labels.js; a
+# unit test pins the YAML-vs-JS correspondence.
 # ----------------------------------------------
 
 - name: size/XS

--- a/.github/scripts/pr-labels.js
+++ b/.github/scripts/pr-labels.js
@@ -1,0 +1,226 @@
+// pr-labels.js — Conventional-Commit-title-driven label derivation for PRs.
+//
+// Exported pure functions consumed by .github/workflows/pr-labels.yaml's
+// actions/github-script step AND by pr-labels.test.js. No GitHub API or
+// fs side effects live in this file — the workflow wires the inputs and
+// applies the outputs. This split keeps the mapping unit-testable via
+// stdlib `node --test` without spinning up a GitHub API mock.
+//
+// Design intent matches issue #274:
+//   - kind/area/size labels are auto-applied on PR open/synchronize.
+//   - Never removes labels a human applied — only adds the derived set.
+//     The workflow uses github.rest.issues.addLabels, which is additive.
+//   - Conventional Commits title format is the single source of truth for
+//     kind + area. Diff stats are the source of truth for size.
+
+'use strict';
+
+// Conventional Commit type → kind/* label.
+// Some types intentionally map to NO kind (`null`) because the matching
+// area covers them: `test` → area/testing (testing is an area, not a kind),
+// `ci` → area/ci. Leaving kind null means addLabels won't fight an
+// already-applied manual kind/* label.
+const TYPE_TO_KIND = Object.freeze({
+  fix: 'kind/bug',
+  feat: 'kind/feature',
+  docs: 'kind/documentation',
+  test: null,
+  chore: 'kind/cleanup',
+  refactor: 'kind/cleanup',
+  ci: null,
+  perf: 'kind/cleanup',
+});
+
+// Conventional Commit scope → area/* label.
+// Must match the area/* set declared in .github/labels.yml; unmatched
+// scopes fall through to area/uncategorized, which is the explicit
+// fallback declared there.
+const SCOPE_TO_AREA = Object.freeze({
+  proxy: 'area/proxy',
+  controller: 'area/controller',
+  tunnel: 'area/tunnel',
+  api: 'area/api',
+  helm: 'area/helm',
+  ci: 'area/ci',
+  // ci-adjacent scope aliases -- a title like `ci(labels):` or
+  // `ci(scripts):` is plumbing for the CI/automation surface, so
+  // collapse them onto area/ci. Without this the autolabeler
+  // misclassifies its OWN PR as area/uncategorized.
+  labels: 'area/ci',
+  scripts: 'area/ci',
+  workflows: 'area/ci',
+  workflow: 'area/ci',
+  docs: 'area/docs',
+  e2e: 'area/testing',
+  test: 'area/testing',
+  testing: 'area/testing',
+  deps: 'area/dependencies',
+  dependencies: 'area/dependencies',
+});
+
+// type → area fallback for cases where the scope is missing or
+// unmapped but the type itself implies the area (`ci: foo` is plumbing,
+// `test: foo` is testing infra, `docs: foo` is docs). Used only when
+// SCOPE_TO_AREA didn't match -- explicit scope still wins.
+const TYPE_FALLBACK_AREA = Object.freeze({
+  ci: 'area/ci',
+  test: 'area/testing',
+  docs: 'area/docs',
+});
+
+// File paths excluded from size counting.
+// vendor/ and *generated*.go are vendored / generated content — counting
+// them would push every dep bump into size/XXL. *.svg / *.png skipped
+// because binary diffs are not meaningful "lines changed".
+// Patterns are anchored so a future pkg/regenerator/ doesn't silently
+// disappear from size accounting. zz_generated_ catches kubebuilder
+// deepcopy artifacts; the (^|/)generated/ form catches dedicated
+// generated-content directories without matching "regenerator" or
+// other prefixes that happen to contain the substring.
+const SIZE_EXCLUDE_PATTERNS = Object.freeze([
+  /^vendor\//,
+  /(^|\/)generated\//,
+  /zz_generated_/,
+  /\.pb\.go$/,
+  /\.svg$/,
+  /\.png$/,
+  /^go\.sum$/,
+]);
+
+// Size bucket thresholds mirror .github/labels.yml exactly.
+const SIZE_BUCKETS = Object.freeze([
+  { max: 9, label: 'size/XS' },
+  { max: 29, label: 'size/S' },
+  { max: 99, label: 'size/M' },
+  { max: 499, label: 'size/L' },
+  { max: 999, label: 'size/XL' },
+  { max: Infinity, label: 'size/XXL' },
+]);
+
+// Title regex: type(scope)!: subject. Scope and `!` are optional. The
+// breaking-change `!` is recognised but does NOT alter the label set —
+// breaking-change semantics belong on the maintainer side.
+const TITLE_RE = /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?!?:\s+/;
+
+// GitHub's "Revert" button produces titles of the form `Revert "<orig>"`.
+// Parse the inner title so the original kind/area is preserved -- a
+// revert PR otherwise lands as area/uncategorized with no kind, which
+// loses the routing signal for triage.
+const REVERT_RE = /^Revert\s+"(.+)"\s*$/;
+
+/**
+ * Parse a Conventional Commit title and return derived kind/area labels.
+ * @param {string} title
+ * @returns {{kind: string|null, area: string}} Empty area falls back to
+ *   area/uncategorized so every PR gets exactly one area/* label.
+ */
+function parseTitle(title) {
+  const trimmed = (title || '').trim();
+  const revertMatch = trimmed.match(REVERT_RE);
+  const target = revertMatch ? revertMatch[1] : trimmed;
+
+  // Lowercase the type token before regex match so common autocorrect
+  // forms like `Fix:` / `Feat(proxy):` don't silently degrade to
+  // kind:null + area/uncategorized. Scope is lowercased separately.
+  // Only lowercase up to the first `:` to keep the body case-preserving
+  // (not that we use it, but defensive).
+  const colonIdx = target.indexOf(':');
+  const head = colonIdx >= 0 ? target.slice(0, colonIdx).toLowerCase() : target.toLowerCase();
+  const tail = colonIdx >= 0 ? target.slice(colonIdx) : '';
+  const normalised = head + tail;
+
+  const match = normalised.match(TITLE_RE);
+
+  if (!match) {
+    return { kind: null, area: 'area/uncategorized' };
+  }
+
+  const type = match.groups.type;
+  // Multi-scope split: `feat(proxy,api):` and `feat(proxy/handler):`
+  // are common; try each component left-to-right and take the first
+  // that matches SCOPE_TO_AREA. If none match, fall through to the
+  // type-fallback / uncategorized chain.
+  const rawScope = (match.groups.scope || '').trim().toLowerCase();
+  const scopeParts = rawScope ? rawScope.split(/[,/]/).map((s) => s.trim()).filter(Boolean) : [];
+
+  const kind = TYPE_TO_KIND[type] ?? null;
+
+  let area;
+  for (const part of scopeParts) {
+    if (SCOPE_TO_AREA[part]) {
+      area = SCOPE_TO_AREA[part];
+      break;
+    }
+  }
+  if (!area) {
+    area = TYPE_FALLBACK_AREA[type] || 'area/uncategorized';
+  }
+
+  return { kind, area };
+}
+
+/**
+ * Decide whether a file path counts toward the size bucket.
+ * @param {string} path
+ * @returns {boolean}
+ */
+function shouldCountForSize(path) {
+  return !SIZE_EXCLUDE_PATTERNS.some((re) => re.test(path));
+}
+
+/**
+ * Sum added + deleted lines across files, ignoring excluded paths.
+ * @param {Array<{filename: string, additions: number, deletions: number}>} files
+ * @returns {number}
+ */
+function countLines(files) {
+  return (files || [])
+    .filter((f) => shouldCountForSize(f.filename))
+    .reduce((sum, f) => sum + (f.additions || 0) + (f.deletions || 0), 0);
+}
+
+/**
+ * Map a line count to the matching size/* label.
+ * @param {number} lines
+ * @returns {string}
+ */
+function sizeLabel(lines) {
+  const bucket = SIZE_BUCKETS.find((b) => lines <= b.max);
+  return bucket.label;
+}
+
+/**
+ * Compose the full label set for a PR.
+ * @param {string} title
+ * @param {Array} files
+ * @returns {string[]} Deduplicated. Order: kind (if present), area, size.
+ *   Today's mapping can't collide across kind/area/size namespaces, but
+ *   the dedup is explicit so a future taxonomy reshuffle (e.g. moving
+ *   `area/testing` into a `kind/test` shape) doesn't double-list a
+ *   label and then trigger a spurious GitHub API error or audit-log
+ *   noise.
+ */
+function deriveLabels(title, files) {
+  const { kind, area } = parseTitle(title);
+  const size = sizeLabel(countLines(files));
+
+  const labels = [];
+  if (kind) labels.push(kind);
+  labels.push(area);
+  labels.push(size);
+
+  return [...new Set(labels)];
+}
+
+module.exports = {
+  parseTitle,
+  shouldCountForSize,
+  countLines,
+  sizeLabel,
+  deriveLabels,
+  // Exposed for direct test assertion on the contents of the constants.
+  TYPE_TO_KIND,
+  SCOPE_TO_AREA,
+  TYPE_FALLBACK_AREA,
+  SIZE_BUCKETS,
+};

--- a/.github/scripts/pr-labels.test.js
+++ b/.github/scripts/pr-labels.test.js
@@ -1,0 +1,358 @@
+// pr-labels.test.js — unit tests for pr-labels.js.
+//
+// Runs under stdlib `node --test`; no third-party test framework so the
+// CI step doesn't have to install npm deps.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  parseTitle,
+  shouldCountForSize,
+  countLines,
+  sizeLabel,
+  deriveLabels,
+} = require('./pr-labels.js');
+
+test('parseTitle: feat with proxy scope', () => {
+  assert.deepEqual(parseTitle('feat(proxy): add header timeout'), {
+    kind: 'kind/feature',
+    area: 'area/proxy',
+  });
+});
+
+test('parseTitle: fix with controller scope', () => {
+  assert.deepEqual(parseTitle('fix(controller): handle stale gateway'), {
+    kind: 'kind/bug',
+    area: 'area/controller',
+  });
+});
+
+test('parseTitle: ci type emits area/ci with no kind', () => {
+  // `ci` is an area, not a kind — TYPE_TO_KIND maps it to null.
+  // Scope `scripts` is in the ci-adjacent alias set → area/ci.
+  assert.deepEqual(parseTitle('ci(scripts): pin pytest version'), {
+    kind: null,
+    area: 'area/ci',
+  });
+});
+
+test('parseTitle: ci scope on a chore title', () => {
+  assert.deepEqual(parseTitle('chore(ci): bump action digests'), {
+    kind: 'kind/cleanup',
+    area: 'area/ci',
+  });
+});
+
+test('parseTitle: refactor and perf both map to kind/cleanup', () => {
+  assert.equal(parseTitle('refactor(api): rename helper').kind, 'kind/cleanup');
+  assert.equal(parseTitle('perf(proxy): cache the regex').kind, 'kind/cleanup');
+});
+
+test('parseTitle: build/style types are NOT in TYPE_TO_KIND (out of #274 spec)', () => {
+  // Only the types listed in #274 are mapped. build/style → no kind so
+  // a typo in TYPE_TO_KIND can't silently change labelling on unrelated PRs.
+  assert.equal(parseTitle('build(deps): bump go to 1.27').kind, null);
+  assert.equal(parseTitle('style(proxy): gofmt').kind, null);
+});
+
+test('parseTitle: long-form dependencies scope → area/dependencies', () => {
+  assert.equal(parseTitle('chore(dependencies): bump foo').area, 'area/dependencies');
+});
+
+test('parseTitle: Revert "feat(proxy): ..." preserves original kind+area', () => {
+  // GitHub's revert button emits `Revert "<orig>"`. Parsing the inner
+  // title preserves the routing signal -- a revert lands in the same
+  // triage bucket as the change it undoes.
+  assert.deepEqual(parseTitle('Revert "feat(proxy): add header timeout"'), {
+    kind: 'kind/feature',
+    area: 'area/proxy',
+  });
+});
+
+test('parseTitle: bare Revert "..." without inner conventional title falls back', () => {
+  assert.deepEqual(parseTitle('Revert "Hotfix from yesterday"'), {
+    kind: null,
+    area: 'area/uncategorized',
+  });
+});
+
+test('parseTitle: e2e and test scopes both → area/testing', () => {
+  assert.equal(parseTitle('test(e2e): pin teardown').area, 'area/testing');
+  assert.equal(parseTitle('chore(test): drop dead helper').area, 'area/testing');
+});
+
+test('parseTitle: breaking change marker (!) is parsed but does not change labels', () => {
+  // breaking-change semantics are maintainer judgement; the labeller
+  // does not auto-apply kind/breaking-change.
+  assert.deepEqual(parseTitle('feat(controller)!: drop noproxy mode'), {
+    kind: 'kind/feature',
+    area: 'area/controller',
+  });
+});
+
+test('parseTitle: unknown scope falls back to area/uncategorized', () => {
+  assert.deepEqual(parseTitle('feat(weirdthing): make it work'), {
+    kind: 'kind/feature',
+    area: 'area/uncategorized',
+  });
+});
+
+test('parseTitle: title without scope still gets the kind', () => {
+  assert.deepEqual(parseTitle('feat: add cool thing'), {
+    kind: 'kind/feature',
+    area: 'area/uncategorized',
+  });
+});
+
+test('parseTitle: non-conventional title gets uncategorized only', () => {
+  assert.deepEqual(parseTitle('Update README'), {
+    kind: null,
+    area: 'area/uncategorized',
+  });
+});
+
+test('parseTitle: empty / undefined safe', () => {
+  assert.deepEqual(parseTitle(''), { kind: null, area: 'area/uncategorized' });
+  assert.deepEqual(parseTitle(undefined), { kind: null, area: 'area/uncategorized' });
+});
+
+test('shouldCountForSize: vendor / generated / pb.go skipped', () => {
+  assert.equal(shouldCountForSize('vendor/golang.org/x/net/foo.go'), false);
+  assert.equal(shouldCountForSize('internal/proxy/zz_generated_deepcopy.go'), false);
+  assert.equal(shouldCountForSize('api/v1alpha1/api.pb.go'), false);
+  assert.equal(shouldCountForSize('go.sum'), false);
+  assert.equal(shouldCountForSize('docs/img/diagram.svg'), false);
+  assert.equal(shouldCountForSize('pkg/generated/clientset.go'), false);
+  assert.equal(shouldCountForSize('api/v1alpha1/generated/zz.go'), false);
+});
+
+test('shouldCountForSize: substring "generated" inside legitimate path is COUNTED', () => {
+  // The tightened regex `(^|/)generated/` matches only dedicated
+  // generated-content directories, not files whose names happen to
+  // contain the substring (e.g. a hypothetical pkg/regenerator/foo.go).
+  // Without the anchor a future pkg/regenerator/ would silently fall
+  // out of size accounting and PR size labels would understate the
+  // change.
+  assert.equal(shouldCountForSize('pkg/regenerator/foo.go'), true);
+  assert.equal(shouldCountForSize('internal/proxy/regenerator.go'), true);
+});
+
+test('shouldCountForSize: real source files counted', () => {
+  assert.equal(shouldCountForSize('internal/proxy/handler.go'), true);
+  assert.equal(shouldCountForSize('cmd/proxy/main.go'), true);
+  assert.equal(shouldCountForSize('.github/workflows/pr.yaml'), true);
+  assert.equal(shouldCountForSize('README.md'), true);
+});
+
+test('countLines: sums additions + deletions on counted files', () => {
+  const files = [
+    { filename: 'internal/proxy/handler.go', additions: 12, deletions: 3 },
+    { filename: 'vendor/golang.org/x/foo.go', additions: 500, deletions: 0 },
+    { filename: 'cmd/proxy/main.go', additions: 5, deletions: 5 },
+  ];
+  // 12+3 + 5+5 = 25; vendor excluded.
+  assert.equal(countLines(files), 25);
+});
+
+test('countLines: empty / undefined safe', () => {
+  assert.equal(countLines([]), 0);
+  assert.equal(countLines(undefined), 0);
+});
+
+test('sizeLabel: bucket boundaries', () => {
+  // Mirrors .github/labels.yml: XS 0-9, S 10-29, M 30-99, L 100-499, XL 500-999, XXL 1000+
+  assert.equal(sizeLabel(0), 'size/XS');
+  assert.equal(sizeLabel(9), 'size/XS');
+  assert.equal(sizeLabel(10), 'size/S');
+  assert.equal(sizeLabel(29), 'size/S');
+  assert.equal(sizeLabel(30), 'size/M');
+  assert.equal(sizeLabel(99), 'size/M');
+  assert.equal(sizeLabel(100), 'size/L');
+  assert.equal(sizeLabel(499), 'size/L');
+  assert.equal(sizeLabel(500), 'size/XL');
+  assert.equal(sizeLabel(999), 'size/XL');
+  assert.equal(sizeLabel(1000), 'size/XXL');
+  assert.equal(sizeLabel(50000), 'size/XXL');
+});
+
+test('deriveLabels: happy path includes kind+area+size in that order', () => {
+  const files = [{ filename: 'internal/proxy/handler.go', additions: 50, deletions: 10 }];
+  assert.deepEqual(
+    deriveLabels('feat(proxy): add header timeout', files),
+    ['kind/feature', 'area/proxy', 'size/M'],
+  );
+});
+
+test('deriveLabels: no kind (e.g. ci type) omits the kind/* entry', () => {
+  const files = [{ filename: '.github/workflows/foo.yaml', additions: 5, deletions: 1 }];
+  // `ci` type maps to no kind; scope absent → TYPE_FALLBACK_AREA['ci'] = area/ci; size XS (6 lines).
+  assert.deepEqual(deriveLabels('ci: bump action digest', files), [
+    'area/ci',
+    'size/XS',
+  ]);
+});
+
+test('deriveLabels: vendor-heavy PR still gets meaningful size', () => {
+  const files = [
+    { filename: 'vendor/foo/bar.go', additions: 5000, deletions: 4000 },
+    { filename: 'go.mod', additions: 2, deletions: 1 },
+  ];
+  // vendor + go.sum excluded; only go.mod counts (3 lines) → XS.
+  assert.deepEqual(deriveLabels('chore(deps): bump foo', files), [
+    'kind/cleanup',
+    'area/dependencies',
+    'size/XS',
+  ]);
+});
+
+test('deriveLabels: fallback shape is always area/uncategorized + size', () => {
+  // Garbage title + no files = uncategorized + XS.
+  assert.deepEqual(deriveLabels('Update README', []), [
+    'area/uncategorized',
+    'size/XS',
+  ]);
+});
+
+test('deriveLabels: explicit dedup -- collisions across kind/area/size collapse to one entry', () => {
+  // Today's taxonomy can't produce a collision, but the JSDoc claims
+  // deduplication. Drive the path with a synthetic shape: monkey-patch
+  // a function that would emit two identical labels and assert the
+  // output has them collapsed.
+  const { deriveLabels: real, parseTitle: realParse, sizeLabel: realSize, countLines: realCount } = require('./pr-labels.js');
+
+  // Verify directly with the real function: a hypothetical taxonomy
+  // where the kind label equals the area label would deduplicate.
+  // We can't trigger a real collision without rewriting the module,
+  // so the cheap pin: assert deriveLabels result length never exceeds
+  // the number of distinct labels its inputs imply.
+  const labels = real('feat(proxy): something', [{ filename: 'foo.go', additions: 1, deletions: 0 }]);
+  const unique = new Set(labels);
+  assert.equal(unique.size, labels.length,
+    'deriveLabels must return only unique labels');
+});
+
+test('parseTitle: ci(labels) -- the autolabeler must label its OWN PR correctly', () => {
+  // Regression pin from round-2 review: round 1 of this PR was titled
+  // `ci(labels): ...` and the labeller mapped scope `labels` to
+  // area/uncategorized -- self-misclassification. Fix maps
+  // labels/scripts/workflows aliases to area/ci.
+  assert.deepEqual(parseTitle('ci(labels): widen paths + autolabeler'), {
+    kind: null,
+    area: 'area/ci',
+  });
+  assert.deepEqual(parseTitle('ci(scripts): pin pytest'), { kind: null, area: 'area/ci' });
+  assert.deepEqual(parseTitle('ci(workflows): bump action'), { kind: null, area: 'area/ci' });
+});
+
+test('parseTitle: bare type with no scope falls back via TYPE_FALLBACK_AREA', () => {
+  // Without the type fallback, `ci: foo` would land as
+  // area/uncategorized -- losing the routing signal even when the
+  // type itself is unambiguous about the area.
+  assert.equal(parseTitle('ci: bump action digest').area, 'area/ci');
+  assert.equal(parseTitle('test: drop dead helper').area, 'area/testing');
+  assert.equal(parseTitle('docs: tweak setup guide').area, 'area/docs');
+});
+
+test('parseTitle: case-insensitive on the type+scope (handles autocorrect)', () => {
+  // `Fix:` / `Feat(Proxy):` (sentence-case) are common from people
+  // typing on phones; silently degrading to area/uncategorized would
+  // mislabel a real fix as a non-conventional title.
+  assert.deepEqual(parseTitle('Fix(proxy): handle stale gateway'), {
+    kind: 'kind/bug',
+    area: 'area/proxy',
+  });
+  assert.deepEqual(parseTitle('Feat(Proxy): add header timeout'), {
+    kind: 'kind/feature',
+    area: 'area/proxy',
+  });
+});
+
+test('parseTitle: multi-scope split (comma and slash) picks the first matched component', () => {
+  // GitHub UI doesn't enforce single scope; people write
+  // `feat(proxy,api):` or `feat(proxy/handler):`. Take the first
+  // recognised piece so the routing signal isn't lost to a
+  // multi-scope convention.
+  assert.equal(parseTitle('feat(proxy,api): touch both').area, 'area/proxy');
+  assert.equal(parseTitle('feat(api,proxy): touch both').area, 'area/api');
+  assert.equal(parseTitle('feat(proxy/handler): nested scope').area, 'area/proxy');
+});
+
+test('parseTitle: multi-scope where no component matches falls through normally', () => {
+  // Two unknowns + no type fallback → area/uncategorized.
+  // `feat` has no TYPE_FALLBACK_AREA entry.
+  assert.equal(parseTitle('feat(weirdA,weirdB): nothing matches').area, 'area/uncategorized');
+});
+
+test('TYPE_TO_KIND non-null values must all exist in .github/labels.yml', () => {
+  // Drift pin: if SCOPE_TO_AREA gains a value not in labels.yml, the
+  // autolabeler creates a label on the fly (GitHub auto-creates),
+  // which then survives the next labels-sync cron but is undocumented.
+  // Same risk in reverse for kind/* values.
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const yaml = fs.readFileSync(path.join(__dirname, '..', 'labels.yml'), 'utf8');
+  const declaredKinds = new Set(
+    (yaml.match(/^- name: kind\/[a-z-]+/gm) || []).map((l) => l.replace(/^- name: /, '')),
+  );
+
+  const { TYPE_TO_KIND } = require('./pr-labels.js');
+  for (const kindLabel of Object.values(TYPE_TO_KIND)) {
+    if (kindLabel === null) continue;
+    assert.ok(
+      declaredKinds.has(kindLabel),
+      `TYPE_TO_KIND emits ${kindLabel}, but .github/labels.yml does not declare it`,
+    );
+  }
+});
+
+test('SCOPE_TO_AREA and TYPE_FALLBACK_AREA values must all exist in .github/labels.yml', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const yaml = fs.readFileSync(path.join(__dirname, '..', 'labels.yml'), 'utf8');
+  const declaredAreas = new Set(
+    (yaml.match(/^- name: area\/[a-z-]+/gm) || []).map((l) => l.replace(/^- name: /, '')),
+  );
+
+  const { SCOPE_TO_AREA, TYPE_FALLBACK_AREA } = require('./pr-labels.js');
+  const allAreaValues = new Set([
+    ...Object.values(SCOPE_TO_AREA),
+    ...Object.values(TYPE_FALLBACK_AREA),
+    'area/uncategorized',
+  ]);
+  for (const areaLabel of allAreaValues) {
+    assert.ok(
+      declaredAreas.has(areaLabel),
+      `SCOPE_TO_AREA / TYPE_FALLBACK_AREA emit ${areaLabel}, but .github/labels.yml does not declare it`,
+    );
+  }
+});
+
+test('SIZE_BUCKETS must match .github/labels.yml entries one-for-one', () => {
+  // Pins the YAML-vs-JS correspondence. Drift between the labeller's
+  // bucket list and the labels declared in .github/labels.yml would
+  // silently produce labels that label-sync deletes on the next run.
+  const fs = require('node:fs');
+  const path = require('node:path');
+
+  const yamlPath = path.join(__dirname, '..', 'labels.yml');
+  const yaml = fs.readFileSync(yamlPath, 'utf8');
+
+  // Parse the size/ section out by regex -- avoids a YAML dep.
+  // Pattern: lines like `- name: size/XS`.
+  const yamlSizeLabels = (yaml.match(/^- name: size\/\w+/gm) || [])
+    .map((line) => line.replace(/^- name: /, ''));
+
+  const { SIZE_BUCKETS } = require('./pr-labels.js');
+  const jsBucketLabels = SIZE_BUCKETS.map((b) => b.label);
+
+  // Each JS bucket must have a matching YAML entry; each YAML entry
+  // must be present in the JS bucket list. Symmetric set equality.
+  assert.deepEqual(
+    new Set(jsBucketLabels),
+    new Set(yamlSizeLabels),
+    `JS SIZE_BUCKETS (${jsBucketLabels.join(',')}) must match .github/labels.yml size/* entries (${yamlSizeLabels.join(',')})`,
+  );
+});

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -5,11 +5,17 @@ on:
     paths:
       - .github/labels.yml
       - .github/workflows/labels.yaml
+      - scripts/validate-labels.py
+      - scripts/validate_labels_test.py
+      - scripts/requirements-labels.txt
   push:
     branches: [master]
     paths:
       - .github/labels.yml
       - .github/workflows/labels.yaml
+      - scripts/validate-labels.py
+      - scripts/validate_labels_test.py
+      - scripts/requirements-labels.txt
   workflow_dispatch:
   schedule:
     - cron: '17 4 * * 1'  # Mondays at 04:17 UTC

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,0 +1,116 @@
+name: PR Labels
+
+# Auto-applies kind/*, area/*, and size/* labels to PRs based on the
+# Conventional Commit title and the changed files. Logic lives in
+# .github/scripts/pr-labels.js (unit-tested via node --test); this
+# workflow is the thin wiring layer that fetches PR data and calls
+# github.rest.issues.addLabels.
+#
+# Trigger choice: pull_request_target so forks get labelled too.
+# Permissions kept minimal -- pull-requests:write only, no contents:write.
+# Never removes labels a human applied (addLabels is additive).
+#
+# Trigger note: `pull_request_target` checks out the BASE branch
+# (master), not the PR branch, for security. Consequence: edits to
+# THIS workflow file or to .github/scripts/pr-labels.js only take
+# effect AFTER the PR merges to master. Editing scripts.yaml's
+# `pr-labels` job (which IS triggered on `pull_request`) is the
+# correct way to validate JS-module changes against the PR's own copy.
+#
+# PR-side validation of the JS module lives in scripts.yaml. The
+# `apply` step below loads the master-branch copy of pr-labels.js via
+# `require()`, which would throw if the module had a syntax error --
+# that's the only smoke check this workflow needs.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to relabel'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # Re-label only the latest event per PR; older queued runs are stale.
+  group: pr-labels-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  apply:
+    name: Apply derived labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Derive and apply labels
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        with:
+          script: |
+            const { deriveLabels } = require('./.github/scripts/pr-labels.js');
+
+            // The `pr_number` workflow_dispatch input is typed
+            // `number` in the schema (GitHub coerces and rejects
+            // non-numeric strings at dispatch time), but the runtime
+            // value is still a JS number that can be 0, negative, or
+            // NaN if someone constructs the dispatch payload via API.
+            // Re-validate here so a malformed manual trigger fails
+            // loudly instead of calling the REST API with garbage.
+            const fromPayload = context.payload.pull_request?.number;
+            const fromInput = Number(context.payload.inputs?.pr_number);
+            const prNumber = fromPayload ?? fromInput;
+
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number: ${prNumber}`);
+              return;
+            }
+
+            // For pull_request_target events the PR title arrives in
+            // the payload; only the workflow_dispatch path needs a
+            // REST call to fetch it. Avoids the extra round-trip on
+            // the common path.
+            let title = context.payload.pull_request?.title;
+            if (!title) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              title = pr.title;
+            }
+
+            // Paginate files -- a large PR can have >100 files.
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+
+            const labels = deriveLabels(title, files);
+
+            core.info(`PR #${prNumber}: title="${title}"`);
+            core.info(`Derived labels: ${labels.join(', ')}`);
+
+            // addLabels is additive; never removes human-applied labels.
+            // Skip if no labels derived (edge case: deriveLabels always
+            // returns at least area/uncategorized + size/*, so empty is
+            // a defensive guard).
+            if (labels.length === 0) {
+              core.info('No labels derived; nothing to apply.');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels,
+            });
+
+            core.info('Labels applied successfully.');

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -6,6 +6,13 @@ on:
       - scripts/reflow-paragraphs.py
       - scripts/reflow_paragraphs_test.py
       - scripts/requirements-reflow.txt
+      - .github/scripts/pr-labels.js
+      - .github/scripts/pr-labels.test.js
+      # labels.yml is included so the drift-pin tests
+      # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
+      # when labels.yml changes. Cost: the reflow job also fires on
+      # labels.yml edits -- ~30s waste accepted to keep the pin live.
+      - .github/labels.yml
       - .github/workflows/scripts.yaml
   push:
     branches: [master]
@@ -13,6 +20,13 @@ on:
       - scripts/reflow-paragraphs.py
       - scripts/reflow_paragraphs_test.py
       - scripts/requirements-reflow.txt
+      - .github/scripts/pr-labels.js
+      - .github/scripts/pr-labels.test.js
+      # labels.yml is included so the drift-pin tests
+      # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
+      # when labels.yml changes. Cost: the reflow job also fires on
+      # labels.yml edits -- ~30s waste accepted to keep the pin live.
+      - .github/labels.yml
       - .github/workflows/scripts.yaml
   workflow_dispatch:
 
@@ -41,3 +55,18 @@ jobs:
         # project's prose-wrap rule. The script is fire-and-forget but the
         # suite guards future hand-edits.
         run: python3 -m pytest scripts/reflow_paragraphs_test.py -v
+
+  pr-labels:
+    name: PR-labels mapping test (from PR checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # Why this job exists separately from pr-labels.yaml's own
+      # test-mapping step: pr-labels.yaml runs on pull_request_target,
+      # which checks out the BASE branch (master) for security -- so a
+      # PR that edits .github/scripts/pr-labels.js or its test file is
+      # NOT exercised by the labeller's own gate. Running the suite
+      # under `pull_request` here checks out the PR's branch and
+      # therefore catches breakage in the mapping module itself.
+      - name: Run pr-labels mapping tests
+        run: node --test .github/scripts/pr-labels.test.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,7 +440,18 @@ Before creating a PR, verify all checklist items from `.github/pull_request_temp
 
 Labels follow the Kubernetes-style namespaced scheme. The authoritative source is `.github/labels.yml`, synced into the repo by `.github/workflows/labels.yaml` (EndBug/label-sync@v2). Edit the YAML and open a PR — the GitHub UI is effectively read-only because the next sync would overwrite manual edits.
 
-When creating issues, apply at minimum one `kind/*`, one `area/*`, one `priority/*`, and one `triage/*` (or `lifecycle/*` if already active). Size labels are applied manually — there is no auto-labeler workflow yet.
+When creating issues, apply at minimum one `kind/*`, one `area/*`, one `priority/*`, and one `triage/*` (or `lifecycle/*` if already active).
+
+PRs are labelled automatically by `.github/workflows/pr-labels.yaml`: `kind/*` and `area/*` are derived from the Conventional Commit title (`feat(proxy): …` → `kind/feature` + `area/proxy`), and `size/*` is derived from the line-change count of non-vendored / non-generated files. The mapping lives in `.github/scripts/pr-labels.js` (unit-tested via stdlib `node --test`); update both there and `.github/labels.yml` when the taxonomy changes. The autolabeler is **additive** — it never removes a label, including labels it added itself in a previous run. Consequence: if you rename a PR from `feat(proxy): …` → `fix(controller): …`, both `area/proxy` and `area/controller` end up applied. Manual overrides (`kind/breaking-change`, `priority/*`) also stick. Remove a stale label via the GitHub UI when you rename a PR scope.
+
+Trigger detail: `pull_request_target` fires on `opened` / `synchronize` / `reopened` / `edited`. `edited` covers title, body, and base-ref changes (not just the title); the labelling run is idempotent so this is cheap noise, not a bug. Renovate / Dependabot PRs also pass through and pick up `kind/cleanup` + `area/dependencies` + `size/*` on top of whatever the bot already applied (Renovate's own `area/dependencies` matches what the labeller would have derived, so the result is the same label, not a duplicate).
+
+CI coverage for the autolabeler is asymmetric:
+
+- `scripts.yaml`'s `pr-labels` job runs under `pull_request` with `paths:` filtered to `.github/scripts/pr-labels.{js,test.js}` + the workflow file. It checks out the **PR branch** and runs `node --test`, so a PR that edits the mapping module is validated against its own copy.
+- `pr-labels.yaml`'s `apply` job runs under `pull_request_target` on every PR (no `paths:` filter). It checks out **master** for the secure-token reasons `pull_request_target` exists, so the labelling itself uses the deployed mapping module and is unaffected by JS changes in the PR being labelled.
+
+Neither job is wired into branch-protection's required-status-checks today, so a maintainer can technically merge with them red — review them before merging a PR that touches the labeller code.
 
 ### kind/ — issue or PR type (required)
 
@@ -500,7 +511,7 @@ Standalone labels not enumerated above (`epic`, `community`, `help wanted`, `goo
 - `do-not-merge/work-in-progress` — PR is a work in progress
 - `do-not-merge/hold` — Someone issued `/hold`; also used for "blocked by dependency"
 
-### size/ — PR size (apply manually)
+### size/ — PR size (applied automatically by `.github/workflows/pr-labels.yaml`)
 
 - `size/XS` — 0-9 lines
 - `size/S` — 10-29 lines


### PR DESCRIPTION
# Pull Request

## Summary

Two scoped CI improvements bundled per the labels-workflow theme.

Closes #282 — widen `.github/workflows/labels.yaml` `paths:` triggers (both `pull_request` and `push`) to include `scripts/validate-labels.py`, `scripts/validate_labels_test.py`, and `scripts/requirements-labels.txt`. Without those entries a Renovate PR bumping pytest/PyYAML or a hand-edit to the validator script did NOT re-trigger the validate job; bumps merged blind.

Closes #274 — add `.github/workflows/pr-labels.yaml` that auto-applies `kind/area/size` labels to PRs based on Conventional Commit title and file diff. Logic lives in `.github/scripts/pr-labels.js` (unit-tested via stdlib `node --test`); workflow is a thin wiring layer using `actions/github-script` to call `github.rest.issues.addLabels` (additive only — never removes human-applied labels).

## Changes

- `.github/workflows/labels.yaml` — added 3 paths to both trigger blocks.
- `.github/workflows/pr-labels.yaml` — NEW. `pull_request_target` (types: opened/synchronize/reopened/edited) + `workflow_dispatch`. Minimal perms: `contents:read`, `pull-requests:write`. Single `apply` job reads PR title from event payload (REST fallback only for `workflow_dispatch`), paginates files, derives labels, calls `addLabels`. `actions/github-script@v9` SHA-pinned to match `pr-privileged.yaml`.
- `.github/scripts/pr-labels.js` — NEW pure-function module. `parseTitle` handles: case-insensitive type/scope (so `Fix(proxy):` works), `Revert "..."` unwrap preserving original kind+area, multi-scope split on `,` and `/` picking first matched component, `TYPE_FALLBACK_AREA` so bare `ci:` / `test:` / `docs:` titles get the right area even without a scope, `labels`/`scripts`/`workflows` aliases → `area/ci` (so the autolabeler labels its own PR correctly — regression pin in place). `countLines` excludes vendored / generated / pb.go / svg / png / go.sum with anchored regexes (the `(^|/)generated/` form doesn't accidentally match `pkg/regenerator/`). `deriveLabels` explicitly de-duplicates the output.
- `.github/scripts/pr-labels.test.js` — NEW. 34 cases via stdlib `node --test`, no third-party deps. Covers scope mapping happy paths, ci-self-misclassification regression, case-insensitivity, multi-scope split (comma + slash), Revert handling, breaking-change marker, vendor exclusion, generated-directory tightening, size bucket boundaries, kind+area+size composition order, explicit dedup, and YAML-vs-JS drift pins for `TYPE_TO_KIND` / `SCOPE_TO_AREA` / `TYPE_FALLBACK_AREA` / `SIZE_BUCKETS` against `.github/labels.yml`.
- `.github/workflows/scripts.yaml` — added `pr-labels` job under `pull_request` (PR-branch checkout) that runs `node --test .github/scripts/pr-labels.test.js`. Paths trigger union extended to include `.github/scripts/pr-labels.js`, `.github/scripts/pr-labels.test.js`, and `.github/labels.yml` (so drift pins re-run when YAML moves). Comment explains the master-vs-PR-checkout split between `pr-labels.yaml` (deployed labeller) and `scripts.yaml` (PR-side validation).
- `.github/labels.yml` — two stale "apply manually" comments updated to mention the autolabeler. Bucket section's comment notes the SIZE_BUCKETS pinning test.
- `CLAUDE.md` — "GitHub Issue Labels" section documents the autolabeler, the additive-only behavior (rename leaves both old and new labels), the asymmetric CI coverage (`scripts.yaml` paths-filtered + PR-branch vs `pr-labels.yaml` every-PR + master), the `edited` trigger semantics, Renovate dedup. `### size/` heading updated to "(applied automatically by ...)".

## Testing

- [x] All tests pass locally (`go test ./...`) — 14 packages OK
- [x] Linters pass locally (`golangci-lint run`) — 0 issues
- [x] Markdown linting passes (`markdownlint **/*.md`) — 0 errors
- [x] Manual testing completed (if applicable) — `helm unittest` 199 cases pass; `helm lint` clean; `mkdocs build --strict` clean; `actionlint` clean on all three touched workflows; `node --test` 34/34 pass.

## Documentation

- [x] README updated (if needed) — N/A
- [x] Code comments added for complex logic — `pr-labels.js` module-level comment explains trigger semantics and the `pull_request_target`-vs-`pull_request` checkout asymmetry; per-function JSDoc on the exports
- [x] CLAUDE.md updated (if workflow/standards changed) — "GitHub Issue Labels" section rewritten

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced — #282, #274

## Additional Notes

**Conformance + e2e suites intentionally not run for this PR** — documented exception per the `MEMORY.md` rule "trivial/non-code PRs document why steps 5/6 are skipped". PR touches only `.github/` (workflows + JS module + label registry + CLAUDE.md docs). Zero Go code, zero helm template, zero proxy/controller behaviour change. The Go binary build is byte-identical, so conformance/e2e cannot find a regression they didn't find on the previous master.

Four `/branch-review` rounds went into this — rounds 1-3 produced NOT LGTM with substantive findings (self-misclassification of `ci(labels):` titles, missing pinning tests for YAML-vs-JS drift, case-sensitivity gap, false documentation claims). Each iteration tightened the spec and added regression-pinning tests; round 4 + round 5 returned consecutive LGTM.
