### PR TITLE
fix(proxy): log RequestMirror dispatch errors and harden mirror delivery tests

### DIFF
--- a/internal/proxy/filter.go
+++ b/internal/proxy/filter.go
@@ -297,6 +297,7 @@ type requestMirror struct {
 	backendURL string
 	percent    *int32
 	client     *http.Client
+	logger     *slog.Logger
 }
 
 // NewRequestMirror creates a filter that mirrors requests to a backend URL.
@@ -320,6 +321,7 @@ func NewRequestMirror(backendURL string, percent *int32, tlsCfg *BackendTLSConfi
 		backendURL: backendURL,
 		percent:    percent,
 		client:     client,
+		logger:     slog.Default(),
 	}
 }
 
@@ -389,9 +391,17 @@ func (f *requestMirror) ProcessRequest(req *http.Request) *http.Response {
 		}()
 
 		resp, doErr := client.Do(mirrorReq)
-		if doErr == nil {
-			resp.Body.Close()
+		if doErr != nil {
+			// Mirroring is fire-and-forget, so a failed dial must not affect
+			// the primary leg — but it must be visible in the logs, otherwise
+			// a mirror-delivery problem is undiagnosable from the proxy.
+			f.logger.Warn("mirror: request dispatch failed",
+				"backend", f.backendURL, "error", doErr)
+
+			return
 		}
+
+		resp.Body.Close()
 	}()
 
 	return nil

--- a/internal/proxy/filter_internal_test.go
+++ b/internal/proxy/filter_internal_test.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// chanHandler is a minimal slog.Handler that forwards every record to a
+// channel. It lets tests deterministically observe a fire-and-forget
+// goroutine's log output without mutating the process-global default logger
+// (which the parallel proxy_test suite also reads).
+type chanHandler struct {
+	records chan slog.Record
+}
+
+func (*chanHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *chanHandler) Handle(_ context.Context, rec slog.Record) error {
+	h.records <- rec.Clone()
+
+	return nil
+}
+
+func (h *chanHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *chanHandler) WithGroup(string) slog.Handler { return h }
+
+// collectAttrs flattens a record's attributes into a key→string map for
+// assertions.
+func collectAttrs(rec slog.Record) map[string]string {
+	attrs := make(map[string]string)
+
+	rec.Attrs(func(attr slog.Attr) bool {
+		attrs[attr.Key] = attr.Value.String()
+
+		return true
+	})
+
+	return attrs
+}
+
+// TestRequestMirror_DispatchError_LogsWarn asserts that a failed mirror dial
+// emits a Warn record identifying the mirror destination and the error,
+// without affecting the primary leg. Mirroring stays fire-and-forget, but a
+// silent failure makes any delivery problem undiagnosable from proxy logs.
+func TestRequestMirror_DispatchError_LogsWarn(t *testing.T) {
+	t.Parallel()
+
+	records := make(chan slog.Record, 8)
+	logger := slog.New(&chanHandler{records: records})
+
+	// Port 1 refuses connections immediately, so the dial fails fast.
+	const backend = "http://127.0.0.1:1"
+
+	mirror := &requestMirror{
+		backendURL: backend,
+		client:     mirrorClient,
+		logger:     logger,
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/test", nil)
+
+	resp := mirror.ProcessRequest(req) //nolint:bodyclose // mirror returns a nil response
+	assert.Nil(t, resp, "mirror filter must not short-circuit the primary leg")
+
+	select {
+	case rec := <-records:
+		assert.Equal(t, slog.LevelWarn, rec.Level, "dispatch failure must log at Warn")
+
+		attrs := collectAttrs(rec)
+		assert.Equal(t, backend, attrs["backend"], "log must identify the mirror destination")
+		assert.NotEmpty(t, attrs["error"], "log must include the dial error")
+	case <-time.After(2 * time.Second):
+		t.Fatal("mirror dispatch error was not logged")
+	}
+}
+
+// TestRequestMirror_DispatchSuccess_NoWarn asserts that a successful mirror
+// emits no Warn record, so percentage mirroring does not produce per-request
+// log noise on the happy path.
+func TestRequestMirror_DispatchSuccess_NoWarn(t *testing.T) {
+	t.Parallel()
+
+	records := make(chan slog.Record, 8)
+	logger := slog.New(&chanHandler{records: records})
+
+	received := make(chan struct{}, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		received <- struct{}{}
+	}))
+	defer backend.Close()
+
+	mirror := &requestMirror{
+		backendURL: backend.URL,
+		client:     mirrorClient,
+		logger:     logger,
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/test", nil)
+
+	resp := mirror.ProcessRequest(req) //nolint:bodyclose // mirror returns a nil response
+	assert.Nil(t, resp, "mirror filter must not short-circuit the primary leg")
+
+	select {
+	case <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("mirror request never reached the backend")
+	}
+
+	// The dispatch goroutine has nothing to log on success; confirm no record
+	// arrives in a short window after delivery completed.
+	select {
+	case rec := <-records:
+		t.Fatalf("unexpected log on mirror happy path: level=%s msg=%q", rec.Level, rec.Message)
+	case <-time.After(500 * time.Millisecond):
+	}
+}

--- a/internal/proxy/filter_test.go
+++ b/internal/proxy/filter_test.go
@@ -506,6 +506,43 @@ func TestRequestMirror_HonorsBackendTLSPolicy(t *testing.T) {
 	}
 }
 
+// TestRequestMirror_DeliversThroughProductionTransportFactory asserts the
+// mirror copy actually reaches the backend when the filter is built with the
+// production transport factory (newTransport, via NewTransportForTest), not
+// only with the legacy global cleartext client or a mock factory that returns
+// the test server's own transport. This guards the factory-built delivery
+// path — the gap that made a transient mirror-delivery issue look like a code
+// regression.
+func TestRequestMirror_DeliversThroughProductionTransportFactory(t *testing.T) {
+	t.Parallel()
+
+	received := make(chan *http.Request, 1)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		received <- req
+	}))
+	defer backend.Close()
+
+	// Adapter so the production transport builder satisfies TransportFactory.
+	factory := func(_ string, protocol proxy.BackendProtocol, tlsCfg *proxy.BackendTLSConfig, _ time.Duration) http.RoundTripper {
+		return proxy.NewTransportForTest(protocol, tlsCfg)
+	}
+
+	filter := proxy.NewRequestMirror(backend.URL, nil, nil, proxy.BackendProtocolHTTP, factory)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/mirror", nil)
+
+	resp := filter.ProcessRequest(req) //nolint:bodyclose // mirror returns nil response
+	assert.Nil(t, resp, "mirror filter MUST NOT short-circuit the primary leg")
+
+	select {
+	case got := <-received:
+		assert.Equal(t, "/mirror", got.URL.Path, "mirror must preserve the request path")
+	case <-time.After(2 * time.Second):
+		t.Fatal("mirror request never reached the backend via the production transport factory")
+	}
+}
+
 func TestRequestMirror(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1137,11 +1137,14 @@ func testHTTPRouteRequestMirror(
 ) {
 	t.Helper()
 
+	clientset := newClientset(t, cfg.KubeContext)
 	mirrorPort := gatewayv1.PortNumber(80)
+
+	const mirrorPath = "/mirror-test"
 
 	route := buildHTTPRoute("mirror-test", cfg, []gatewayv1.HTTPRouteRule{
 		{
-			Matches: []gatewayv1.HTTPRouteMatch{{Path: pathPrefix("/mirror-test")}},
+			Matches: []gatewayv1.HTTPRouteMatch{{Path: pathPrefix(mirrorPath)}},
 			Filters: []gatewayv1.HTTPRouteFilter{
 				{
 					Type: gatewayv1.HTTPRouteFilterRequestMirror,
@@ -1158,13 +1161,28 @@ func testHTTPRouteRequestMirror(
 	})
 
 	createHTTPRoute(t, k8sClient, route)
-	waitForBackend(t, httpClient, cfg.TunnelHostname, "/mirror-test", "echo-v1-", 60*time.Second)
+	waitForBackend(t, httpClient, cfg.TunnelHostname, mirrorPath, "echo-v1-", 60*time.Second)
 
 	// Response should come from echo-v1 (mirror is fire-and-forget).
-	echo, resp, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/mirror-test", nil)
+	echo, resp, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, mirrorPath, nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "response from primary → echo-v1, got: %s", echo.Pod)
+
+	// The mirror copy must actually reach echo-v3. Mirroring is fire-and-forget,
+	// so poll the mirror backend's logs (the echo-basic server logs every
+	// request it receives) with a bounded timeout. Each poll re-sends the
+	// request so a single transient mirror drop does not fail the test. Without
+	// this assertion the test passes even when mirror delivery is fully broken.
+	require.Eventually(t, func() bool {
+		if _, _, reqErr := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, mirrorPath, nil); reqErr != nil {
+			return false
+		}
+
+		logs := backendPodLogs(t, context.Background(), clientset, cfg.TestNamespace, "echo-v3")
+
+		return strings.Contains(logs, mirrorPath)
+	}, 30*time.Second, 2*time.Second, "mirror copy never reached echo-v3 (path %q absent from its logs)", mirrorPath)
 }
 
 func testHTTPRouteRedirectPort(

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -4,6 +4,8 @@ package e2e
 
 import (
 	"context"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,8 +50,72 @@ func newK8sClient(t *testing.T, kubeContext string) client.Client {
 	return k8sClient
 }
 
-// setupEchoBackends deploys echo-v1 and echo-v2 backends using the official
-// Gateway API conformance echo-basic server.
+// newClientset creates a typed Kubernetes clientset for the given kubeconfig
+// context. It is used for operations the controller-runtime client does not
+// support, such as streaming pod logs.
+func newClientset(t *testing.T, kubeContext string) *kubernetes.Clientset {
+	t.Helper()
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{
+		CurrentContext: kubeContext,
+	}
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+	restConfig, err := kubeConfig.ClientConfig()
+	require.NoError(t, err, "failed to get kubeconfig for context %s", kubeContext)
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	require.NoError(t, err, "failed to create kubernetes clientset")
+
+	return clientset
+}
+
+// backendPodLogs returns the concatenated logs of every pod matching
+// app=<appLabel> in the given namespace. The echo-basic server logs each
+// request it receives, so this is used to verify a mirror copy actually
+// reached the mirror backend, mirroring the conformance suite's DumpEchoLogs.
+func backendPodLogs(t *testing.T, ctx context.Context, clientset *kubernetes.Clientset, namespace, appLabel string) string {
+	t.Helper()
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=" + appLabel,
+	})
+	require.NoError(t, err, "failed to list pods for app=%s", appLabel)
+
+	var builder strings.Builder
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		stream, streamErr := clientset.CoreV1().
+			Pods(namespace).
+			GetLogs(pod.Name, &corev1.PodLogOptions{}).
+			Stream(ctx)
+		if streamErr != nil {
+			t.Logf("failed to stream logs for pod %s: %v", pod.Name, streamErr)
+
+			continue
+		}
+
+		data, readErr := io.ReadAll(stream)
+		_ = stream.Close()
+
+		if readErr != nil {
+			t.Logf("failed to read logs for pod %s: %v", pod.Name, readErr)
+
+			continue
+		}
+
+		builder.Write(data)
+	}
+
+	return builder.String()
+}
+
+// setupEchoBackends deploys the echo-v1, echo-v2, and echo-v3 backends using
+// the official Gateway API conformance echo-basic server.
 func setupEchoBackends(t *testing.T, k8sClient client.Client, cfg testConfig) {
 	t.Helper()
 


### PR DESCRIPTION
# Pull Request

## Description

The RequestMirror filter dispatches the mirror copy in a detached, fire-and-forget goroutine and previously discarded the result of `client.Do` — the failure branch was empty, so a failed mirror dial produced no log line at any level. That made any mirror-delivery problem undiagnosable from the proxy logs. The failure path now logs at Warn with the mirror backend and the error, while keeping the mirror strictly fire-and-forget (the primary leg is never affected, and successful mirrors emit no per-request log noise).

Mirror delivery was also under-tested. The unit coverage only exercised the legacy global cleartext client and a mock factory that returns the test server's own transport, so the production transport factory (`newTransport`) delivery path was never validated. The e2e mirror test only asserted the primary response came from the primary backend; it never checked the mirror copy actually reached the mirror backend, so it passed even when mirror delivery was completely broken.

This PR adds: an injectable logger seam on the filter for the dispatch-error log, a unit test that pins delivery through the production transport factory, and an e2e assertion that polls the mirror backend's pod logs (the echo server logs every request) to confirm the copy lands — re-sending on each poll so a single transient drop does not flake the run.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that breaks existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update
- [ ] 🔨 CI/CD or build process changes

## Related Issues

Related: #349 (dispatch errors swallowed without logging), #350 (e2e/unit mirror-delivery coverage gap).

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [ ] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [ ] Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller`)
- [ ] Helm lint passes (`helm lint charts/cloudflare-tunnel-gateway-controller`)
- [ ] Helm README is up to date (`helm-docs charts/cloudflare-tunnel-gateway-controller`)
- [ ] Manual testing completed (if applicable)

No markdown, Helm chart, or docs files were touched, so those checks are not applicable.

New unit tests added and verified under `-race`:

- `TestRequestMirror_DispatchError_LogsWarn` — fails (no log) before the fix, passes after.
- `TestRequestMirror_DispatchSuccess_NoWarn` — asserts the happy path stays silent.
- `TestRequestMirror_DeliversThroughProductionTransportFactory` — pins delivery through `newTransport`.

The live-tunnel e2e and official conformance suites are maintainer-gated (they need a Cloudflare account, a registered tunnel, and a reachable cluster) and are run as part of the pre-merge verification.

## Documentation

- [ ] README updated (if needed)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed)

## Additional Notes

The dispatch-error log uses an injectable `logger` field defaulted to `slog.Default()`; tests override it via a channel-backed `slog.Handler` rather than mutating the process-global default logger, which the parallel test suite also reads.
