### PR TITLE
docs: drop stale Cloudflare-path-matching limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,14 +173,7 @@ All matching and filter behavior is performed by the in-process L7 proxy that th
 
 ### Known Limitations
 
-The L7 proxy removes the v1/v2 Cloudflare-Tunnel-API path-matching limitations. Edge-side caveats (Cloudflare hostname registration, edge HTTPS termination, etc.) are documented in the [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/) page.
-
-Historical context — Cloudflare Tunnel's native ingress rules have path matching behavior that differs from Gateway API:
-
-- **No true exact path match**: `/api` (Exact) will still match `/api/v1`
-- **Common prefix routing**: Paths like `/multi-v1`, `/multi-v2` may all route to the first backend
-
-**Workaround:** Use distinct path prefixes (e.g., `/alpha`, `/beta`, `/gamma`), or enable the L7 proxy.
+The in-process L7 proxy handles routing for every tunnel request, so the v1/v2 Cloudflare-Tunnel-API path-matching quirks (no true exact match, prefix bleed across `/foo` siblings) no longer apply. Edge-side caveats (Cloudflare hostname registration, edge HTTPS termination, etc.) are documented in the [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/) page.
 
 `BackendTLSPolicy` (proxy → backend TLS) is supported at minimum-viable scope:
 

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -4,7 +4,7 @@ This document describes the known limitations of the Cloudflare Tunnel Gateway C
 
 ## Historical context (pre-v3 only)
 
-In the v1/v2 chart line, several HTTPRoute features required opting into the L7 proxy because the alternative path (Cloudflare Tunnel's native ingress) cannot express exact-path / header / query / method matching, weighted splitting, or filters. **v3 collapses this to a single data plane** — the proxy is always rendered, so all of those features work unconditionally. The bullets below are kept as historical context; if you are running v3 you can skip to the [Path Matching Limitations](#cloudflare-tunnel-path-matching-limitations) section.
+In the v1/v2 chart line, several HTTPRoute features required opting into the L7 proxy because the alternative path (Cloudflare Tunnel's native ingress) cannot express exact-path / header / query / method matching, weighted splitting, or filters. **v3 collapses this to a single data plane** — the proxy is always rendered, so all of those features work unconditionally. The bullets below are kept as historical context; if you are running v3 you can skip to the [Controller Limitations](#controller-limitations) section.
 
 ??? note "v1/v2 feature matrix (kept for upgrade context)"
 
@@ -22,64 +22,13 @@ In the v1/v2 chart line, several HTTPRoute features required opting into the L7 
     | Traffic splitting (weighted) | No | Yes |
     | Regex path matching | No | Yes |
 
-## Cloudflare Tunnel Path Matching Limitations
-
-Cloudflare Tunnel has specific path matching behavior that differs from Gateway API expectations:
-
-### No True Exact Path Match
-
-Cloudflare Tunnel does **not** support true exact path matching. A path rule without a wildcard (e.g., `/api`) will still match subpaths like `/api/v1`.
-
-**Example:** If you configure:
-
-- `/api` (Exact) → backend-a
-- `/api` (PathPrefix) → backend-b
-
-Both `/api` and `/api/v1` will route to backend-a because Cloudflare treats all paths as prefixes internally.
-
-**Workaround:** Use different base paths for different backends:
-
-```yaml
-# Instead of same path with different match types
-- path: /api-exact    # Exact match
-- path: /api-prefix   # Prefix match
-```
-
-### Paths with Common Prefixes
-
-Paths sharing a common prefix may exhibit unexpected routing behavior. For example, `/multi-v1`, `/multi-v2`, and `/multi-v3` might all route to the first matching backend.
-
-**Workaround:** Use distinct path prefixes:
-
-```yaml
-# Instead of:
-- path: /multi-v1
-- path: /multi-v2
-- path: /multi-v3
-
-# Use:
-- path: /alpha
-- path: /beta
-- path: /gamma
-```
-
-### Path Priority
-
-The controller sorts paths to ensure consistent behavior:
-
-1. Longer paths match before shorter paths (`/api/v2` before `/api`)
-2. Paths of equal length are sorted alphabetically for determinism
-3. Wildcard hostname `*` always comes last
-
-This ensures predictable routing despite Cloudflare's limitations.
-
 ## Controller Limitations
 
 | Limitation | Description |
 |------------|-------------|
 | Full sync | Any change triggers full config sync |
 | No cross-cluster | Only in-cluster services supported |
-| Service only | Only `Service` kind backends (ClusterIP, NodePort, LoadBalancer, ExternalName) |
+| Service only | Only `Service` kind backends (ClusterIP, NodePort, LoadBalancer, ExternalName); evaluating non-Service kinds is tracked in [#337](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/337) |
 
 ## Traffic Splitting and Load Balancing
 

--- a/internal/docsdrift/docsdrift_test.go
+++ b/internal/docsdrift/docsdrift_test.go
@@ -144,6 +144,14 @@ var retiredSubstrings = []struct {
 		needle: "weights indicate preference, not failover order",
 		why:    "v3 has no highest-weight selection or failover order; weighted-random splitting makes the preference/failover framing wrong",
 	},
+	{
+		needle: "No true exact path match",
+		why:    "v3 in-process proxy does true exact path matching (r.URL.Path == m.path); the Cloudflare-ingress prefix-bleed limitation no longer applies to routing",
+	},
+	{
+		needle: "treats all paths as prefixes",
+		why:    "v3 routing is done by the in-process proxy with proper exact/prefix semantics; the Cloudflare-ingress prefix-treatment claim is stale for actual routing",
+	},
 }
 
 // trackedRoots is the list of trees this guard scans. Walked
@@ -242,6 +250,8 @@ var allowedFiles = map[string]map[string]bool{
 		"highest weight is selected":                      true,
 		"sends 100% of traffic to it":                     true,
 		"weights indicate preference, not failover order": true,
+		"No true exact path match":                        true,
+		"treats all paths as prefixes":                    true,
 	},
 }
 


### PR DESCRIPTION
## Summary

Drop stale Cloudflare-path-matching limitations from the docs. The v3 in-process L7 proxy does true exact path matching (`r.URL.Path == m.path`) and segment-aware prefix matching (`/app` does not match `/application`, `/svc.A/` does not match `/svc.AB/Method`), so the pre-v3 "no true exact path match" / "treats all paths as prefixes" warnings no longer apply to actual routing — Cloudflare's ingress rules are not consulted at runtime, the proxy's matchers are.

## Changes

- `docs/gateway-api/limitations.md`: delete the entire `## Cloudflare Tunnel Path Matching Limitations` section (No True Exact Path Match, Paths with Common Prefixes, Path Priority). Fix the now-dangling "skip to" anchor in the Historical context paragraph. Annotate the `Service only` row with a `#337` reference so the limitation is trackable.
- `README.md`: drop the matching "Historical context" bullets in Known Limitations. The v3-accurate one-line summary that already preceded them ("the L7 proxy removes the v1/v2 Cloudflare-Tunnel-API path-matching quirks") is kept and tightened.
- `internal/docsdrift/docsdrift_test.go`: pin the retired phrases (`No true exact path match`, `treats all paths as prefixes`) so a future doc edit can't silently re-introduce the stale claim.

## Testing

- [x] `go test -race -count=1 ./internal/docsdrift/...` (drift guard catches the new pins)
- [x] `golangci-lint run --timeout=5m`
- [x] `markdownlint-cli2 'README.md' 'docs/gateway-api/limitations.md'`
- [x] `mkdocs build --strict`

## Documentation

- [x] README updated
- [x] Limitations page trimmed and accurate
- [ ] CLAUDE.md updated (no workflow change)

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code
- [x] Breaking changes: none (doc-only)
- [x] Related issues referenced (#337)
