### PR TITLE
ci(helm): add values.schema.json coverage for proxy.accessLog / proxy.websocket / proxy.authTokenSecretRef

### DIFF
--- a/charts/cloudflare-tunnel-gateway-controller/tests/schema_validation_test.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/tests/schema_validation_test.yaml
@@ -2,6 +2,7 @@ suite: test schema validation
 templates:
   - deployment.yaml
   - gatewayclassconfig.yaml
+  - deployment-proxy.yaml
 tests:
   # Note: These tests verify that schema validation works correctly.
   # Schema validation happens BEFORE template rendering in Helm,
@@ -119,3 +120,232 @@ tests:
       - template: gatewayclassconfig.yaml
         hasDocuments:
           count: 0
+
+  # ---
+  # proxy.accessLog schema
+  # ---
+
+  - it: should accept valid proxy.accessLog samplingRate (number in [0,1])
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        accessLog:
+          enabled: true
+          samplingRate: 0.5
+          stripQuery: true
+    asserts:
+      - template: deployment-proxy.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROXY_ACCESS_LOG_ENABLED
+            value: "true"
+
+  - it: should reject string samplingRate (must be number)
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        accessLog:
+          samplingRate: "halfish"
+    asserts:
+      - failedTemplate:
+          errorPattern: samplingRate
+
+  - it: should reject samplingRate above 1
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        accessLog:
+          samplingRate: 50
+    asserts:
+      - failedTemplate:
+          errorPattern: samplingRate
+
+  - it: should reject negative samplingRate
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        accessLog:
+          samplingRate: -0.1
+    asserts:
+      - failedTemplate:
+          errorPattern: samplingRate
+
+  - it: should reject non-boolean stripQuery
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        accessLog:
+          stripQuery: "yes-please"
+    asserts:
+      - failedTemplate:
+          errorPattern: stripQuery
+
+  # ---
+  # proxy.websocket schema
+  # ---
+
+  - it: should accept valid Go duration websocket.dialTimeout
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        websocket:
+          dialTimeout: 10s
+          handshakeTimeout: 1m
+    asserts:
+      - template: deployment-proxy.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROXY_WS_DIAL_TIMEOUT
+            value: "10s"
+
+  - it: should accept empty websocket.dialTimeout (chart default)
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        websocket:
+          dialTimeout: ""
+    asserts:
+      - template: deployment-proxy.yaml
+        notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: PROXY_WS_DIAL_TIMEOUT
+
+  - it: should accept compound Go-duration websocket.dialTimeout (1h30m form)
+    # time.ParseDuration accepts concatenated units; the schema must
+    # match that so an operator widening "1m" to "1m30s" doesn't trip
+    # helm lint while the proxy runtime would have accepted it.
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        websocket:
+          dialTimeout: "1h30m"
+          handshakeTimeout: "2m30s"
+    asserts:
+      - template: deployment-proxy.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROXY_WS_DIAL_TIMEOUT
+            value: "1h30m"
+      - template: deployment-proxy.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROXY_WS_HANDSHAKE_TIMEOUT
+            value: "2m30s"
+
+  - it: should accept three-component compound Go-duration (2h45m30s form)
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        websocket:
+          dialTimeout: "2h45m30s"
+    asserts:
+      - template: deployment-proxy.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROXY_WS_DIAL_TIMEOUT
+            value: "2h45m30s"
+
+  - it: should reject negative websocket.dialTimeout
+    # time.ParseDuration accepts "-5s" but the proxy's downstream
+    # > 0 gate drops negative values silently; schema rejection
+    # flags the typo at chart-time. Pin the rejection so a future
+    # regex loosening doesn't quietly re-introduce the silent-drop.
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        websocket:
+          dialTimeout: "-5s"
+    asserts:
+      - failedTemplate:
+          errorPattern: dialTimeout
+
+  - it: should reject bare numeric websocket.dialTimeout (no unit suffix)
+    # Without a unit the value is meaningless. time.ParseDuration
+    # only accepts "0" as a no-unit value; the schema requires a
+    # unit suffix on every numeric value (including "0s") so a
+    # bare "0" / "60" typo is caught at chart-time.
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        websocket:
+          dialTimeout: "0"
+    asserts:
+      - failedTemplate:
+          errorPattern: dialTimeout
+
+  - it: should reject malformed websocket.dialTimeout (not a Go duration)
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        websocket:
+          dialTimeout: "10seconds"
+    asserts:
+      - failedTemplate:
+          errorPattern: dialTimeout
+
+  # ---
+  # proxy.authTokenSecretRef schema
+  # ---
+
+  - it: should accept valid authTokenSecretRef
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        authTokenSecretRef:
+          name: proxy-auth
+          key: token
+    asserts:
+      - template: deployment-proxy.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROXY_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: proxy-auth
+                key: token
+
+  - it: should reject non-string authTokenSecretRef.name
+    set:
+      proxy:
+        enabled: true
+        tunnelTokenSecretRef:
+          name: tunnel-token
+        authTokenSecretRef:
+          name: 42
+    asserts:
+      - failedTemplate:
+          errorPattern: authTokenSecretRef

--- a/charts/cloudflare-tunnel-gateway-controller/values.schema.json
+++ b/charts/cloudflare-tunnel-gateway-controller/values.schema.json
@@ -636,6 +636,60 @@
             }
           }
         },
+        "authTokenSecretRef": {
+          "type": "object",
+          "description": "Optional Secret reference for the config API Bearer token (PROXY_AUTH_TOKEN); when name is empty the config API runs without authentication",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the Secret (leave empty to disable config API auth)"
+            },
+            "key": {
+              "type": "string",
+              "description": "Key in the Secret containing the auth token",
+              "default": "auth-token"
+            }
+          }
+        },
+        "websocket": {
+          "type": "object",
+          "description": "WebSocket upgrade-path tunables. Both bound only the pre-upgrade phase (TCP/TLS dial, 101-Switching-Protocols read). Empty string leaves the proxy binary's 30s default. The pattern accepts Go-duration compound forms (1h30m, 1m30s, etc.) matching time.ParseDuration. Negative durations are intentionally rejected here even though time.ParseDuration accepts them -- the proxy's downstream `> 0` gate would drop a negative value silently, so flagging it at chart-time is the discoverability win.",
+          "properties": {
+            "dialTimeout": {
+              "type": "string",
+              "pattern": "^(|[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))*)$",
+              "description": "Backend TCP/TLS dial timeout as a Go duration (e.g. \"10s\", \"1m\", \"1h30m\"). Empty preserves the 30s default."
+            },
+            "handshakeTimeout": {
+              "type": "string",
+              "pattern": "^(|[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))*)$",
+              "description": "101-Switching-Protocols read deadline as a Go duration (e.g. \"45s\", \"2m30s\"). Empty preserves the 30s default."
+            }
+          }
+        },
+        "accessLog": {
+          "type": "object",
+          "description": "Structured per-request access logging on the in-process proxy. Off by default (zero allocation on the hot path).",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable per-request access logging.",
+              "default": false
+            },
+            "samplingRate": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Fraction of non-5xx requests to log when enabled, in [0, 1]. 1.0 logs all; 0.0 logs only 5xx (always-log-errors carve-out is independent of this knob).",
+              "default": 1.0
+            },
+            "stripQuery": {
+              "type": "boolean",
+              "description": "Zero the `query` field in every emitted line. Source-level privacy mitigation for token-bearing query strings.",
+              "default": false
+            }
+          }
+        },
         "resources": {
           "type": "object",
           "description": "Container resource requirements"


### PR DESCRIPTION
# Pull Request

## Summary

Closes #286. Pre-existing schema gap surfaced during #245 review: `charts/cloudflare-tunnel-gateway-controller/values.schema.json` did not cover `proxy.accessLog`, `proxy.websocket`, or `proxy.authTokenSecretRef`. A typo like `proxy.accessLog.samplingRate: abc` or `proxy.websocket.dialTimeout: 10seconds` was only caught at proxy startup (via the WARN+default fallback in `cmd/proxy/main.go`), not by `helm lint` or `helm install`.

## Changes

- `values.schema.json`: JSON-schema entries for all three blocks.
  - `proxy.accessLog`: `enabled` (bool), `samplingRate` (number with `minimum: 0` / `maximum: 1`), `stripQuery` (bool). Covers the #245 + #290 surface.
  - `proxy.websocket`: `dialTimeout`, `handshakeTimeout` (Go-duration regex pattern that accepts empty string for chart-default fallback).
  - `proxy.authTokenSecretRef`: `name`, `key` (strings).
- `tests/schema_validation_test.yaml`: 10 helm-unittest cases pinning the positive-shape AND the rejection paths — string-where-number, above-maximum, negative, non-bool stripQuery, malformed Go duration, non-string secret name. `deployment-proxy.yaml` added to the suite's templates list so the accessLog / websocket / authTokenSecretRef chart wiring is exercised under the schema's eye.

## Testing

- [x] All tests pass locally (`go test ./...`) — N/A (no Go changes)
- [x] Linters pass locally (`golangci-lint run`) — 0 issues (Go test still passes; lint covers Go-only)
- [x] Markdown linting passes (`markdownlint **/*.md`) — 0 errors (no markdown changes)
- [x] Manual testing completed (if applicable) — `helm unittest` 215 cases (10 new); `helm lint` clean; `mkdocs build --strict` clean; `helm template test ... --set proxy.accessLog.samplingRate=abc` now fails fast with `Error: values don't meet the specifications` referencing the offending path.

## Documentation

- [x] README updated (if needed) — N/A (helm-docs regenerated, no diff since values.yaml unchanged)
- [x] Code comments added for complex logic — schema entries carry `description` fields explaining each knob
- [x] CLAUDE.md updated (if workflow/standards changed) — N/A

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none. Schema additions are additive; existing valid `values.yaml` still validate. Operators who were running with values that DON'T satisfy the new constraints (e.g. `samplingRate: 50` typo) will now get an upfront `helm lint` error instead of a startup-time WARN — that's the explicit goal, but it's a behaviour change worth noting.
- [x] Related issues referenced — #286 (Closes), refs #245.
