### PR TITLE
docs: dewrap admonition prose to one line per paragraph

### DIFF
--- a/docs/gateway-api/grpcroute.md
+++ b/docs/gateway-api/grpcroute.md
@@ -2,16 +2,9 @@
 
 !!! warning "Not supported in v3"
 
-    The v3 controller's in-process L7 proxy intercepts all tunnel
-    traffic and has no gRPC matcher, so GRPCRoute requests return
-    `404`. The CRD is still watched for status reasons, but no runtime
-    routing happens. See the [GRPCRoute limitation](limitations.md#grpcroute-is-not-supported-in-v3)
-    for the full explanation, and the [v2 → v3 migration guide](../upgrading/v2-to-v3.md)
-    for workarounds. Workaround: use HTTPRoute, or stay on the v2.x
-    chart line until gRPC support is reinstated in the proxy.
+    The v3 controller's in-process L7 proxy intercepts all tunnel traffic and has no gRPC matcher, so GRPCRoute requests return `404`. The CRD is still watched for status reasons, but no runtime routing happens. See the [GRPCRoute limitation](limitations.md#grpcroute-is-not-supported-in-v3) for the full explanation, and the [v2 → v3 migration guide](../upgrading/v2-to-v3.md) for workarounds. Workaround: use HTTPRoute, or stay on the v2.x chart line until gRPC support is reinstated in the proxy.
 
-The examples below describe the v0.8-era behaviour and remain in the
-docs for historical context only — none of this routes in v3.
+The examples below describe the v0.8-era behaviour and remain in the docs for historical context only — none of this routes in v3.
 
 GRPCRoute enables routing gRPC traffic through Cloudflare Tunnel with service and method-level matching.
 

--- a/docs/gateway-api/index.md
+++ b/docs/gateway-api/index.md
@@ -93,8 +93,4 @@ flowchart TB
 
 !!! info "Full Sync"
 
-    Any change to HTTPRoute triggers a full configuration sync to
-    Cloudflare Tunnel. The controller rebuilds the entire ingress
-    configuration on each reconciliation. GRPCRoute is still watched
-    for status reasons but does not feed the runtime proxy in v3 — see
-    [limitations](limitations.md#grpcroute-is-not-supported-in-v3).
+    Any change to HTTPRoute triggers a full configuration sync to Cloudflare Tunnel. The controller rebuilds the entire ingress configuration on each reconciliation. GRPCRoute is still watched for status reasons but does not feed the runtime proxy in v3 — see [limitations](limitations.md#grpcroute-is-not-supported-in-v3).

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,10 +34,7 @@ See the [L7 Proxy Guide](guides/l7-proxy.md) for setup and examples.
 
 !!! warning
 
-    The controller assumes **exclusive ownership** of the tunnel configuration.
-    It will remove any ingress rules not managed by HTTPRoute resources.
-    Do not use a tunnel that has manually configured routes or is shared with
-    other systems.
+    The controller assumes **exclusive ownership** of the tunnel configuration. It will remove any ingress rules not managed by HTTPRoute resources. Do not use a tunnel that has manually configured routes or is shared with other systems.
 
 ## Quick Start
 

--- a/docs/reference/crd-reference.md
+++ b/docs/reference/crd-reference.md
@@ -119,12 +119,7 @@ spec:
 
 !!! warning "Not supported in v3"
 
-    GRPCRoute is recognised as a CRD kind but does not route in v3 —
-    the in-process L7 proxy has no gRPC matcher and requests return
-    `404`. The example below is preserved as a v0.8-era reference; use
-    HTTPRoute as a v3 workaround, or stay on the v2.x chart line. See
-    the [GRPCRoute limitation](../gateway-api/limitations.md#grpcroute-is-not-supported-in-v3)
-    for the full explanation.
+    GRPCRoute is recognised as a CRD kind but does not route in v3 — the in-process L7 proxy has no gRPC matcher and requests return `404`. The example below is preserved as a v0.8-era reference; use HTTPRoute as a v3 workaround, or stay on the v2.x chart line. See the [GRPCRoute limitation](../gateway-api/limitations.md#grpcroute-is-not-supported-in-v3) for the full explanation.
 
 Standard Gateway API GRPCRoute:
 


### PR DESCRIPTION
## Summary

Reflow four admonition blocks I added or last touched in #294 to one continuous line per paragraph, matching CLAUDE.md's "One continuous line per paragraph" rule. The wrapped shape leaked in from my Go-godoc training reflex and breaks the renderer's natural width handling on narrow viewports.

## Changes

- `docs/index.md`: dewrap the top-of-page `!!! warning` about exclusive tunnel ownership.
- `docs/gateway-api/index.md`: dewrap the Full-Sync admonition that explains GRPCRoute's status-only reconciliation in v3.
- `docs/gateway-api/grpcroute.md`: dewrap the `!!! warning "Not supported in v3"` admonition + the standalone v0.8-era examples-context paragraph below it.
- `docs/reference/crd-reference.md`: dewrap the `!!! warning "Not supported in v3"` admonition above the GRPCRoute example.

No semantic change. No links, code fences, or anchors moved. The four blocks I touched in #294 are the scope; other long-standing hardwraps across `docs/` are out of scope for this PR and tracked separately.

## Testing

- [x] `markdownlint-cli2 docs/...` — 0 errors
- [x] `mkdocs build --strict` — clean
- [ ] Manual testing — N/A, prose-only

## Documentation

- [ ] README updated — N/A
- [x] Code comments added for complex logic — N/A, dewrap only
- [ ] CLAUDE.md updated — N/A

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] Breaking changes documented — N/A
- [x] Related issues referenced — N/A

## Additional Notes

Pure-text PR. Homelab deploy waived (no runtime touches). Single commit, easy to audit visually.
