### PR TITLE
feat(api): enforce Cloudflare account-ID format via CRD CEL rule

### DIFF
--- a/api/v1alpha1/gatewayclassconfig_types.go
+++ b/api/v1alpha1/gatewayclassconfig_types.go
@@ -31,7 +31,14 @@ type GatewayClassConfigSpec struct {
 	// AccountID is the Cloudflare account ID. Optional - if not specified, it will be
 	// read from the credentials secret ("account-id" key) or auto-detected if the API token
 	// has access to only one account.
+	//
+	// When set, must be a 32-character lowercase hexadecimal string -- the format
+	// Cloudflare uses for account IDs. Validated server-side via a CRD-level CEL
+	// rule (Kubernetes >= 1.25) so an invalid value is rejected at admission time,
+	// before the controller has to reconcile it. Empty string passes through
+	// because the field is optional. Closes #110.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^[a-f0-9]{32}$')",message="accountID must be a 32-character lowercase hexadecimal string (Cloudflare account ID format)"
 	AccountID string `json:"accountId,omitempty"`
 
 	// TunnelID is the Cloudflare Tunnel UUID.

--- a/charts/cloudflare-tunnel-gateway-controller/crds/cf.k8s.lex.la_gatewayclassconfigs.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/crds/cf.k8s.lex.la_gatewayclassconfigs.yaml
@@ -59,6 +59,9 @@ spec:
                 accountId:
                   type: string
                   description: Cloudflare account ID. Optional - auto-detected if not set.
+                  x-kubernetes-validations:
+                    - rule: "self == '' || self.matches('^[a-f0-9]{32}$')"
+                      message: "accountID must be a 32-character lowercase hexadecimal string (Cloudflare account ID format)"
                 tunnelID:
                   type: string
                   description: Cloudflare Tunnel UUID.

--- a/internal/controller/gccconfig_cel_envtest_test.go
+++ b/internal/controller/gccconfig_cel_envtest_test.go
@@ -1,0 +1,139 @@
+//go:build envtest
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/api/v1alpha1"
+)
+
+// TestGatewayClassConfig_AccountIDCELValidation pins the CRD-level CEL
+// rule that enforces the Cloudflare account-ID format (32-char
+// lowercase hex) at admission time. Closes #110.
+//
+// CEL validations attach to the CRD's openAPIV3Schema and are
+// evaluated by the kube-apiserver, so we exercise them through the
+// real envtest control plane rather than the fake client (which does
+// not run schema validation).
+func TestGatewayClassConfig_AccountIDCELValidation(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, envK8sClient, "envtest must be wired up; see suite_envtest_test.go")
+
+	cases := []struct {
+		name      string
+		accountID string
+		wantErr   bool
+		wantSub   string
+	}{
+		{
+			name:      "empty accountID accepted (field is optional)",
+			accountID: "",
+			wantErr:   false,
+		},
+		{
+			name:      "valid 32-char lowercase hex accepted",
+			accountID: "0123456789abcdef0123456789abcdef",
+			wantErr:   false,
+		},
+		{
+			name:      "uppercase hex rejected (must be lowercase)",
+			accountID: "0123456789ABCDEF0123456789ABCDEF",
+			wantErr:   true,
+			wantSub:   "lowercase hexadecimal",
+		},
+		{
+			name:      "wrong length rejected (31 chars)",
+			accountID: "0123456789abcdef0123456789abcde",
+			wantErr:   true,
+			wantSub:   "lowercase hexadecimal",
+		},
+		{
+			name:      "wrong length rejected (33 chars)",
+			accountID: "0123456789abcdef0123456789abcdef0",
+			wantErr:   true,
+			wantSub:   "lowercase hexadecimal",
+		},
+		{
+			name:      "non-hex characters rejected",
+			accountID: "ghijkl12345678901234567890123456",
+			wantErr:   true,
+			wantSub:   "lowercase hexadecimal",
+		},
+	}
+
+	for idx, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gcc := &v1alpha1.GatewayClassConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					// Unique per-case name so parallel subtests don't collide
+					// in the shared envtest namespace.
+					Name: stringHashSuffix("cel-test", idx, tc.name),
+				},
+				Spec: v1alpha1.GatewayClassConfigSpec{
+					TunnelID: "12345678-1234-1234-1234-123456789012",
+					CloudflareCredentialsSecretRef: v1alpha1.SecretReference{
+						Name: "cloudflare-credentials",
+					},
+					AccountID: tc.accountID,
+				},
+			}
+
+			err := envK8sClient.Create(context.Background(), gcc)
+			if tc.wantErr {
+				require.Error(t, err, "invalid accountID %q must be rejected at admission", tc.accountID)
+				assert.Contains(t, strings.ToLower(err.Error()), strings.ToLower(tc.wantSub),
+					"rejection message must mention the rule's `message` text so users see what they got wrong")
+
+				return
+			}
+
+			require.NoError(t, err, "valid accountID %q must pass admission", tc.accountID)
+			// Best-effort cleanup; the envtest namespace is torn down per
+			// suite anyway, so a failure here doesn't poison other cases.
+			_ = envK8sClient.Delete(context.Background(), gcc)
+		})
+	}
+}
+
+// stringHashSuffix builds a deterministic resource name suffix from the
+// case index + name so parallel subtests don't collide in the same
+// cluster-scoped namespace. Kubernetes name shape (RFC 1123 subdomain)
+// requires lowercase + hyphen; we sanitise the test name into that.
+func stringHashSuffix(prefix string, idx int, name string) string {
+	safe := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + ('a' - 'A')
+		case r >= '0' && r <= '9':
+			return r
+		case r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, name)
+	// Collapse repeats / trim leading and trailing dashes; clip to keep
+	// within Kubernetes' 63-char limit.
+	for strings.Contains(safe, "--") {
+		safe = strings.ReplaceAll(safe, "--", "-")
+	}
+
+	safe = strings.Trim(safe, "-")
+	if len(safe) > 40 {
+		safe = safe[:40]
+	}
+
+	return prefix + "-" + safe + "-" + string(rune('a'+idx))
+}


### PR DESCRIPTION
## Summary

Add CRD-level CEL validation for `GatewayClassConfig.spec.accountId` that rejects anything except a 32-character lowercase hex string (the Cloudflare account-ID format), or the empty string (the field is optional). Closes #110.

## Why not a webhook

The original issue scoped a full admission webhook with four validation rules. Three of the four are already covered by inline kubebuilder validations or no longer apply in v3:

| Original rule | Status |
| --- | --- |
| `tunnelID` is a UUID | Already enforced via `+kubebuilder:validation:Pattern` |
| `accountID` is a 32-char hex | **Gap — closed by this PR** |
| `cloudflareCredentialsSecretRef.name` required | Already enforced via `+kubebuilder:validation:Required` + `MinLength=1` |
| `tunnelTokenSecretRef` required when `cloudflared.enabled` is true | N/A in v3 (#294 dropped both fields from the CRD; the tunnel-token Secret now lives in chart values) |

Standing up a full webhook for one regex would mean: cert-manager dependency, ValidatingWebhookConfiguration manifest, WebhookConfiguration RBAC, separate Service, separate readiness probe, plus the cert-rotation lifecycle. None of that is justified here.

Use a CRD-level CEL rule (Kubernetes ≥ 1.25) instead — it attaches directly to the openAPIV3 schema, evaluates server-side at admission time, and needs zero extra deploy surface.

## The rule

```cel
self == '' || self.matches('^[a-f0-9]{32}$')
```

- `self == ''` keeps the field optional (auto-detect from the credentials Secret).
- Otherwise insists on the exact Cloudflare-account-ID shape so an invalid value is rejected before the controller has to reconcile it.

## Tests

`TestGatewayClassConfig_AccountIDCELValidation` (envtest, build tag `envtest`) runs through the real kube-apiserver and pins six cases:

| Case | Expected |
| --- | --- |
| empty string | accepted (optional) |
| valid lowercase hex | accepted |
| uppercase hex | rejected — "lowercase hexadecimal" |
| length 31 | rejected |
| length 33 | rejected |
| non-hex characters | rejected |

The rejection-message assertion ensures the rule's `message` text reaches the kubectl / controller-runtime error path so users see what they got wrong, not just a generic violation.

## CRD YAML editing

The chart's CRD YAML was hand-edited to add only the three-line CEL block. Regenerating with controller-gen v0.21.0 onto the existing v0.14.0-formatted file would have rewritten the entire indentation and list style, turning a three-line semantic change into a ~150-line cosmetic churn. The kubebuilder marker in the Go source is the source of truth for any future regeneration.

## Testing

- [x] All tests pass locally (`go test -race ./...` + `-tags=envtest`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [x] Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller` — 220/220)
- [ ] Manual testing completed — N/A, fake apiserver via envtest is the integration test

## Documentation

- [ ] README updated — N/A
- [x] Code comments added for complex logic (CEL rule rationale on the AccountID field)
- [ ] CLAUDE.md updated — N/A

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] Breaking changes documented — N/A (additive validation; old valid values still pass; invalid values that were silently accepted before are now rejected — this is the desired behaviour)
- [x] Related issues referenced (Closes #110)

## Additional Notes

Pure CRD + test change. No runtime code touched. Homelab deploy gate waived per project rule for PRs that don't touch runtime code. CEL evaluation is built into kube-apiserver since 1.25 — homelab is well past that. Existing GatewayClassConfig with an invalid accountId would only fail on next `kubectl apply`/`update`, not at controller startup — so there's no risk of a freshly-deployed controller refusing to reconcile a legacy resource.
