### PR TITLE
fix(controller): push cached proxy config on EndpointSlice churn

### DIFF
--- a/charts/cloudflare-tunnel-gateway-controller/templates/clusterrole.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/templates/clusterrole.yaml
@@ -31,6 +31,13 @@ rules:
   - apiGroups: [""]
     resources: ["services", "namespaces"]
     verbs: ["get", "list", "watch"]
+  # EndpointSlice: the ProxyEndpointReconciler watches EndpointSlices owned
+  # by the proxy headless Service so that a newly-joined proxy pod gets
+  # the cached config pushed to it immediately, rather than waiting for
+  # the next HTTPRoute reconcile. Read-only.
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
   # Secrets: the controller only reads them (Cloudflare credentials, TLS
   # certificate refs, BackendTLSPolicy CA bundles). It does not create,
   # mutate, or delete Secrets, so write verbs are intentionally absent.

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -29,6 +29,13 @@ rules:
   - apiGroups: [""]
     resources: ["services", "namespaces"]
     verbs: ["get", "list", "watch"]
+  # EndpointSlice: the ProxyEndpointReconciler watches EndpointSlices owned
+  # by the proxy headless Service so that a newly-joined proxy pod gets
+  # the cached config pushed to it immediately, rather than waiting for
+  # the next HTTPRoute reconcile. Read-only.
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
   # Secrets: the controller only reads them (Cloudflare credentials, TLS
   # certificate refs, BackendTLSPolicy CA bundles). It does not create,
   # mutate, or delete Secrets, so write verbs are intentionally absent.

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -165,6 +165,16 @@ Pushes routing config to the L7 proxy pods over HTTP:
 - **Endpoint discovery**: Resolves the proxy's headless Service DNS name to per-pod URLs (`--proxy-endpoints` is a required CLI flag — `internal/controller/manager.go` rejects an empty value at startup).
 - **Conversion**: Translates HTTPRoute specs into the proxy's wire-format config via `internal/proxy/converter.go`.
 - **Auth**: When `proxy.authTokenSecretRef.name` is set, attaches the Bearer token to every push so unauthenticated clients cannot reprogram the proxy.
+- **Last-config cache**: After every successful `SyncRoutes` push, ProxySyncer caches the built `*proxy.Config` under its mutex. `ResyncEndpoints(endpoints)` replays that cached config to a supplied endpoint list without rebuilding from HTTPRoutes — the bootstrap-race fix below depends on this.
+
+### Config push triggers
+
+Config push fires on TWO independent events:
+
+1. **HTTPRoute reconcile** — the canonical path. Any change to an HTTPRoute (create, update, delete, status flip) reconciles the route set, rebuilds the proxy config, caches it, and pushes to every endpoint currently visible to the headless-Service DNS lookup.
+2. **Proxy EndpointSlice change** — the bootstrap-race fix from issue #293. `ProxyEndpointReconciler` (`internal/controller/proxy_endpoint_reconciler.go`) watches EndpointSlices labelled `kubernetes.io/service-name=<headless-svc>` for each Service named in `--proxy-endpoints`. On any change it calls `ProxySyncer.ResyncEndpoints` with the static `--proxy-endpoints` URL list, which re-resolves DNS and pushes the cached config to every replica it finds — including the newly-joined ones.
+
+Without the second trigger a proxy pod that becomes Ready between HTTPRoute reconciles stays at `/readyz == 503` forever: the first HTTPRoute reconcile published config to the pods that existed at the time, and there is no next HTTPRoute change to fan out to the new pod. The historic workaround was `kubectl rollout restart deployment <controller>`; the watcher removes that requirement.
 
 GRPCRoutes are NOT pushed — the proxy converter does not yet support gRPC-specific routing semantics. v3's `OverrideProxy` hook intercepts ALL tunnel traffic, so gRPC requests reach the proxy without a matching route and return `404`. The Cloudflare-side ingress rules built by `internal/ingress/grpc_builder` exist only so the Cloudflare dashboard shows the expected hostname → service mapping — they are not consulted at runtime. See [GRPCRoute limitations](../gateway-api/limitations.md#grpcroute-is-not-supported-in-v3).
 

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -23,6 +23,26 @@ import (
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/config"
 )
 
+// installSchemes registers the Gateway API v1, v1beta1 (for ReferenceGrant)
+// and GatewayClassConfig CRD types into the manager's runtime scheme.
+// Extracted from Run so the per-reconciler setup chain in Run stays under
+// the cyclomatic-complexity gate.
+func installSchemes(mgr ctrl.Manager) error {
+	if err := gatewayv1.Install(mgr.GetScheme()); err != nil {
+		return errors.Wrap(err, "failed to add gateway-api scheme")
+	}
+
+	if err := gatewayv1beta1.Install(mgr.GetScheme()); err != nil {
+		return errors.Wrap(err, "failed to add gateway-api v1beta1 scheme")
+	}
+
+	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		return errors.Wrap(err, "failed to add GatewayClassConfig scheme")
+	}
+
+	return nil
+}
+
 // Config holds all configuration options for the controller manager.
 // Values are typically populated from CLI flags or environment variables.
 type Config struct {
@@ -114,19 +134,8 @@ func Run(ctx context.Context, cfg *Config) error {
 		return errors.Wrap(err, "failed to create manager")
 	}
 
-	// Register Gateway API types
-	if err := gatewayv1.Install(mgr.GetScheme()); err != nil {
-		return errors.Wrap(err, "failed to add gateway-api scheme")
-	}
-
-	// Register Gateway API v1beta1 types (required for ReferenceGrant)
-	if err := gatewayv1beta1.Install(mgr.GetScheme()); err != nil {
-		return errors.Wrap(err, "failed to add gateway-api v1beta1 scheme")
-	}
-
-	// Register GatewayClassConfig CRD types
-	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
-		return errors.Wrap(err, "failed to add GatewayClassConfig scheme")
+	if err := installSchemes(mgr); err != nil {
+		return err
 	}
 
 	// Create metrics collector and register with controller-runtime
@@ -202,6 +211,10 @@ func Run(ctx context.Context, cfg *Config) error {
 		return errors.Wrap(err, "failed to setup gatewayclassconfig controller")
 	}
 
+	if err := setupProxyEndpointReconciler(mgr, proxySyncer, proxyEndpoints); err != nil {
+		return err
+	}
+
 	if err := setupStatusReconcilers(mgr, cfg.ControllerName); err != nil {
 		return err
 	}
@@ -218,6 +231,28 @@ func Run(ctx context.Context, cfg *Config) error {
 
 	if err := mgr.Start(ctx); err != nil {
 		return errors.Wrap(err, "failed to start manager")
+	}
+
+	return nil
+}
+
+// setupProxyEndpointReconciler wires the EndpointSlice watcher that
+// re-pushes the cached proxy config whenever a new proxy pod joins (or
+// an old one leaves) the headless Service's endpoints. Without this, a
+// pod that becomes Ready BETWEEN HTTPRoute reconciles stays at
+// /readyz == 503 until the next HTTPRoute change. Issue #293.
+//
+// Extracted from Run so the per-reconciler setup chain in Run stays
+// under the cyclomatic-complexity gate.
+func setupProxyEndpointReconciler(mgr ctrl.Manager, proxySyncer *ProxySyncer, proxyEndpoints []string) error {
+	reconciler := &ProxyEndpointReconciler{
+		Client:         mgr.GetClient(),
+		ProxySyncer:    proxySyncer,
+		ProxyEndpoints: proxyEndpoints,
+	}
+
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		return errors.Wrap(err, "failed to setup proxy endpoint reconciler")
 	}
 
 	return nil

--- a/internal/controller/proxy_endpoint_reconciler.go
+++ b/internal/controller/proxy_endpoint_reconciler.go
@@ -1,0 +1,219 @@
+package controller
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/logging"
+)
+
+// ipv4SegmentCount is the number of dotted segments in an IPv4 address;
+// pulled out to avoid a magic-number lint hit in isProbablyIP.
+const ipv4SegmentCount = 4
+
+// proxyServiceTarget identifies one proxy headless Service the reconciler
+// must watch. It is the (namespace, service-name) pair extracted from a
+// --proxy-endpoints URL by parseProxyServiceTargets, and the EndpointSlice
+// watch predicate matches against the EndpointSlice's
+// `kubernetes.io/service-name` label and its namespace.
+type proxyServiceTarget struct {
+	namespace string
+	name      string
+}
+
+// ProxyEndpointReconciler watches EndpointSlices for the proxy headless
+// Services named in --proxy-endpoints. Whenever the endpoint set changes
+// (a new proxy pod becomes Ready, an old one drains, the Service is
+// rebuilt), it triggers ProxySyncer.ResyncEndpoints so the cached config
+// gets pushed to every replica -- including replicas that joined AFTER
+// the most recent HTTPRoute reconcile.
+//
+// Without this, a proxy pod that joins the EndpointSlice between
+// HTTPRoute reconciles stays at /readyz == 503 forever (issue #293):
+// the controller's push logic is HTTPRoute-driven and never re-iterates
+// the endpoint list on Service churn. The workaround was
+// `kubectl rollout restart deployment <controller>`, which is easy to
+// forget during a chart bump.
+type ProxyEndpointReconciler struct {
+	Client      client.Client
+	ProxySyncer *ProxySyncer
+	// ProxyEndpoints holds the raw --proxy-endpoints URLs. The reconciler
+	// passes them through to ProxySyncer.ResyncEndpoints unchanged; the
+	// syncer's resolveEndpoints does the DNS expansion to per-pod IPs.
+	ProxyEndpoints []string
+
+	// targets is parsed from ProxyEndpoints at SetupWithManager time and
+	// drives the EndpointSlice watch predicate. Each entry corresponds
+	// to one headless Service whose churn should trigger a resync.
+	targets []proxyServiceTarget
+}
+
+// Reconcile implements reconcile.Reconciler. It is invoked whenever an
+// EndpointSlice for one of the proxy headless Services changes; the
+// concrete EndpointSlice contents are intentionally ignored -- we only
+// care that "something moved", at which point we hand the full
+// endpoint URL list off to ProxySyncer.ResyncEndpoints which re-resolves
+// DNS and pushes the cached config to every replica it finds.
+func (r *ProxyEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := logging.Component(ctx, "proxy-endpoint-reconciler")
+	logger.Info("proxy EndpointSlice change observed; resyncing cached config",
+		"endpointslice", req.String(),
+	)
+
+	ctx = logging.WithLogger(ctx, logger)
+
+	if err := r.ProxySyncer.ResyncEndpoints(ctx, r.ProxyEndpoints); err != nil {
+		// Non-fatal: the next endpoint-change event (or the next
+		// HTTPRoute reconcile) gets another chance. Surface as an
+		// error so controller-runtime exponentially backs off.
+		return ctrl.Result{}, errors.Wrap(err, "resync proxy endpoints")
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager wires the reconciler into the manager with an
+// EndpointSlice watch filtered to the proxy headless Services. Filtering
+// is done via a predicate matching the EndpointSlice's
+// `kubernetes.io/service-name` label against the parsed target list --
+// cheaper than a label-selector list-watch and resilient to the rest of
+// the cluster's EndpointSlice churn.
+func (r *ProxyEndpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.targets = parseProxyServiceTargets(r.ProxyEndpoints)
+
+	if len(r.targets) == 0 {
+		// No parseable Service targets means we cannot scope the watch
+		// to anything meaningful. The controller-bootstrap layer already
+		// rejects an empty --proxy-endpoints list, so this branch only
+		// fires when every endpoint URL was a bare IP or other shape
+		// that doesn't map to a Service. Skip the watch rather than
+		// drown the controller in cluster-wide EndpointSlice events.
+		return nil
+	}
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("proxy-endpoint-reconciler").
+		For(&discoveryv1.EndpointSlice{}, builder.WithPredicates(r.endpointSliceMatchesProxy())).
+		Complete(r); err != nil {
+		return errors.Wrap(err, "setup proxy endpoint reconciler")
+	}
+
+	return nil
+}
+
+// endpointSliceMatchesProxy returns a predicate that fires only on
+// EndpointSlices whose owning Service matches one of our parsed
+// proxy-endpoint targets. controller-runtime's predicate stack runs
+// once per event before enqueueing the reconcile request.
+func (r *ProxyEndpointReconciler) endpointSliceMatchesProxy() predicate.Predicate {
+	matches := func(obj client.Object) bool {
+		slice, ok := obj.(*discoveryv1.EndpointSlice)
+		if !ok {
+			return false
+		}
+
+		serviceName := slice.Labels[discoveryv1.LabelServiceName]
+		if serviceName == "" {
+			return false
+		}
+
+		for _, target := range r.targets {
+			if target.name == serviceName && target.namespace == slice.Namespace {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return matches(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return matches(e.ObjectNew) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return matches(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return matches(e.Object) },
+	}
+}
+
+// parseProxyServiceTargets extracts (namespace, service-name) pairs from a
+// list of --proxy-endpoints URLs. Recognises the Kubernetes cluster-DNS
+// shapes: `<svc>`, `<svc>.<ns>`, `<svc>.<ns>.svc`, and the fully-qualified
+// `<svc>.<ns>.svc.<cluster-domain>`. A URL whose host is a bare IP or an
+// unrecognised shape is silently skipped -- the caller treats an empty
+// target list as "no watch", which is the conservative outcome.
+func parseProxyServiceTargets(endpoints []string) []proxyServiceTarget {
+	seen := map[proxyServiceTarget]struct{}{}
+	out := make([]proxyServiceTarget, 0, len(endpoints))
+
+	for _, raw := range endpoints {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+
+		parsed, err := url.Parse(trimmed)
+		if err != nil || parsed.Host == "" {
+			continue
+		}
+
+		host := parsed.Hostname()
+		if host == "" {
+			continue
+		}
+
+		// Bare IP is unparseable as a Service ref; skip.
+		if strings.ContainsAny(host, ":") || isProbablyIP(host) {
+			continue
+		}
+
+		parts := strings.Split(host, ".")
+		if len(parts) < 2 {
+			// `service` alone -- no namespace info, skip.
+			continue
+		}
+
+		target := proxyServiceTarget{name: parts[0], namespace: parts[1]}
+		if _, ok := seen[target]; ok {
+			continue
+		}
+
+		seen[target] = struct{}{}
+
+		out = append(out, target)
+	}
+
+	return out
+}
+
+// isProbablyIP returns true for an IPv4-looking dotted-quad. We don't try
+// to be exhaustive about IPv6 because Cluster-DNS Service names never
+// look like one and a false negative here just means the URL falls
+// through to the multi-segment Service-name parser.
+func isProbablyIP(host string) bool {
+	parts := strings.Split(host, ".")
+	if len(parts) != ipv4SegmentCount {
+		return false
+	}
+
+	for _, p := range parts {
+		if p == "" {
+			return false
+		}
+
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/internal/controller/proxy_endpoint_reconciler_test.go
+++ b/internal/controller/proxy_endpoint_reconciler_test.go
@@ -1,0 +1,131 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseProxyServiceTargets pins the URL-to-(svc,ns) shape recognition
+// the EndpointSlice watch predicate depends on. Each row is a small fact
+// about what we DO and DON'T pick up:
+//
+//   - cluster-DNS shapes (1, 2, and 3+ dotted segments after the host) all
+//     resolve to the same (svc, ns) pair because we only need the first
+//     two segments.
+//   - bare hosts (no namespace) are skipped: we cannot watch
+//     EndpointSlices across the cluster, and a single-segment Service
+//     name is ambiguous.
+//   - bare IPs are skipped for the same reason -- there is no Service
+//     identity to match against.
+//   - empty / unparseable URLs are silently dropped.
+//   - duplicates collapse so the watch predicate doesn't double-fire.
+func TestParseProxyServiceTargets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []proxyServiceTarget
+	}{
+		{
+			name: "fully qualified cluster-DNS",
+			in:   []string{"http://cftunnel-proxy.cloudflare-tunnel-system.svc.cluster.local:8081/config"},
+			want: []proxyServiceTarget{{name: "cftunnel-proxy", namespace: "cloudflare-tunnel-system"}},
+		},
+		{
+			name: "svc and ns only",
+			in:   []string{"http://cftunnel-proxy.cloudflare-tunnel-system:8081/config"},
+			want: []proxyServiceTarget{{name: "cftunnel-proxy", namespace: "cloudflare-tunnel-system"}},
+		},
+		{
+			name: "svc.ns.svc shorthand",
+			in:   []string{"http://cftunnel-proxy.cloudflare-tunnel-system.svc:8081/config"},
+			want: []proxyServiceTarget{{name: "cftunnel-proxy", namespace: "cloudflare-tunnel-system"}},
+		},
+		{
+			name: "bare service name (no namespace) is skipped",
+			in:   []string{"http://cftunnel-proxy:8081/config"},
+			want: []proxyServiceTarget{},
+		},
+		{
+			name: "bare IPv4 is skipped",
+			in:   []string{"http://10.0.0.5:8081/config"},
+			want: []proxyServiceTarget{},
+		},
+		{
+			name: "empty / blank entries are silently dropped",
+			in:   []string{"", "   "},
+			want: []proxyServiceTarget{},
+		},
+		{
+			name: "unparseable URL is silently dropped",
+			in:   []string{":::not a url:::"},
+			want: []proxyServiceTarget{},
+		},
+		{
+			name: "duplicates collapse",
+			in: []string{
+				"http://cftunnel-proxy.cloudflare-tunnel-system.svc.cluster.local:8081/config",
+				"http://cftunnel-proxy.cloudflare-tunnel-system:8081/config",
+			},
+			want: []proxyServiceTarget{{name: "cftunnel-proxy", namespace: "cloudflare-tunnel-system"}},
+		},
+		{
+			name: "multiple distinct headless services kept",
+			in: []string{
+				"http://proxy-a.ns-a.svc.cluster.local:8081/config",
+				"http://proxy-b.ns-b.svc.cluster.local:8081/config",
+			},
+			want: []proxyServiceTarget{
+				{name: "proxy-a", namespace: "ns-a"},
+				{name: "proxy-b", namespace: "ns-b"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := parseProxyServiceTargets(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestIsProbablyIP pins the cheap dotted-quad detector. False negatives
+// (an IP that gets classified as a Service) just fall through to the
+// multi-segment parser and produce a meaningless target -- ugly but
+// recoverable. False positives (a Service host that looks like an IP)
+// would silently drop the watch. We accept ASCII-digit-only segments
+// in groups of four; an IPv6 host (which always contains "[" or "::")
+// never satisfies the predicate. Service DNS names never look like
+// dotted quads.
+func TestIsProbablyIP(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"10.0.0.5", true},
+		{"255.255.255.255", true},
+		{"127.0.0.1", true},
+		{"1.2.3", false},
+		{"1.2.3.4.5", false},
+		{"a.b.c.d", false},
+		{"10.0.0.x", false},
+		{"", false},
+		{"10..0.5", false},
+		{"my-svc.ns.svc.cluster.local", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, isProbablyIP(tc.host))
+		})
+	}
+}

--- a/internal/controller/proxy_syncer.go
+++ b/internal/controller/proxy_syncer.go
@@ -38,6 +38,14 @@ const configMapKind = "ConfigMap"
 
 // ProxySyncer converts HTTPRoute resources to proxy config
 // and pushes it to enhanced-cloudflared replicas via HTTP API.
+//
+// lastCfg caches the most recent successfully-built config so the
+// endpoint-watcher (see ProxyEndpointReconciler) can re-push to a
+// newly-joined proxy pod without waiting for the next HTTPRoute
+// reconcile. Before the first SyncRoutes call, lastCfg is nil and
+// ResyncEndpoints is a no-op -- there is nothing to push yet.
+// Guarded by syncMu so the cache update is consistent with the push
+// it follows.
 type ProxySyncer struct {
 	clusterDomain       string
 	logger              *slog.Logger
@@ -47,6 +55,7 @@ type ProxySyncer struct {
 	tlsResolver         proxy.BackendTLSResolver
 	gatewayCertResolver proxy.GatewayClientCertResolver
 	syncMu              sync.Mutex
+	lastCfg             *proxy.Config
 }
 
 // NewProxySyncer creates a ProxySyncer for pushing config to proxy replicas.
@@ -623,6 +632,73 @@ func (s *ProxySyncer) SyncRoutes(
 		"rules", len(cfg.Rules),
 		"version", cfg.Version,
 	)
+
+	// Cache the successfully-pushed config so ResyncEndpoints can replay
+	// it to a newly-joined proxy pod that arrives between HTTPRoute
+	// reconciles. We cache AFTER the push so a failed push does not poison
+	// the cache with a config the replicas never actually received.
+	s.lastCfg = cfg
+
+	return nil
+}
+
+// ResyncEndpoints replays the most recent successfully-pushed config to the
+// supplied endpoints without rebuilding from HTTPRoutes. The endpoint
+// watcher uses this to bring a newly-joined proxy pod up to date when the
+// HTTPRoute set has not changed; without it the new pod stays at
+// /readyz == 503 until the next HTTPRoute reconcile, which is the race
+// the workaround "kubectl rollout restart deployment <controller>" was
+// papering over.
+//
+// Before the first SyncRoutes call (or after a controller restart that
+// has not yet built any config) lastCfg is nil and this is a no-op --
+// nothing meaningful to push yet, and the next HTTPRoute reconcile will
+// reach the new endpoint along with the others.
+//
+// Push errors are returned but not fatal: a transient endpoint flake
+// gets corrected on the next endpoint-change event.
+func (s *ProxySyncer) ResyncEndpoints(ctx context.Context, endpoints []string) error {
+	// Resolve headless service DNS names before acquiring the lock so a
+	// slow DNS lookup does not block a concurrent SyncRoutes -- mirrors
+	// the same pattern in SyncRoutes for symmetric lock-hold time.
+	resolved := resolveEndpoints(ctx, endpoints)
+
+	s.syncMu.Lock()
+	defer s.syncMu.Unlock()
+
+	if s.lastCfg == nil {
+		return nil
+	}
+
+	logger := logging.FromContext(ctx)
+	if logger == slog.Default() {
+		logger = s.logger
+	}
+
+	logger.Info("resyncing cached proxy config to endpoints",
+		"endpoints", len(resolved),
+		"version", s.lastCfg.Version,
+	)
+
+	results := s.pusher.Push(ctx, s.lastCfg, resolved)
+
+	var pushErrors []error
+
+	for _, result := range results {
+		if result.Err != nil {
+			logger.Error("failed to resync config to endpoint",
+				"endpoint", result.Endpoint,
+				"error", result.Err,
+			)
+
+			pushErrors = append(pushErrors, result.Err)
+		}
+	}
+
+	if len(pushErrors) > 0 {
+		return fmt.Errorf("failed to resync config to %d/%d endpoints: %w",
+			len(pushErrors), len(resolved), errors.Join(pushErrors...))
+	}
 
 	return nil
 }

--- a/internal/controller/proxy_syncer_test.go
+++ b/internal/controller/proxy_syncer_test.go
@@ -160,6 +160,123 @@ func TestProxySyncer_NoRoutes_PushesEmptyConfig(t *testing.T) {
 	assert.True(t, receivedConfig.Version > 0, "version should be positive even with no routes")
 }
 
+// TestProxySyncer_ResyncEndpoints_NoLastConfig pins the bootstrap-safe
+// no-op: before any SyncRoutes has succeeded the cache is empty, and
+// ResyncEndpoints must not invent a config or hit the wire. A new pod
+// arriving in this window catches up on the next HTTPRoute reconcile.
+func TestProxySyncer_ResyncEndpoints_NoLastConfig(t *testing.T) {
+	t.Parallel()
+
+	var pushCount atomic.Int32
+
+	configServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodPut {
+			pushCount.Add(1)
+		}
+
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer configServer.Close()
+
+	testClient := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+
+	syncer := controller.NewProxySyncer(
+		"cluster.local",
+		"",
+		"",
+		testClient,
+		slog.Default(),
+	)
+
+	err := syncer.ResyncEndpoints(context.Background(), []string{configServer.URL + "/config"})
+	require.NoError(t, err, "ResyncEndpoints must be a no-op before the first SyncRoutes")
+
+	assert.Equal(t, int32(0), pushCount.Load(), "no push must happen when lastCfg is nil")
+}
+
+// TestProxySyncer_ResyncEndpoints_ReplaysLastConfig pins issue #293's
+// fix: after a successful SyncRoutes, calling ResyncEndpoints with a
+// freshly-discovered endpoint pushes the cached config to it without
+// touching the HTTPRoute set. The cached version must be preserved
+// across the resync (no rebuild, no version bump).
+func TestProxySyncer_ResyncEndpoints_ReplaysLastConfig(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	var (
+		firstReceived  proxy.Config
+		secondReceived proxy.Config
+		pushCount      atomic.Int32
+	)
+
+	configServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodPut {
+			count := pushCount.Add(1)
+			target := &firstReceived
+			if count == 2 {
+				target = &secondReceived
+			}
+
+			if decodeErr := json.NewDecoder(req.Body).Decode(target); decodeErr != nil {
+				writer.WriteHeader(http.StatusBadRequest)
+
+				return
+			}
+		}
+
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer configServer.Close()
+
+	testClient := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+
+	syncer := controller.NewProxySyncer(
+		"cluster.local",
+		"",
+		"",
+		testClient,
+		slog.Default(),
+	)
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "web-route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							makeBackendRef("web-svc", 80, 1),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	endpoint := configServer.URL + "/config"
+
+	require.NoError(t, syncer.SyncRoutes(context.Background(), []string{endpoint}, routes, nil))
+	require.Equal(t, int32(1), pushCount.Load(), "first sync must push once")
+	require.NotEmpty(t, firstReceived.Rules, "first push must carry the built config")
+
+	// Simulate a newly-joined proxy endpoint URL; in production the URL
+	// itself is unchanged (the headless Service hostname resolves to a
+	// new IP set), but the syncer treats endpoints as opaque strings, so
+	// re-pushing to the same URL is a sound proxy for the real scenario.
+	require.NoError(t, syncer.ResyncEndpoints(context.Background(), []string{endpoint}))
+	require.Equal(t, int32(2), pushCount.Load(), "resync must push once more")
+
+	assert.Equal(t, firstReceived.Version, secondReceived.Version,
+		"resync must replay the cached config verbatim -- no version bump, no rebuild")
+	assert.Equal(t, len(firstReceived.Rules), len(secondReceived.Rules),
+		"resync must replay the cached rules verbatim")
+}
+
 func TestProxySyncer_SyncRoutes_H2CBackend(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fix the proxy bootstrap race documented in #293: a proxy pod that becomes Ready BETWEEN HTTPRoute reconciles used to stay at `/readyz == 503` forever, because the controller's push logic was HTTPRoute-driven and never re-iterated the endpoint list on Service churn. The historic workaround was `kubectl rollout restart deployment <controller>` after every chart bump — easy to forget, ~60 minutes of hang when missed.

Implements [option (1)](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/293) from the issue: watch EndpointSlices for the proxy headless Service and trigger a re-push on change.

## How it works

1. **`ProxySyncer.lastCfg`** — every successful `SyncRoutes` caches the built `*proxy.Config` under the existing `syncMu`. The cache update happens AFTER the push succeeds so a failed push does not poison it.
2. **`ProxySyncer.ResyncEndpoints(ctx, endpoints)`** — replays the cached config to the supplied endpoints without rebuilding from HTTPRoutes. Preserves version, rules, BackendTLS decisions verbatim. Before the first `SyncRoutes` it is a no-op; the next HTTPRoute reconcile catches up.
3. **`ProxyEndpointReconciler`** — watches EndpointSlices owned by the proxy headless Service(s) named in `--proxy-endpoints`. The Service identity is parsed out of each URL via `parseProxyServiceTargets` (recognises cluster-DNS shapes `<svc>.<ns>`, `<svc>.<ns>.svc`, fully-qualified; bare hosts and bare IPs silently skipped). A predicate matches the EndpointSlice's `kubernetes.io/service-name` label against the parsed `(svc, ns)` set so unrelated EndpointSlice churn never triggers the reconciler.
4. On any EndpointSlice event the reconciler calls `ProxySyncer.ResyncEndpoints` with the static `--proxy-endpoints` URL list. The syncer's `resolveEndpoints` re-resolves DNS, which now includes the newly-joined pod IP, and pushes the cached config to it.

## Tests (TDD)

- `TestProxySyncer_ResyncEndpoints_NoLastConfig` — bootstrap-safe no-op before any `SyncRoutes`.
- `TestProxySyncer_ResyncEndpoints_ReplaysLastConfig` — cached config replayed verbatim (same version, same rule count), so a new pod sees byte-identical config to its older siblings.
- `TestParseProxyServiceTargets` — URL-to-`(svc, ns)` shape recognition across cluster-DNS, bare service, bare IP, empty, unparseable, and duplicate inputs.
- `TestIsProbablyIP` — cheap dotted-quad detector.

## RBAC

Adds `discovery.k8s.io / endpointslices` read-only verbs in both `deploy/rbac/role.yaml` and the chart-rendered ClusterRole. The `rbacdrift` test still passes (chart and deploy stay in sync). No write verbs added — the reconciler only watches.

## Docs

`docs/development/architecture.md` gains a "Config push triggers" section under ProxySyncer explaining the two-trigger model (HTTPRoute reconcile + EndpointSlice change) and what each trigger covers. The historic workaround is documented as no-longer-required.

## Adjacent refactor

Extracted `installSchemes(mgr)` and `setupProxyEndpointReconciler(...)` helpers from `manager.Run` so the new wiring stays under the cyclomatic-complexity gate.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [x] Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller`)
- [x] Documentation site builds strict (`mkdocs build --strict`)
- [ ] Manual testing completed — pending homelab deploy + scale-up verify (see Acceptance)

## Documentation

- [ ] README updated — N/A
- [x] Code comments added for complex logic (cache rationale, watch predicate, IP detector, parser shapes)
- [ ] CLAUDE.md updated — N/A

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] Breaking changes documented — N/A, additive watcher
- [x] Related issues referenced (Closes #293)

## Acceptance

The issue requires: "scale proxy from 1 to 2 (or 2 to 3), wait for new pod to be Ready, assert `/readyz` returns 200 within 30 seconds of pod Ready transition, even though no HTTPRoute was modified." Unit tests pin the syncer + parser contracts; full acceptance requires a homelab deploy of this PR followed by a `kubectl scale deployment cloudflare-tunnel-gateway-controller-proxy --replicas=+1` smoke run. That will happen as part of the standard pre-merge homelab cycle.
