### PR TITLE
feat(controller): watch tunnel-token Secret to auto-roll proxy on rotation

### DIFF
--- a/charts/cloudflare-tunnel-gateway-controller/templates/clusterrole.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/templates/clusterrole.yaml
@@ -38,6 +38,14 @@ rules:
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
+  # Deployments: the ProxySecretReconciler patches the proxy Deployment's
+  # pod-template annotation when the tunnel-token Secret rotates, so
+  # Kubernetes rolls the pods natively and cloudflared picks up the new
+  # credential. List + patch only; no create/delete -- the chart owns
+  # Deployment lifecycle. Issue #114.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
   # Secrets: the controller only reads them (Cloudflare credentials, TLS
   # certificate refs, BackendTLSPolicy CA bundles). It does not create,
   # mutate, or delete Secrets, so write verbs are intentionally absent.

--- a/charts/cloudflare-tunnel-gateway-controller/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
             {{- if .Values.proxy.authTokenSecretRef.name }}
             - "--proxy-auth-token=$(PROXY_AUTH_TOKEN)"
             {{- end }}
+            {{- if .Values.proxy.tunnelTokenSecretRef.name }}
+            - "--proxy-token-secret={{ .Release.Namespace }}/{{ .Values.proxy.tunnelTokenSecretRef.name }}"
+            {{- end }}
             {{- if .Values.leaderElection.enabled }}
             - "--leader-elect=true"
             - "--leader-election-name={{ .Values.leaderElection.leaseName }}"

--- a/charts/cloudflare-tunnel-gateway-controller/tests/deployment_test.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/tests/deployment_test.yaml
@@ -620,3 +620,20 @@ tests:
         contains:
           path: spec.template.spec.containers[0].args
           content: "--leader-election-namespace=my-namespace"
+
+  - it: should wire --proxy-token-secret to the tunnel-token Secret when configured
+    # The chart auto-derives --proxy-token-secret=<release-namespace>/<secret-name>
+    # from proxy.tunnelTokenSecretRef.name. Without this the controller-side
+    # SecretReconciler stays off and a rotated tunnel-token Secret never
+    # propagates into the proxy pods. Issue #114.
+    set:
+      proxy:
+        tunnelTokenSecretRef:
+          name: cloudflare-tunnel-token
+    release:
+      namespace: cloudflare-tunnel-system
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--proxy-token-secret=cloudflare-tunnel-system/cloudflare-tunnel-token"

--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -64,6 +64,8 @@ func init() {
 	// L7 proxy data plane configuration (--proxy-endpoints is required in v3)
 	rootCmd.Flags().StringSlice("proxy-endpoints", nil, "Proxy config API endpoints (e.g., http://proxy-0:8081,http://proxy-1:8081). Required; the chart wires this to the proxy's headless Service.")
 	rootCmd.Flags().String("proxy-auth-token", "", "Bearer token for authenticating proxy config push requests")
+	rootCmd.Flags().String("proxy-token-secret", "", "Tunnel-token Secret to watch in `<namespace>/<name>` form; when set, the controller rolls the proxy Deployment whenever the Secret data changes (issue #114). Empty disables the watcher.")
+	rootCmd.Flags().String("proxy-deployment-label", "", "Label selector identifying the proxy Deployment(s) to roll on tunnel-token change, in `key=value` form. Defaults to `app.kubernetes.io/component=proxy` (matches the chart).")
 
 	// Deprecated: --gateway-class-name is no longer used. The controller discovers
 	// GatewayClasses by spec.controllerName, not by name.
@@ -141,8 +143,10 @@ func runController(_ *cobra.Command, _ []string) error {
 		LeaderElectNS:   viper.GetString("leader-election-namespace"),
 		LeaderElectName: viper.GetString("leader-election-name"),
 
-		ProxyEndpoints: viper.GetStringSlice("proxy-endpoints"),
-		ProxyAuthToken: viper.GetString("proxy-auth-token"),
+		ProxyEndpoints:       viper.GetStringSlice("proxy-endpoints"),
+		ProxyAuthToken:       viper.GetString("proxy-auth-token"),
+		ProxyTokenSecret:     viper.GetString("proxy-token-secret"),
+		ProxyDeploymentLabel: viper.GetString("proxy-deployment-label"),
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -36,6 +36,14 @@ rules:
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
+  # Deployments: the ProxySecretReconciler patches the proxy Deployment's
+  # pod-template annotation when the tunnel-token Secret rotates, so
+  # Kubernetes rolls the pods natively and cloudflared picks up the new
+  # credential. List + patch only; no create/delete -- the chart owns
+  # Deployment lifecycle. Issue #114.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
   # Secrets: the controller only reads them (Cloudflare credentials, TLS
   # certificate refs, BackendTLSPolicy CA bundles). It does not create,
   # mutate, or delete Secrets, so write verbs are intentionally absent.

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -78,6 +77,25 @@ type Config struct {
 	// ProxyAuthToken is the Bearer token for authenticating config push requests.
 	// When set, the controller includes "Authorization: Bearer <token>" in push requests.
 	ProxyAuthToken string
+
+	// ProxyTokenSecret identifies the Secret holding the tunnel token used by
+	// the proxy. Format: "<namespace>/<name>". When set, the controller
+	// watches the named Secret and patches the proxy Deployment's pod
+	// template with a revision annotation on every change, causing
+	// Kubernetes to roll the pods so cloudflared picks up the rotated
+	// credential. Issue #114.
+	//
+	// Empty value disables the watcher entirely -- safe default for setups
+	// that don't rotate the token, and for `helm template` rendering
+	// without a real Secret.
+	ProxyTokenSecret string
+
+	// ProxyDeploymentLabel selects the proxy Deployment(s) to roll on
+	// tunnel-token Secret change. Format: "key=value". When unset, the
+	// SecretReconciler falls back to the chart's standard proxy label set
+	// (`app.kubernetes.io/component=proxy`) within ProxyTokenSecret's
+	// namespace.
+	ProxyDeploymentLabel string
 }
 
 // Run initializes and starts the controller manager with the provided configuration.
@@ -215,6 +233,10 @@ func Run(ctx context.Context, cfg *Config) error {
 		return err
 	}
 
+	if err := setupProxySecretReconciler(mgr, cfg.ProxyTokenSecret, cfg.ProxyDeploymentLabel); err != nil {
+		return err
+	}
+
 	if err := setupStatusReconcilers(mgr, cfg.ControllerName); err != nil {
 		return err
 	}
@@ -231,6 +253,32 @@ func Run(ctx context.Context, cfg *Config) error {
 
 	if err := mgr.Start(ctx); err != nil {
 		return errors.Wrap(err, "failed to start manager")
+	}
+
+	return nil
+}
+
+// setupProxySecretReconciler wires the tunnel-token Secret watcher that
+// patches the proxy Deployment's pod template on Secret change so
+// Kubernetes natively rolls the pods (issue #114). When
+// proxyTokenSecret is empty the watcher is skipped entirely -- the
+// controller starts and runs without it, matching the behaviour of
+// clusters that don't rotate the token at runtime.
+//
+// Extracted from Run to keep the per-reconciler setup chain in Run
+// under the cyclomatic-complexity gate.
+func setupProxySecretReconciler(mgr ctrl.Manager, proxyTokenSecret, proxyDeploymentLabel string) error {
+	if strings.TrimSpace(proxyTokenSecret) == "" {
+		return nil
+	}
+
+	reconciler, err := NewProxySecretReconciler(mgr.GetClient(), proxyTokenSecret, proxyDeploymentLabel)
+	if err != nil {
+		return errors.Wrap(err, "failed to construct proxy secret reconciler")
+	}
+
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		return errors.Wrap(err, "failed to setup proxy secret reconciler")
 	}
 
 	return nil
@@ -315,10 +363,4 @@ func getControllerNamespace() string {
 
 	// Fallback to default
 	return "default"
-}
-
-// init registers core types needed for watching Secrets.
-func init() {
-	// corev1 is already registered by controller-runtime, but we ensure it's available
-	_ = corev1.AddToScheme
 }

--- a/internal/controller/proxy_secret_reconciler.go
+++ b/internal/controller/proxy_secret_reconciler.go
@@ -1,0 +1,250 @@
+package controller
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/logging"
+)
+
+// tokenRevisionAnnotation is stamped onto the proxy Deployment's pod
+// template every time the tunnel-token Secret changes. Its value is the
+// hex SHA-256 of the Secret's data map; toggling it forces the Deployment
+// controller to roll the pods because the pod template hash changes.
+//
+// The annotation is namespaced to this project so it cannot collide with
+// any Stakater Reloader / kustomize / external-restart tool the operator
+// might also be running on the same Deployment.
+//
+//nolint:gosec // G101: this is an annotation key, not a credential.
+const tokenRevisionAnnotation = "cf.k8s.lex.la/tunnel-token-revision"
+
+// Static sentinels for config-parse failures so err113 stays happy and
+// callers can `errors.Is` on them.
+var (
+	errEmptyProxyTokenSecret       = errors.New("--proxy-token-secret must not be empty")
+	errInvalidProxyTokenSecret     = errors.New("--proxy-token-secret must be in `<namespace>/<name>` format")
+	errInvalidProxyDeploymentLabel = errors.New("--proxy-deployment-label must be in `key=value` format")
+)
+
+// ProxySecretReconciler watches the tunnel-token Secret named in
+// --proxy-token-secret. On any change to the Secret it patches the proxy
+// Deployment(s)' pod template with a fresh revision annotation, which
+// triggers a native rolling restart so cloudflared picks up the rotated
+// credential.
+//
+// This closes the gap left by ESO / External Secrets Operator rotating
+// the source Secret out-of-band: Kubernetes does NOT restart pods on
+// Secret data change by itself; the env-from-secretKeyRef stays at the
+// stale value until something bumps the pod template. Issue #114.
+//
+// When ProxyTokenSecret is empty (no --proxy-token-secret flag), the
+// reconciler skips registration entirely.
+type ProxySecretReconciler struct {
+	Client client.Client
+
+	// TokenSecretNamespace is the namespace of the tunnel-token Secret.
+	TokenSecretNamespace string
+
+	// TokenSecretName is the name of the tunnel-token Secret.
+	TokenSecretName string
+
+	// DeploymentLabelKey / DeploymentLabelValue select the proxy
+	// Deployment(s) to roll on Secret change. When unset, defaults to
+	// `app.kubernetes.io/component=proxy`.
+	DeploymentLabelKey   string
+	DeploymentLabelValue string
+}
+
+// NewProxySecretReconciler parses the controller config's
+// `<namespace>/<name>` token-secret reference and optional
+// `key=value` deployment label. Caller MUST ensure proxyTokenSecret is
+// non-empty before invoking; empty is treated as a programmer error,
+// not a runtime "watcher disabled" path (the manager's wiring layer
+// filters that case out before getting here).
+func NewProxySecretReconciler(c client.Client, proxyTokenSecret, proxyDeploymentLabel string) (*ProxySecretReconciler, error) {
+	proxyTokenSecret = strings.TrimSpace(proxyTokenSecret)
+	if proxyTokenSecret == "" {
+		return nil, errEmptyProxyTokenSecret
+	}
+
+	parts := strings.SplitN(proxyTokenSecret, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("%w: got %q", errInvalidProxyTokenSecret, proxyTokenSecret)
+	}
+
+	labelKey := "app.kubernetes.io/component"
+	labelValue := "proxy"
+
+	if trimmed := strings.TrimSpace(proxyDeploymentLabel); trimmed != "" {
+		labelParts := strings.SplitN(trimmed, "=", 2)
+		if len(labelParts) != 2 || labelParts[0] == "" || labelParts[1] == "" {
+			return nil, fmt.Errorf("%w: got %q", errInvalidProxyDeploymentLabel, proxyDeploymentLabel)
+		}
+
+		labelKey = labelParts[0]
+		labelValue = labelParts[1]
+	}
+
+	return &ProxySecretReconciler{
+		Client:               c,
+		TokenSecretNamespace: parts[0],
+		TokenSecretName:      parts[1],
+		DeploymentLabelKey:   labelKey,
+		DeploymentLabelValue: labelValue,
+	}, nil
+}
+
+// Reconcile fires on any change to the watched tunnel-token Secret. It
+// hashes the Secret's data map and patches every matching proxy
+// Deployment's pod template annotation with that hash. A no-op patch
+// (same hash) is filtered out by the kube-apiserver before the
+// Deployment controller observes it, so there is no spurious rollout
+// on benign Secret events (e.g. resourceVersion-only churn from a
+// metadata controller).
+func (r *ProxySecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := logging.Component(ctx, "proxy-secret-reconciler")
+	ctx = logging.WithLogger(ctx, logger)
+
+	var secret corev1.Secret
+	if err := r.Client.Get(ctx, req.NamespacedName, &secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Secret was deleted; nothing to propagate. The proxy will
+			// fail open on its next restart anyway -- we don't preemptively
+			// scramble the Deployment annotation.
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, errors.Wrap(err, "fetch tunnel-token Secret")
+	}
+
+	revision := hashSecretData(secret.Data)
+
+	var deployments appsv1.DeploymentList
+
+	listOpts := []client.ListOption{
+		client.InNamespace(secret.Namespace),
+		client.MatchingLabels{r.DeploymentLabelKey: r.DeploymentLabelValue},
+	}
+
+	if err := r.Client.List(ctx, &deployments, listOpts...); err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "list proxy Deployments")
+	}
+
+	for idx := range deployments.Items {
+		dep := &deployments.Items[idx]
+		if err := r.patchRevision(ctx, dep, revision); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "patch Deployment %s/%s", dep.Namespace, dep.Name)
+		}
+	}
+
+	logger.Info("proxy tunnel-token Secret reconciled",
+		"secret", req.String(),
+		"revision", revision,
+		"deployments_patched", len(deployments.Items),
+	)
+
+	return ctrl.Result{}, nil
+}
+
+// patchRevision sets the token-revision annotation on the Deployment's
+// pod template. If the existing value already matches the new revision
+// the call is skipped -- a server-side apply with an identical patch
+// body still bumps the Deployment's generation in some Kubernetes
+// versions, which would spuriously roll the pods.
+func (r *ProxySecretReconciler) patchRevision(ctx context.Context, dep *appsv1.Deployment, revision string) error {
+	current := ""
+	if dep.Spec.Template.Annotations != nil {
+		current = dep.Spec.Template.Annotations[tokenRevisionAnnotation]
+	}
+
+	if current == revision {
+		return nil
+	}
+
+	patch := client.MergeFrom(dep.DeepCopy())
+
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = map[string]string{}
+	}
+
+	dep.Spec.Template.Annotations[tokenRevisionAnnotation] = revision
+
+	if err := r.Client.Patch(ctx, dep, patch); err != nil {
+		return errors.Wrap(err, "merge-patch Deployment annotation")
+	}
+
+	return nil
+}
+
+// SetupWithManager registers the watcher with the manager. The
+// predicate filters EVERY non-target Secret event out before it
+// enqueues a Reconcile request -- the controller is per-Secret, so
+// any other Secret churn in the cluster is irrelevant.
+func (r *ProxySecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("proxy-secret-reconciler").
+		For(&corev1.Secret{}, builder.WithPredicates(r.matchesTokenSecret())).
+		Complete(r); err != nil {
+		return errors.Wrap(err, "setup proxy secret reconciler")
+	}
+
+	return nil
+}
+
+func (r *ProxySecretReconciler) matchesTokenSecret() predicate.Predicate {
+	matches := func(obj client.Object) bool {
+		return obj.GetNamespace() == r.TokenSecretNamespace && obj.GetName() == r.TokenSecretName
+	}
+
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return matches(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return matches(e.ObjectNew) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return matches(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return matches(e.Object) },
+	}
+}
+
+// TokenSecretKey returns the NamespacedName of the watched Secret;
+// exposed for tests so they can synthesise reconcile requests without
+// reaching into the struct directly.
+func (r *ProxySecretReconciler) TokenSecretKey() types.NamespacedName {
+	return types.NamespacedName{Namespace: r.TokenSecretNamespace, Name: r.TokenSecretName}
+}
+
+// hashSecretData returns the hex SHA-256 of the Secret's data map,
+// computed in a key-sorted order so the result is deterministic and
+// independent of map iteration order. Used as the value of the
+// pod-template revision annotation.
+func hashSecretData(data map[string][]byte) string {
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	hasher := sha256.New()
+	for _, k := range keys {
+		_, _ = fmt.Fprintf(hasher, "%s=", k)
+		_, _ = hasher.Write(data[k])
+		_, _ = hasher.Write([]byte{0})
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/internal/controller/proxy_secret_reconciler_test.go
+++ b/internal/controller/proxy_secret_reconciler_test.go
@@ -1,0 +1,337 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestNewProxySecretReconciler_ParseShapes pins the input-validation
+// contract: empty, malformed, partial, and valid cluster-DNS shapes
+// all classify deterministically. The sentinel errors are matchable
+// with errors.Is so the manager wiring can decide whether to refuse
+// startup or skip-and-log.
+func TestNewProxySecretReconciler_ParseShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		tokenSecret     string
+		deploymentLabel string
+		wantSentinel    error
+		wantNamespace   string
+		wantName        string
+		wantLabelKey    string
+		wantLabelValue  string
+	}{
+		{
+			name:         "empty token secret fails fast",
+			tokenSecret:  "",
+			wantSentinel: errEmptyProxyTokenSecret,
+		},
+		{
+			name:         "whitespace-only token secret fails fast",
+			tokenSecret:  "   ",
+			wantSentinel: errEmptyProxyTokenSecret,
+		},
+		{
+			name:         "missing namespace fails",
+			tokenSecret:  "/cloudflare-tunnel-token",
+			wantSentinel: errInvalidProxyTokenSecret,
+		},
+		{
+			name:         "missing name fails",
+			tokenSecret:  "cloudflare-tunnel-system/",
+			wantSentinel: errInvalidProxyTokenSecret,
+		},
+		{
+			name:         "no slash fails",
+			tokenSecret:  "cloudflare-tunnel-token",
+			wantSentinel: errInvalidProxyTokenSecret,
+		},
+		{
+			name:           "valid shape with default deployment label",
+			tokenSecret:    "cloudflare-tunnel-system/cloudflare-tunnel-token",
+			wantNamespace:  "cloudflare-tunnel-system",
+			wantName:       "cloudflare-tunnel-token",
+			wantLabelKey:   "app.kubernetes.io/component",
+			wantLabelValue: "proxy",
+		},
+		{
+			name:            "valid shape with custom deployment label",
+			tokenSecret:     "cf-tunnel/token-secret",
+			deploymentLabel: "role=proxy-data-plane",
+			wantNamespace:   "cf-tunnel",
+			wantName:        "token-secret",
+			wantLabelKey:    "role",
+			wantLabelValue:  "proxy-data-plane",
+		},
+		{
+			name:            "malformed deployment label fails",
+			tokenSecret:     "ns/name",
+			deploymentLabel: "no-equals-sign",
+			wantSentinel:    errInvalidProxyDeploymentLabel,
+		},
+		{
+			name:            "deployment label missing key fails",
+			tokenSecret:     "ns/name",
+			deploymentLabel: "=value",
+			wantSentinel:    errInvalidProxyDeploymentLabel,
+		},
+		{
+			name:            "deployment label missing value fails",
+			tokenSecret:     "ns/name",
+			deploymentLabel: "key=",
+			wantSentinel:    errInvalidProxyDeploymentLabel,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewProxySecretReconciler(nil, tc.tokenSecret, tc.deploymentLabel)
+			if tc.wantSentinel != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantSentinel),
+					"want errors.Is(err, %v); got %v", tc.wantSentinel, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantNamespace, got.TokenSecretNamespace)
+			assert.Equal(t, tc.wantName, got.TokenSecretName)
+			assert.Equal(t, tc.wantLabelKey, got.DeploymentLabelKey)
+			assert.Equal(t, tc.wantLabelValue, got.DeploymentLabelValue)
+		})
+	}
+}
+
+// TestHashSecretData_Deterministic pins that the same data produces the
+// same revision regardless of map insertion order. The reconciler relies
+// on this to skip no-op patches; a non-deterministic hash would cause
+// spurious rollouts on benign Secret resourceVersion bumps.
+func TestHashSecretData_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	a := map[string][]byte{"k1": []byte("v1"), "k2": []byte("v2"), "k3": []byte("v3")}
+	b := map[string][]byte{"k3": []byte("v3"), "k1": []byte("v1"), "k2": []byte("v2")}
+
+	assert.Equal(t, hashSecretData(a), hashSecretData(b),
+		"key-order independence: same data must hash to the same revision")
+}
+
+// TestHashSecretData_DistinguishesContent pins that any change to the
+// data map produces a different hash. Single-key change, key rename,
+// and value rotation must all collide-free.
+func TestHashSecretData_DistinguishesContent(t *testing.T) {
+	t.Parallel()
+
+	base := map[string][]byte{"tunnel-token": []byte("eyJhIjoiYiJ9")}
+
+	rotated := map[string][]byte{"tunnel-token": []byte("eyJhIjoiYyJ9")}
+	renamed := map[string][]byte{"token": []byte("eyJhIjoiYiJ9")}
+	extended := map[string][]byte{"tunnel-token": []byte("eyJhIjoiYiJ9"), "extra": []byte("noise")}
+
+	for name, other := range map[string]map[string][]byte{
+		"value rotation":  rotated,
+		"key rename":      renamed,
+		"extra key added": extended,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.NotEqual(t, hashSecretData(base), hashSecretData(other),
+				"%s must produce a distinct revision", name)
+		})
+	}
+}
+
+// TestProxySecretReconciler_PatchesDeploymentOnSecretChange pins the
+// end-to-end behaviour: a Secret event reaches Reconcile, the matching
+// proxy Deployment's pod template annotation is set to the Secret's
+// data hash, and Kubernetes' native rolling-restart kicks in.
+//
+// The fake client doesn't run the Deployment controller, so we
+// observe the annotation directly. Issue #114.
+func TestProxySecretReconciler_PatchesDeploymentOnSecretChange(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ns      = "cloudflare-tunnel-system"
+		secret  = "cloudflare-tunnel-token"
+		deployN = "cf-tunnel-proxy"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secret, Namespace: ns},
+		Data:       map[string][]byte{"tunnel-token": []byte("freshly-rotated-jwt")},
+	}
+
+	proxyDeploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployN,
+			Namespace: ns,
+			Labels:    map[string]string{"app.kubernetes.io/component": "proxy"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app.kubernetes.io/component": "proxy"},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tokenSecret, proxyDeploy).
+		Build()
+
+	r := &ProxySecretReconciler{
+		Client:               fakeClient,
+		TokenSecretNamespace: ns,
+		TokenSecretName:      secret,
+		DeploymentLabelKey:   "app.kubernetes.io/component",
+		DeploymentLabelValue: "proxy",
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: secret},
+	})
+	require.NoError(t, err)
+
+	var got appsv1.Deployment
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Namespace: ns, Name: deployN}, &got))
+
+	annotations := got.Spec.Template.Annotations
+	require.NotNil(t, annotations, "pod template must have annotations after reconcile")
+
+	wantRevision := hashSecretData(tokenSecret.Data)
+	assert.Equal(t, wantRevision, annotations[tokenRevisionAnnotation],
+		"pod template revision annotation must equal hash of Secret data")
+}
+
+// TestProxySecretReconciler_IdempotentOnUnchangedData pins the no-op
+// guard: re-reconciling the same Secret value MUST NOT bump the
+// Deployment's generation, otherwise every benign metadata-controller
+// event on the Secret would silently roll the proxy pods.
+func TestProxySecretReconciler_IdempotentOnUnchangedData(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ns      = "cloudflare-tunnel-system"
+		secretN = "cloudflare-tunnel-token"
+		deployN = "cf-tunnel-proxy"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+
+	data := map[string][]byte{"tunnel-token": []byte("stable-value")}
+
+	preStamped := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       deployN,
+			Namespace:  ns,
+			Labels:     map[string]string{"app.kubernetes.io/component": "proxy"},
+			Generation: 7,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app.kubernetes.io/component": "proxy"},
+					Annotations: map[string]string{
+						tokenRevisionAnnotation: hashSecretData(data),
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: secretN, Namespace: ns},
+				Data:       data,
+			},
+			preStamped,
+		).
+		Build()
+
+	r := &ProxySecretReconciler{
+		Client:               fakeClient,
+		TokenSecretNamespace: ns,
+		TokenSecretName:      secretN,
+		DeploymentLabelKey:   "app.kubernetes.io/component",
+		DeploymentLabelValue: "proxy",
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: secretN},
+	})
+	require.NoError(t, err)
+
+	var got appsv1.Deployment
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Namespace: ns, Name: deployN}, &got))
+
+	assert.Equal(t, hashSecretData(data), got.Spec.Template.Annotations[tokenRevisionAnnotation],
+		"annotation must remain at the same revision")
+	assert.Equal(t, int64(7), got.Generation,
+		"Generation must NOT bump when the Secret hash is unchanged "+
+			"-- otherwise Kubernetes rolls the pods on every benign Secret resourceVersion event")
+}
+
+// TestProxySecretReconciler_SecretDeletedIsNoop pins that a Secret
+// deletion does NOT scramble the Deployment annotation. The proxy will
+// eventually fail on its own when the env-from-secretKeyRef resolves
+// to a missing value; preemptively bumping the annotation only adds
+// noise and would mask the real source-of-truth Secret event.
+func TestProxySecretReconciler_SecretDeletedIsNoop(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ns      = "cloudflare-tunnel-system"
+		secretN = "cloudflare-tunnel-token"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := &ProxySecretReconciler{
+		Client:               fakeClient,
+		TokenSecretNamespace: ns,
+		TokenSecretName:      secretN,
+		DeploymentLabelKey:   "app.kubernetes.io/component",
+		DeploymentLabelValue: "proxy",
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: secretN},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res, "Secret-not-found path must be a clean no-op")
+}


### PR DESCRIPTION
## Summary

Add a controller-side `ProxySecretReconciler` that watches the tunnel-token Secret and rolls the proxy Deployment when the Secret's data changes. Closes #114.

Kubernetes does not restart pods when a Secret data field changes — `env-from-secretKeyRef` freezes the value at pod admission time, so an out-of-band rotation (External Secrets Operator syncing a fresh tunnel token from Vault/OpenBao into the source Secret) leaves the running cloudflared authenticating with the stale credential. The historic workaround was to manually patch + `kubectl rollout restart` the proxy Deployment.

This PR closes the gap with a native-Kubernetes pattern (analogous to the EndpointSlice watcher landed in #299).

## How it works

1. New `--proxy-token-secret=<namespace>/<name>` CLI flag identifies the Secret to watch. Optional `--proxy-deployment-label=key=value` selects the proxy Deployment(s) (default `app.kubernetes.io/component=proxy`).
2. `ProxySecretReconciler` filters Secret events via a predicate so only the named Secret enters Reconcile — unrelated Secret churn in the cluster is invisible.
3. On a matching event the reconciler hashes the Secret's data map in key-sorted order (deterministic across map iteration), then sets the resulting hex revision on a project-namespaced pod template annotation `cf.k8s.lex.la/tunnel-token-revision` on every matching Deployment.
4. Kubernetes' native Deployment controller diffs the pod template and rolls the pods. cloudflared starts fresh and picks up the rotated credential.
5. The reconciler skips the patch entirely when the existing annotation already matches the new hash — benign Secret `resourceVersion` churn from metadata controllers, ESO heartbeats with no data change, etc. never roll the proxy.

## RBAC

Adds `apps/deployments` get/list/watch/patch to both `deploy/rbac/role.yaml` and the chart's ClusterRole. No create/delete — the chart owns Deployment lifecycle. The `rbacdrift` test still passes.

## Helm wiring

The chart auto-wires `--proxy-token-secret=<release-namespace>/<proxy.tunnelTokenSecretRef.name>` when the operator has configured the token secret (which they must, per existing chart contract). When `proxy.tunnelTokenSecretRef.name` is empty the flag is omitted and the watcher stays off — safe default.

## Tests (TDD)

- `TestNewProxySecretReconciler_ParseShapes` — pins the `--proxy-token-secret` / `--proxy-deployment-label` input contract via `errors.Is`-matchable sentinel errors.
- `TestHashSecretData_Deterministic` — pins key-order independence; required so the no-op guard works reliably.
- `TestHashSecretData_DistinguishesContent` — pins that value rotation, key rename, and key addition all produce a fresh hash.
- `TestProxySecretReconciler_PatchesDeploymentOnSecretChange` — pins end-to-end via fake controller-runtime client: a Secret event lands → matching Deployment's pod template annotation equals the data hash.
- `TestProxySecretReconciler_IdempotentOnUnchangedData` — pins the no-op guard: re-reconcile on identical data does NOT bump `Deployment.Generation`, preventing spurious rollouts.
- `TestProxySecretReconciler_SecretDeletedIsNoop` — pins the NotFound path: no annotation scramble, no panic.

## Adjacent refactor

`setupProxySecretReconciler` helper extracted from `manager.Run` to keep the per-reconciler setup chain under the cyclomatic-complexity gate (the same pattern used for `setupProxyEndpointReconciler` in #299).

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [x] Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller` — 219/219)
- [x] Helm lint passes
- [ ] Manual testing completed — pending homelab deploy + Secret-rotation smoke (the canonical acceptance: rotate `cloudflare-tunnel-token` Secret data, expect proxy Deployment to roll within ~5 s, new proxy pod to reach `/readyz=200` within ~30 s)

## Documentation

- [ ] README updated — N/A
- [x] Code comments added for complex logic (hash determinism, no-op-on-unchanged guard, predicate scoping rationale)
- [ ] CLAUDE.md updated — N/A

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] Breaking changes documented — N/A (additive watcher; default off when `--proxy-token-secret` unset)
- [x] Related issues referenced (Closes #114)

## Acceptance plan (homelab)

1. Deploy this PR's chart (`pr-N-1d`) to homelab and wait for rollout.
2. `kubectl patch secret cloudflare-tunnel-token --type=json --patch='[{"op": "replace", "path": "/data/tunnel-token", "value": "<base64-of-something-different>"}]'` (followed by reverting to the real value so the tunnel stays up).
3. Expect: proxy Deployment to roll within ~5 s of each patch; new pod reaches `/readyz=200` within ~30 s; old pods drain via standard `terminationGracePeriodSeconds`.
4. Smoke-test the 16 CF tunnel hostnames; expect no 5xx surge through the rotation.
