### PR TITLE
fix(proxy): default redirect scheme from the parent listener protocol

### DIFF
--- a/internal/controller/proxy_syncer.go
+++ b/internal/controller/proxy_syncer.go
@@ -668,6 +668,14 @@ func (s *ProxySyncer) buildProxyConfig(
 	// before handing to the converter; the input routes are left untouched.
 	routes = withEffectiveHostnames(ctx, s.k8sClient, routes)
 
+	// A RequestRedirect filter that leaves scheme empty must default to the
+	// scheme of the request, which behind the tunnel means the parent
+	// listener's protocol (cloudflared terminates TLS at the edge, so the
+	// origin request carries no usable scheme). Resolve it here so the
+	// converter sees an explicit scheme instead of the proxy's hardcoded
+	// https fallback. Input routes are left untouched.
+	routes = withDefaultRedirectScheme(ctx, s.k8sClient, routes)
+
 	// Convert to proxy config with cross-namespace validation, backend
 	// protocol resolution (e.g. h2c from Service appProtocol), and
 	// BackendTLSPolicy lookup for the proxy → backend TLS hop.

--- a/internal/controller/route_effective_hostnames.go
+++ b/internal/controller/route_effective_hostnames.go
@@ -230,16 +230,7 @@ func listenerSetAcceptedHostnames(
 		return nil
 	}
 
-	matched := result.MatchedListeners
-
-	// Drop sections whose merged-view entry is conflicted — a conflicted
-	// listener is not programmed, so a route must not inherit its hostname.
-	if parent, found := listenerSetParentGateway(ctx, cli, &listenerSet); found {
-		if siblings, collectErr := collectAcceptedListenerSetsForGateway(ctx, cli, parent); collectErr == nil {
-			merged := listenermerge.Merge(parent, siblings)
-			matched = dropConflictedSections(merged, &listenerSet, matched)
-		}
-	}
+	matched := nonConflictedSections(ctx, cli, &listenerSet, result.MatchedListeners)
 
 	hostByName := make(map[gatewayv1.SectionName]*gatewayv1.Hostname, len(listenerSet.Spec.Listeners))
 	for i := range listenerSet.Spec.Listeners {
@@ -247,6 +238,34 @@ func listenerSetAcceptedHostnames(
 	}
 
 	return hostnamesForSections(matched, hostByName)
+}
+
+// nonConflictedSections drops, from sections, any matched listener whose
+// merged-view entry (across the parent Gateway and its sibling ListenerSets) is
+// conflicted and therefore not programmed. A route binds to neither the
+// hostname nor the protocol of a conflicted listener, so both the
+// hostname-inheritance and redirect-scheme passes route their accepted
+// sections through this. When the parent Gateway cannot be resolved the input
+// sections are returned unchanged (best-effort, matching the prior behaviour).
+func nonConflictedSections(
+	ctx context.Context,
+	cli client.Client,
+	listenerSet *gatewayv1.ListenerSet,
+	sections []gatewayv1.SectionName,
+) []gatewayv1.SectionName {
+	parent, found := listenerSetParentGateway(ctx, cli, listenerSet)
+	if !found {
+		return sections
+	}
+
+	siblings, err := collectAcceptedListenerSetsForGateway(ctx, cli, parent)
+	if err != nil {
+		return sections
+	}
+
+	merged := listenermerge.Merge(parent, siblings)
+
+	return dropConflictedSections(merged, listenerSet, sections)
 }
 
 func dropConflictedSections(

--- a/internal/controller/route_effective_hostnames_test.go
+++ b/internal/controller/route_effective_hostnames_test.go
@@ -312,3 +312,68 @@ func buildGatewayFakeClient(t *testing.T, objs ...client.Object) client.Client {
 
 	return builder.Build()
 }
+
+// TestWithEffectiveHostnames_ListenerSetConflictedEntryNotInherited pins the
+// hostname side of the shared nonConflictedSections drop: when the route's
+// matched ListenerSet entry is conflicted in the merged view (a
+// higher-precedence Gateway listener on the same port claims the same
+// hostname), that entry is not programmed, so the route must NOT inherit its
+// hostname. Without the conflict drop the route would wrongly serve the
+// conflicted listener's hostname. The redirect-scheme path has a sibling test;
+// both callers of nonConflictedSections need independent coverage.
+func TestWithEffectiveHostnames_ListenerSetConflictedEntryNotInherited(t *testing.T) {
+	t.Parallel()
+
+	host := gatewayv1.Hostname("dup.example.com")
+	fromAll := gatewayv1.NamespacesFromAll
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "infra"},
+		Spec: gatewayv1.GatewaySpec{
+			AllowedListeners: &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{From: &fromAll},
+			},
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "g", Port: 80, Protocol: gatewayv1.HTTPProtocolType, Hostname: &host,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+			},
+		},
+	}
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "infra"},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{Name: "gw"},
+			Listeners: []gatewayv1.ListenerEntry{
+				{
+					Name: "only", Port: 80, Protocol: gatewayv1.HTTPProtocolType, Hostname: &host,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+			},
+		},
+	}
+
+	lsKind := gatewayv1.Kind(kindListenerSet)
+	lsNS := gatewayv1.Namespace("infra")
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "team"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Kind: &lsKind, Name: "ls", Namespace: &lsNS},
+				},
+			},
+		},
+	}
+
+	cli := buildGatewayFakeClient(t, gw, ls)
+
+	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	assert.Empty(t, out[0].Spec.Hostnames,
+		"a conflicted ListenerSet entry is not programmed → its hostname must not be inherited")
+}

--- a/internal/controller/route_redirect_scheme.go
+++ b/internal/controller/route_redirect_scheme.go
@@ -1,0 +1,297 @@
+package controller
+
+import (
+	"context"
+	"slices"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/routebinding"
+)
+
+// redirectSchemeHTTP and redirectSchemeHTTPS are the only two values the
+// Gateway API permits for HTTPRequestRedirectFilter.Scheme
+// (+kubebuilder:validation:Enum=http;https).
+const (
+	redirectSchemeHTTP  = "http"
+	redirectSchemeHTTPS = "https"
+)
+
+// withDefaultRedirectScheme returns copies of the given routes in which every
+// rule-level RequestRedirect filter that leaves Scheme empty has it defaulted
+// to the scheme implied by the parent listener the route binds to.
+//
+// Why: the Gateway API says of HTTPRequestRedirectFilter.Scheme "when empty,
+// the scheme of the request is used". Behind a Cloudflare Tunnel the proxy
+// never sees the original wire scheme (cloudflared terminates TLS at the edge
+// and hands the origin a scheme-less server request), so "the scheme of the
+// request" has to be reconstructed from the listener the route is attached to:
+// an HTTP listener implies http, an HTTPS/TLS listener implies https. Without
+// this the proxy falls back to a hardcoded https for every scheme-less
+// redirect, which violates the spec for routes on an HTTP listener.
+//
+// Only listeners that actually ACCEPT the route contribute, reusing the same
+// binding validator as hostname inheritance. When no managed parent resolves,
+// the filter's Scheme is left nil and the proxy's own fallback applies.
+//
+// The function never mutates the input routes; a route is deep-copied only
+// when it has at least one scheme-less redirect filter AND a parent scheme was
+// resolved.
+func withDefaultRedirectScheme(
+	ctx context.Context,
+	cli client.Client,
+	routes []*gatewayv1.HTTPRoute,
+) []*gatewayv1.HTTPRoute {
+	if len(routes) == 0 {
+		return routes
+	}
+
+	validator := routebinding.NewValidator(cli)
+	out := make([]*gatewayv1.HTTPRoute, len(routes))
+
+	for i, route := range routes {
+		out[i] = defaultRedirectSchemeForRoute(ctx, cli, validator, route)
+	}
+
+	return out
+}
+
+// defaultRedirectSchemeForRoute returns route unchanged when it carries no
+// scheme-less redirect filter or no parent scheme resolves; otherwise it
+// returns a deep copy with the empty redirect schemes filled in.
+func defaultRedirectSchemeForRoute(
+	ctx context.Context,
+	cli client.Client,
+	validator *routebinding.Validator,
+	route *gatewayv1.HTTPRoute,
+) *gatewayv1.HTTPRoute {
+	if !routeHasEmptyRedirectScheme(route) {
+		return route
+	}
+
+	scheme := acceptedListenerScheme(ctx, cli, validator, HTTPRouteWrapper{route})
+	if scheme == "" {
+		return route
+	}
+
+	clone := route.DeepCopy()
+	applyDefaultRedirectScheme(clone, scheme)
+
+	return clone
+}
+
+// redirectFilters returns pointers to every RequestRedirect filter on the
+// route, at BOTH the rule level (Rules[].Filters) and the backendRef level
+// (Rules[].BackendRefs[].Filters). The Gateway API permits RequestRedirect in
+// both places (backendRef-level support is Extended) and the proxy executes
+// both — rule filters via result.Filters and backendRef filters via
+// result.BackendFilters — so scheme defaulting must reach both. The pointers
+// alias the route's backing arrays, so mutating through them mutates the route
+// (callers pass a deep copy when they intend to write).
+func redirectFilters(route *gatewayv1.HTTPRoute) []*gatewayv1.HTTPRouteFilter {
+	var out []*gatewayv1.HTTPRouteFilter
+
+	for ruleIdx := range route.Spec.Rules {
+		rule := &route.Spec.Rules[ruleIdx]
+
+		for filterIdx := range rule.Filters {
+			out = append(out, &rule.Filters[filterIdx])
+		}
+
+		for backendIdx := range rule.BackendRefs {
+			backendFilters := rule.BackendRefs[backendIdx].Filters
+			for filterIdx := range backendFilters {
+				out = append(out, &backendFilters[filterIdx])
+			}
+		}
+	}
+
+	return out
+}
+
+// routeHasEmptyRedirectScheme reports whether any RequestRedirect filter on the
+// route (rule level or backendRef level) leaves Scheme unset — the only case
+// the defaulting touches.
+func routeHasEmptyRedirectScheme(route *gatewayv1.HTTPRoute) bool {
+	return slices.ContainsFunc(redirectFilters(route), isEmptySchemeRedirect)
+}
+
+// applyDefaultRedirectScheme sets the resolved scheme on every scheme-less
+// RequestRedirect filter of the (already cloned) route, at both the rule and
+// backendRef levels.
+func applyDefaultRedirectScheme(route *gatewayv1.HTTPRoute, scheme string) {
+	for _, filter := range redirectFilters(route) {
+		if isEmptySchemeRedirect(filter) {
+			value := scheme
+			filter.RequestRedirect.Scheme = &value
+		}
+	}
+}
+
+func isEmptySchemeRedirect(filter *gatewayv1.HTTPRouteFilter) bool {
+	return filter.Type == gatewayv1.HTTPRouteFilterRequestRedirect &&
+		filter.RequestRedirect != nil &&
+		filter.RequestRedirect.Scheme == nil
+}
+
+// acceptedListenerScheme returns the redirect scheme implied by the listeners
+// that accept the route: "https" if any accepting listener terminates HTTPS,
+// otherwise "http" if at least one accepting HTTP listener resolves, or "" when
+// no managed L7 parent accepts the route. HTTPS wins ties so a route bound to
+// both an HTTP and an HTTPS listener defaults to the more secure scheme.
+//
+// Only HTTP and HTTPS listeners are considered: a TLS/TCP/UDP listener never
+// accepts an HTTPRoute (the binding validator's default kinds for those
+// protocols exclude HTTPRoute), so such a listener never appears in the
+// accepted set and contributes no scheme. TLS in particular is terminated at
+// the Cloudflare edge and is not a supported frontend listener for HTTPRoute.
+func acceptedListenerScheme(
+	ctx context.Context,
+	cli client.Client,
+	validator *routebinding.Validator,
+	route Route,
+) string {
+	sawHTTP := false
+
+	for _, ref := range route.GetParentRefs() {
+		for _, protocol := range acceptedProtocolsForParentRef(ctx, cli, validator, route, ref) {
+			switch protocol {
+			case gatewayv1.HTTPSProtocolType:
+				return redirectSchemeHTTPS
+			case gatewayv1.HTTPProtocolType:
+				sawHTTP = true
+			case gatewayv1.TLSProtocolType, gatewayv1.TCPProtocolType, gatewayv1.UDPProtocolType:
+				// Non-HTTP(S) listeners never accept an HTTPRoute, so they
+				// imply no redirect scheme.
+			}
+		}
+	}
+
+	if sawHTTP {
+		return redirectSchemeHTTP
+	}
+
+	return ""
+}
+
+// acceptedProtocolsForParentRef mirrors acceptedHostnamesForParentRef but
+// collects the protocols of the listeners that accept the route, so the
+// redirect-scheme default can be inferred from the parent listener. It applies
+// the same group / kind / namespace resolution before delegating to the
+// Gateway or ListenerSet branch.
+func acceptedProtocolsForParentRef(
+	ctx context.Context,
+	cli client.Client,
+	validator *routebinding.Validator,
+	route Route,
+	ref gatewayv1.ParentReference,
+) []gatewayv1.ProtocolType {
+	if ref.Group != nil && string(*ref.Group) != "" && string(*ref.Group) != gatewayv1.GroupName {
+		return nil
+	}
+
+	kind := kindGateway
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
+
+	namespace := route.GetNamespace()
+	if ref.Namespace != nil {
+		namespace = string(*ref.Namespace)
+	}
+
+	routeInfo := &routebinding.RouteInfo{
+		Name:      route.GetName(),
+		Namespace: route.GetNamespace(),
+		// Real hostnames here — unlike the hostname-inheritance path, which
+		// passes nil because it runs only on routes with empty spec.hostnames.
+		// Redirect routes may carry hostnames, so they must reach the binding
+		// validator for accurate per-listener hostname filtering.
+		Hostnames:   route.GetHostnames(),
+		Kind:        route.GetRouteKind(),
+		SectionName: ref.SectionName,
+		Port:        ref.Port,
+	}
+
+	switch kind {
+	case kindGateway:
+		return gatewayAcceptedProtocols(ctx, cli, validator, namespace, string(ref.Name), routeInfo)
+	case kindListenerSet:
+		return listenerSetAcceptedProtocols(ctx, cli, validator, namespace, string(ref.Name), routeInfo)
+	}
+
+	return nil
+}
+
+func gatewayAcceptedProtocols(
+	ctx context.Context,
+	cli client.Client,
+	validator *routebinding.Validator,
+	namespace, name string,
+	routeInfo *routebinding.RouteInfo,
+) []gatewayv1.ProtocolType {
+	var gateway gatewayv1.Gateway
+	if err := cli.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &gateway); err != nil {
+		return nil
+	}
+
+	result, err := validator.ValidateBinding(ctx, &gateway, routeInfo)
+	if err != nil || !result.Accepted {
+		return nil
+	}
+
+	protoByName := make(map[gatewayv1.SectionName]gatewayv1.ProtocolType, len(gateway.Spec.Listeners))
+	for i := range gateway.Spec.Listeners {
+		protoByName[gateway.Spec.Listeners[i].Name] = gateway.Spec.Listeners[i].Protocol
+	}
+
+	return protocolsForSections(result.MatchedListeners, protoByName)
+}
+
+func listenerSetAcceptedProtocols(
+	ctx context.Context,
+	cli client.Client,
+	validator *routebinding.Validator,
+	namespace, name string,
+	routeInfo *routebinding.RouteInfo,
+) []gatewayv1.ProtocolType {
+	var listenerSet gatewayv1.ListenerSet
+	if err := cli.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &listenerSet); err != nil {
+		return nil
+	}
+
+	result, err := validator.ValidateBindingForListenerSet(ctx, &listenerSet, routeInfo)
+	if err != nil || !result.Accepted {
+		return nil
+	}
+
+	// Drop sections whose merged-view entry is conflicted — a conflicted
+	// listener is not programmed, so a route must not infer its scheme from
+	// that listener's protocol. Same step the hostname-inheritance path takes.
+	matched := nonConflictedSections(ctx, cli, &listenerSet, result.MatchedListeners)
+
+	protoByName := make(map[gatewayv1.SectionName]gatewayv1.ProtocolType, len(listenerSet.Spec.Listeners))
+	for i := range listenerSet.Spec.Listeners {
+		protoByName[listenerSet.Spec.Listeners[i].Name] = listenerSet.Spec.Listeners[i].Protocol
+	}
+
+	return protocolsForSections(matched, protoByName)
+}
+
+// protocolsForSections maps each accepted listener section to its protocol,
+// mirroring hostnamesForSections on the hostname-inheritance path.
+func protocolsForSections(
+	sections []gatewayv1.SectionName,
+	protoByName map[gatewayv1.SectionName]gatewayv1.ProtocolType,
+) []gatewayv1.ProtocolType {
+	var out []gatewayv1.ProtocolType
+
+	for _, section := range sections {
+		if protocol, ok := protoByName[section]; ok && protocol != "" {
+			out = append(out, protocol)
+		}
+	}
+
+	return out
+}

--- a/internal/controller/route_redirect_scheme_test.go
+++ b/internal/controller/route_redirect_scheme_test.go
@@ -1,0 +1,402 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// redirectRoute builds an HTTPRoute bound to gw/infra with a single
+// rule-level RequestRedirect filter whose Scheme is left nil unless overridden.
+func redirectRoute(scheme *string) *gatewayv1.HTTPRoute {
+	gwKind := gatewayv1.Kind(kindGateway)
+	gwNS := gatewayv1.Namespace("infra")
+
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "team"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Kind: &gwKind, Name: "gw", Namespace: &gwNS},
+				},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+							RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+								Scheme:     scheme,
+								StatusCode: new(302),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// gatewayWithListenerProtocol builds a Gateway named gw/infra with one
+// all-namespaces listener of the given protocol and no hostname, isolating the
+// protocol → redirect-scheme inference from hostname inheritance.
+func gatewayWithListenerProtocol(protocol gatewayv1.ProtocolType, port gatewayv1.PortNumber) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "infra"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "l", Port: port, Protocol: protocol,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+			},
+		},
+	}
+}
+
+func redirectFilterScheme(route *gatewayv1.HTTPRoute) *string {
+	return route.Spec.Rules[0].Filters[0].RequestRedirect.Scheme
+}
+
+// TestWithDefaultRedirectScheme_HTTPListenerDefaultsToHTTP pins the spec rule
+// "when empty, the scheme of the request is used": a redirect with no explicit
+// scheme, bound to an HTTP listener, must default to http — not the hardcoded
+// https the proxy falls back to without this inference.
+func TestWithDefaultRedirectScheme_HTTPListenerDefaultsToHTTP(t *testing.T) {
+	t.Parallel()
+
+	gw := gatewayWithListenerProtocol(gatewayv1.HTTPProtocolType, 80)
+	route := redirectRoute(nil)
+	cli := buildGatewayFakeClient(t, gw)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	got := redirectFilterScheme(out[0])
+	require.NotNil(t, got, "redirect scheme must be defaulted from the HTTP listener")
+	assert.Equal(t, "http", *got)
+
+	assert.Nil(t, redirectFilterScheme(route), "input route must not be mutated")
+}
+
+// TestWithDefaultRedirectScheme_HTTPSListenerDefaultsToHTTPS proves the same
+// inference yields https when the bound listener terminates HTTPS.
+func TestWithDefaultRedirectScheme_HTTPSListenerDefaultsToHTTPS(t *testing.T) {
+	t.Parallel()
+
+	gw := gatewayWithListenerProtocol(gatewayv1.HTTPSProtocolType, 443)
+	route := redirectRoute(nil)
+	cli := buildGatewayFakeClient(t, gw)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	got := redirectFilterScheme(out[0])
+	require.NotNil(t, got)
+	assert.Equal(t, "https", *got)
+}
+
+// TestWithDefaultRedirectScheme_TLSListenerLeavesSchemeNil proves a TLS
+// listener infers no redirect scheme: an HTTPRoute never binds to a TLS
+// listener (the binding validator's default kinds for TLS exclude HTTPRoute,
+// and TLS is terminated at the Cloudflare edge), so the listener never appears
+// in the accepted set and the scheme is left nil for the proxy fallback.
+func TestWithDefaultRedirectScheme_TLSListenerLeavesSchemeNil(t *testing.T) {
+	t.Parallel()
+
+	gw := gatewayWithListenerProtocol(gatewayv1.TLSProtocolType, 443)
+	route := redirectRoute(nil)
+	cli := buildGatewayFakeClient(t, gw)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	assert.Nil(t, redirectFilterScheme(out[0]), "a TLS listener does not accept an HTTPRoute → no inferred scheme")
+}
+
+// TestWithDefaultRedirectScheme_TCPListenerLeavesSchemeNil proves a non-L7
+// (TCP) listener implies no HTTP redirect scheme: the route does not bind to a
+// TCP listener as an HTTPRoute, so nothing is inferred and the scheme stays nil
+// for the proxy fallback. This also pins the exhaustive switch's TCP/UDP arm.
+func TestWithDefaultRedirectScheme_TCPListenerLeavesSchemeNil(t *testing.T) {
+	t.Parallel()
+
+	gw := gatewayWithListenerProtocol(gatewayv1.TCPProtocolType, 9000)
+	route := redirectRoute(nil)
+	cli := buildGatewayFakeClient(t, gw)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	assert.Nil(t, redirectFilterScheme(out[0]), "a TCP listener implies no L7 redirect scheme")
+}
+
+// TestWithDefaultRedirectScheme_ExplicitSchemePreserved proves an operator's
+// explicit scheme is never overwritten by the inferred default.
+func TestWithDefaultRedirectScheme_ExplicitSchemePreserved(t *testing.T) {
+	t.Parallel()
+
+	gw := gatewayWithListenerProtocol(gatewayv1.HTTPSProtocolType, 443)
+	route := redirectRoute(new("http"))
+	cli := buildGatewayFakeClient(t, gw)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	got := redirectFilterScheme(out[0])
+	require.NotNil(t, got)
+	assert.Equal(t, "http", *got, "explicit scheme must win over the listener-inferred default")
+}
+
+// TestWithDefaultRedirectScheme_NoRedirectFilterPassthrough proves a route with
+// no redirect filter is returned unchanged (same pointer, no deep copy).
+func TestWithDefaultRedirectScheme_NoRedirectFilterPassthrough(t *testing.T) {
+	t.Parallel()
+
+	gw := gatewayWithListenerProtocol(gatewayv1.HTTPProtocolType, 80)
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "team"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{{}},
+		},
+	}
+	cli := buildGatewayFakeClient(t, gw)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	assert.Same(t, route, out[0], "routes without a redirect filter must pass through untouched")
+}
+
+// TestWithDefaultRedirectScheme_NoParentLeavesSchemeNil proves that when no
+// managed parent listener resolves, the scheme is left nil so the proxy's own
+// fallback applies rather than guessing.
+func TestWithDefaultRedirectScheme_NoParentLeavesSchemeNil(t *testing.T) {
+	t.Parallel()
+
+	route := redirectRoute(nil)
+	cli := buildGatewayFakeClient(t) // no Gateway seeded
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	assert.Nil(t, redirectFilterScheme(out[0]), "no resolvable parent → no inferred scheme")
+}
+
+// listenerSetRedirectRoute builds a redirect HTTPRoute bound to ls/infra.
+func listenerSetRedirectRoute() *gatewayv1.HTTPRoute {
+	lsKind := gatewayv1.Kind(kindListenerSet)
+	lsNS := gatewayv1.Namespace("infra")
+	route := redirectRoute(nil)
+	route.Spec.ParentRefs = []gatewayv1.ParentReference{
+		{Kind: &lsKind, Name: "ls", Namespace: &lsNS},
+	}
+
+	return route
+}
+
+// TestWithDefaultRedirectScheme_ListenerSetHTTPDefaultsToHTTP proves the
+// ListenerSet parentRef branch infers the scheme from the entry's protocol,
+// exactly like the Gateway branch. Without the parent Gateway seeded,
+// nonConflictedSections is a best-effort no-op, so this isolates the
+// section→protocol mapping for the accepted ListenerSet entry.
+func TestWithDefaultRedirectScheme_ListenerSetHTTPDefaultsToHTTP(t *testing.T) {
+	t.Parallel()
+
+	entryHost := gatewayv1.Hostname("ls.example.com")
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "infra"},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{Name: "gw"},
+			Listeners: []gatewayv1.ListenerEntry{
+				{
+					Name: "only", Port: 80, Protocol: gatewayv1.HTTPProtocolType, Hostname: &entryHost,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+			},
+		},
+	}
+
+	cli := buildGatewayFakeClient(t, ls)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{listenerSetRedirectRoute()})
+	require.Len(t, out, 1)
+	got := redirectFilterScheme(out[0])
+	require.NotNil(t, got, "scheme must be inferred from the accepted ListenerSet entry")
+	assert.Equal(t, "http", *got)
+}
+
+// TestWithDefaultRedirectScheme_ListenerSetConflictedEntryLeavesSchemeNil
+// pins the conflict-drop fix: when the route's matched ListenerSet entry is
+// conflicted in the merged view (a higher-precedence entry on the same port
+// claimed the same hostname), that entry is not programmed, so its protocol
+// must NOT seed the redirect scheme. Without the dropConflictedSections step
+// the scheme would wrongly be inferred from the conflicted entry.
+func TestWithDefaultRedirectScheme_ListenerSetConflictedEntryLeavesSchemeNil(t *testing.T) {
+	t.Parallel()
+
+	host := gatewayv1.Hostname("dup.example.com")
+	fromAll := gatewayv1.NamespacesFromAll
+	// The Gateway listener claims the same (port, hostname) as the ListenerSet
+	// entry. Gateway listeners always precede ListenerSet entries in the merged
+	// view, so the Gateway wins and the ListenerSet entry is annotated with a
+	// HostnameConflict — deterministically, with no dependence on resource
+	// name ordering.
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "infra"},
+		Spec: gatewayv1.GatewaySpec{
+			// Opt the ListenerSet into the merged view; without this the
+			// Gateway's default (From=None) excludes it and the conflict the
+			// test relies on is never annotated.
+			AllowedListeners: &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{From: &fromAll},
+			},
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "g", Port: 80, Protocol: gatewayv1.HTTPProtocolType, Hostname: &host,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+			},
+		},
+	}
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "infra"},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{Name: "gw"},
+			Listeners: []gatewayv1.ListenerEntry{
+				{
+					Name: "only", Port: 80, Protocol: gatewayv1.HTTPProtocolType, Hostname: &host,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+			},
+		},
+	}
+
+	cli := buildGatewayFakeClient(t, gw, ls)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{listenerSetRedirectRoute()})
+	require.Len(t, out, 1)
+	assert.Nil(t, redirectFilterScheme(out[0]),
+		"a conflicted ListenerSet entry is not programmed → its protocol must not seed the scheme")
+}
+
+// backendRefRedirectRoute builds an HTTPRoute bound to gw/infra whose redirect
+// filter lives at the backendRef level (HTTPBackendRef.Filters), not the rule
+// level. The Gateway API permits RequestRedirect there (Support: Extended) and
+// the proxy executes it, so scheme defaulting must reach it too.
+func backendRefRedirectRoute() *gatewayv1.HTTPRoute {
+	gwKind := gatewayv1.Kind(kindGateway)
+	gwNS := gatewayv1.Namespace("infra")
+
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "team"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Kind: &gwKind, Name: "gw", Namespace: &gwNS},
+				},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "svc", Port: new(gatewayv1.PortNumber(80)),
+								},
+							},
+							Filters: []gatewayv1.HTTPRouteFilter{
+								{
+									Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+									RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+										StatusCode: new(302),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func backendRefRedirectFilterScheme(route *gatewayv1.HTTPRoute) *string {
+	return route.Spec.Rules[0].BackendRefs[0].Filters[0].RequestRedirect.Scheme
+}
+
+// TestWithDefaultRedirectScheme_BackendRefHTTPListenerDefaultsToHTTP proves the
+// defaulting reaches a backendRef-level RequestRedirect filter, not just
+// rule-level ones: a scheme-less backendRef redirect on an HTTP listener must
+// default to http.
+func TestWithDefaultRedirectScheme_BackendRefHTTPListenerDefaultsToHTTP(t *testing.T) {
+	t.Parallel()
+
+	gw := gatewayWithListenerProtocol(gatewayv1.HTTPProtocolType, 80)
+	route := backendRefRedirectRoute()
+	cli := buildGatewayFakeClient(t, gw)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	got := backendRefRedirectFilterScheme(out[0])
+	require.NotNil(t, got, "backendRef redirect scheme must be defaulted from the HTTP listener")
+	assert.Equal(t, "http", *got)
+
+	assert.Nil(t, backendRefRedirectFilterScheme(route), "input route must not be mutated")
+}
+
+// TestWithDefaultRedirectScheme_BackendRefHTTPSListenerDefaultsToHTTPS is the
+// HTTPS counterpart of the backendRef-level case.
+func TestWithDefaultRedirectScheme_BackendRefHTTPSListenerDefaultsToHTTPS(t *testing.T) {
+	t.Parallel()
+
+	gw := gatewayWithListenerProtocol(gatewayv1.HTTPSProtocolType, 443)
+	route := backendRefRedirectRoute()
+	cli := buildGatewayFakeClient(t, gw)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	got := backendRefRedirectFilterScheme(out[0])
+	require.NotNil(t, got)
+	assert.Equal(t, "https", *got)
+}
+
+// TestWithDefaultRedirectScheme_HTTPSWinsTie pins the documented tie-break: a
+// route accepted by both an HTTP and an HTTPS listener on the same Gateway
+// defaults its scheme to the more secure https.
+func TestWithDefaultRedirectScheme_HTTPSWinsTie(t *testing.T) {
+	t.Parallel()
+
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "infra"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+				{
+					Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+			},
+		},
+	}
+	route := redirectRoute(nil)
+	cli := buildGatewayFakeClient(t, gw)
+
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	require.Len(t, out, 1)
+	got := redirectFilterScheme(out[0])
+	require.NotNil(t, got)
+	assert.Equal(t, "https", *got, "https must win when the route is bound to both an HTTP and an HTTPS listener")
+}

--- a/internal/proxy/filter.go
+++ b/internal/proxy/filter.go
@@ -169,6 +169,13 @@ func (f *requestRedirect) buildRedirectURL(req *http.Request) string {
 
 // buildRedirectBase constructs the base URL (scheme + host) for a redirect.
 func buildRedirectBase(req *http.Request, config *RedirectConfig) *url.URL {
+	// Per spec, an empty redirect scheme means "the scheme of the request".
+	// Behind the tunnel cloudflared terminates TLS at the edge, so the origin
+	// request carries no usable scheme — the controller resolves the intended
+	// scheme from the parent listener's protocol and stamps it into
+	// config.Scheme (see withDefaultRedirectScheme). This https fallback only
+	// applies when neither an explicit nor a listener-resolved scheme is
+	// available (e.g. no managed parent resolved the route).
 	scheme := req.URL.Scheme
 	if scheme == "" {
 		scheme = schemeHTTPS

--- a/internal/proxy/filter_test.go
+++ b/internal/proxy/filter_test.go
@@ -166,6 +166,62 @@ func TestRequestRedirect_Basic(t *testing.T) {
 	assert.Equal(t, "https://new.example.com/path", resp.Header.Get("Location"))
 }
 
+// TestRequestRedirect_ConfigSchemeOverridesEmptyRequestScheme is the seam test
+// for the redirect-scheme defaulting: behind the tunnel cloudflared hands the
+// proxy a scheme-less request (req.URL.Scheme == ""), and the controller stamps
+// the parent listener's scheme into RedirectConfig.Scheme. This proves the
+// stamped scheme reaches the emitted Location — an http listener yields an
+// http:// redirect, not the https:// the bare fallback would emit.
+func TestRequestRedirect_ConfigSchemeOverridesEmptyRequestScheme(t *testing.T) {
+	t.Parallel()
+
+	scheme := "http"
+	statusCode := http.StatusFound
+
+	filter := proxy.NewRequestRedirect(&proxy.RedirectConfig{
+		Scheme:     &scheme,
+		StatusCode: &statusCode,
+	})
+
+	// Scheme-less URL, exactly what the tunnel origin request carries.
+	req := &http.Request{
+		Host:   "app.example.com",
+		URL:    &url.URL{Host: "app.example.com", Path: "/p"},
+		Header: http.Header{},
+	}
+
+	resp := filter.ProcessRequest(req)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, "http://app.example.com/p", resp.Header.Get("Location"),
+		"the controller-stamped http scheme must reach the Location header")
+}
+
+// TestRequestRedirect_EmptySchemeFallsBackToHTTPS pins the documented fallback:
+// when neither the request carries a scheme nor the config sets one (no managed
+// parent resolved a listener scheme), the proxy emits https://.
+func TestRequestRedirect_EmptySchemeFallsBackToHTTPS(t *testing.T) {
+	t.Parallel()
+
+	statusCode := http.StatusFound
+
+	filter := proxy.NewRequestRedirect(&proxy.RedirectConfig{
+		StatusCode: &statusCode,
+	})
+
+	req := &http.Request{
+		Host:   "app.example.com",
+		URL:    &url.URL{Host: "app.example.com", Path: "/p"},
+		Header: http.Header{},
+	}
+
+	resp := filter.ProcessRequest(req)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, "https://app.example.com/p", resp.Header.Get("Location"),
+		"with no request scheme and no config scheme, the fallback is https")
+}
+
 func TestRequestRedirect_PortAndPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Pull Request

## Description

A `RequestRedirect` filter that leaves `scheme` empty must, per the Gateway API spec, use "the scheme of the request". Behind a Cloudflare Tunnel that contract was being violated: cloudflared terminates TLS at the edge and hands the in-process proxy a scheme-less origin request, so `buildRedirectBase` fell back to a hardcoded `https` for every scheme-less redirect. A route bound to a plain HTTP listener therefore redirected to `https://` instead of `http://`.

This surfaced as a full sweep of redirect conformance failures (`HTTPRoute303/307/308Redirect`, `HTTPRouteRedirectHostAndStatus`, `HTTPRouteRedirectPath`, `HTTPRouteRedirectPort`) once those tests were de-skipped: the controller emitted the correct status, host, port, and path, but the scheme came back `https` where the suite expected `http`. `HTTPRouteRedirectScheme` passed throughout because it sets the scheme explicitly, which isolates the defaulting path as the culprit.

The fix reconstructs "the scheme of the request" from the only place it survives behind the tunnel — the protocol of the listener the route is accepted on. A new controller pass (`withDefaultRedirectScheme`, wired into `ProxySyncer.buildProxyConfig` right after the existing hostname-inheritance pass) resolves the accepted-listener protocol through the same binding validator and stamps `http`/`https` into each scheme-less redirect filter before conversion. HTTP listeners imply `http`; HTTPS/TLS listeners imply `https`. Explicit operator schemes are preserved, and when no managed parent resolves, the filter is left untouched so the data-plane fallback still applies.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that breaks existing functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] ✅ Test update
- [ ] 🔨 CI/CD or build process changes

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [ ] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [ ] Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller`)
- [ ] Helm lint passes (`helm lint charts/cloudflare-tunnel-gateway-controller`)
- [ ] Helm README is up to date (`helm-docs charts/cloudflare-tunnel-gateway-controller`)
- [ ] Manual testing completed (if applicable)

No markdown, Helm chart, or docs files were touched, so those checks are not applicable.

Unit coverage (`TestWithDefaultRedirectScheme_*`) pins: HTTP listener → `http`, HTTPS listener → `https`, TLS listener → `https`, TCP listener → scheme left nil (non-L7), explicit scheme preserved, route without a redirect filter passes through untouched, and no resolvable parent → scheme left nil.

The redirect conformance family this unblocks is maintainer-gated (a live run against a real Cloudflare Tunnel) and is part of the pre-merge verification.

## Documentation

- [ ] README updated (if needed)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed)

## Additional Notes

The new pass mirrors `withEffectiveHostnames` — same validator, same parentRef walk, same "only accepted listeners count" semantics, same non-mutating deep-copy-on-write. The `https`-wins-ties rule (a route bound to both an HTTP and an HTTPS listener defaults to the more secure scheme) is documented inline. `RouteInfo.Hostnames` is populated with the route's real hostnames here (unlike the hostname-inheritance pass, which passes nil because it runs only on hostname-less routes) so per-listener hostname filtering stays accurate.
