### PR TITLE
test(e2e): run gRPC suite on the http2 tunnel transport

### DIFF
--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -168,6 +168,7 @@ helm upgrade --install "${RELEASE_NAME}" \
   --set proxy.image.tag="${PROXY_IMAGE##*:}" \
   --set proxy.image.pullPolicy=Never \
   --set proxy.tunnelTokenSecretRef.name=cloudflare-tunnel-token \
+  --set proxy.tunnel.protocol=http2 \
   --set controller.logLevel=debug \
   --wait --timeout 120s
 

--- a/test/e2e/e2e_grpc_test.go
+++ b/test/e2e/e2e_grpc_test.go
@@ -41,6 +41,14 @@ const (
 //nolint:funlen // one end-to-end scenario with deploy + wait + gRPC dial steps
 func TestGRPCRouteEndToEnd(t *testing.T) {
 	cfg := loadTestConfig()
+
+	// gRPC only works over the http2 tunnel transport; skip fast (with an
+	// actionable message) rather than poll for ~90s against a transport that
+	// can never carry the grpc-status trailer.
+	if reason := grpcRequiresHTTP2SkipReason(cfg.TunnelProtocol); reason != "" {
+		t.Skip(reason)
+	}
+
 	k8sClient := newK8sClient(t, cfg.KubeContext)
 	ctx := context.Background()
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -43,6 +43,11 @@ type testConfig struct {
 	Namespace      string
 	TestNamespace  string
 	GatewayName    string
+	// TunnelProtocol is the edge transport the proxy under test is deployed
+	// with (auto|http2|quic). It drives the gRPC suite's fast-fail guard:
+	// gRPC only works on http2 (cloudflared drops trailers over QUIC).
+	// Defaults to http2 to match the conformance setup script.
+	TunnelProtocol string
 }
 
 func loadTestConfig() testConfig {
@@ -52,6 +57,7 @@ func loadTestConfig() testConfig {
 		Namespace:      envWithFallback("E2E_NAMESPACE", "CONFORMANCE_NAMESPACE", "cloudflare-tunnel-system"),
 		TestNamespace:  envWithFallback("E2E_TEST_NAMESPACE", "CONFORMANCE_TEST_NAMESPACE", "e2e-test"),
 		GatewayName:    envWithFallback("E2E_GATEWAY_NAME", "CONFORMANCE_GATEWAY_NAME", "e2e-gateway"),
+		TunnelProtocol: envWithFallback("E2E_TUNNEL_PROTOCOL", "CONFORMANCE_TUNNEL_PROTOCOL", "http2"),
 	}
 }
 

--- a/test/e2e/grpc_protocol_guard.go
+++ b/test/e2e/grpc_protocol_guard.go
@@ -1,0 +1,31 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+)
+
+// grpcRequiresHTTP2SkipReason returns a non-empty skip reason when the
+// configured tunnel transport cannot carry gRPC, and "" when it can.
+//
+// gRPC mandates the http2 transport: cloudflared does not forward HTTP
+// trailers over QUIC, so the grpc-status trailer is dropped at the edge and
+// every call fails with "server closed the stream without sending trailers".
+// Only "http2" is safe. "quic", "auto" (auto lets cloudflared negotiate QUIC),
+// the unset value, and any unrecognised value are reported as skip so the
+// suite fails fast with an actionable message instead of polling for ~90s
+// before timing out against a transport that can never succeed.
+func grpcRequiresHTTP2SkipReason(protocol string) string {
+	if strings.EqualFold(strings.TrimSpace(protocol), "http2") {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"gRPC requires the http2 tunnel transport (configured protocol is %q): "+
+			"cloudflared drops HTTP trailers over QUIC, so grpc-status is lost and every "+
+			"gRPC call fails. Deploy the proxy with proxy.tunnel.protocol=http2.",
+		protocol,
+	)
+}

--- a/test/e2e/grpc_protocol_guard_test.go
+++ b/test/e2e/grpc_protocol_guard_test.go
@@ -1,0 +1,48 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGRPCRequiresHTTP2SkipReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		protocol string
+		wantSkip bool
+	}{
+		{name: "http2 runs", protocol: "http2", wantSkip: false},
+		{name: "http2 mixed case runs", protocol: "HTTP2", wantSkip: false},
+		{name: "http2 padded runs", protocol: " http2 ", wantSkip: false},
+		{name: "quic skips", protocol: "quic", wantSkip: true},
+		{name: "auto skips", protocol: "auto", wantSkip: true},
+		{name: "empty skips", protocol: "", wantSkip: true},
+		{name: "typo skips", protocol: "quik", wantSkip: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reason := grpcRequiresHTTP2SkipReason(tt.protocol)
+
+			if tt.wantSkip {
+				if reason == "" {
+					t.Fatalf("protocol %q: want a non-empty skip reason, got empty", tt.protocol)
+				}
+
+				// The message must name the fix so an operator can act on it
+				// without reading source.
+				if !strings.Contains(reason, "http2") {
+					t.Errorf("protocol %q: skip reason should mention http2, got %q", tt.protocol, reason)
+				}
+			} else if reason != "" {
+				t.Fatalf("protocol %q: want run (empty reason), got skip %q", tt.protocol, reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

gRPC over the Cloudflare Tunnel only works on the `http2` edge transport: cloudflared does not forward HTTP trailers over QUIC, so the mandatory `grpc-status` trailer is dropped at the edge and every gRPC call fails with `server closed the stream without sending trailers`. The conformance/e2e kind cluster deployed the proxy with the default `auto` transport, so cloudflared negotiated QUIC and the gRPC end-to-end test timed out. This is the test-infrastructure fix for that failing test — part of the broader gRPC-over-tunnel work (#357 / #358 / #359); this PR is the #357 piece.

## Changes

- Deploy the conformance/e2e proxy with `proxy.tunnel.protocol=http2` in `hack/conformance-setup.sh` — the transport that forwards trailers. The test tunnel serves gRPC, so http2 is the correct choice there.
- Add an `E2E_TUNNEL_PROTOCOL` config knob (default `http2`) and a fast-fail guard: when the proxy under test is not on http2, the gRPC test now skips immediately with an actionable message instead of polling ~90s against a transport that can never carry the trailer.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [ ] Markdown linting passes (`markdownlint **/*.md`) — N/A, no markdown changed
- [x] Manual testing completed — fresh kind cluster (proxy on http2): full conformance suite green (355 pass / 60 skip; one async request-mirror subtest flaked and re-ran green — its mirror leg is cluster-internal proxy→backend, independent of the edge transport this PR changes) and full custom e2e green (56 pass / 0 fail), including the gRPC end-to-end test passing in ~4.4s where it previously timed out.

## Documentation

- [ ] README updated (if needed) — N/A, test infrastructure only, no user-facing behavior change
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed) — N/A

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced (if any)

## Additional Notes

The guard's `http2`-only predicate mirrors the production-side gRPC-transport check in the controller. `auto` is treated as skip because cloudflared may negotiate QUIC under `auto`; once `auto`/unset auto-upgrades to http2 for gRPC (#358), the e2e can run on `auto` too.

Homelab deploy + re-verify gate skipped: this PR touches only `hack/conformance-setup.sh` (a dev/test setup script, shipped in no image or chart) and `test/e2e/*.go` (all `//go:build e2e`, compiled into neither the controller nor proxy binary nor the chart). The shipped artifacts are byte-identical to master (verifiable via `git diff --stat`), so a homelab deploy would pull the same digests and exercise the same binaries — zero observable signal. Verification was done on a fresh kind cluster instead.

Separately noted for a follow-up: CI runs `golangci-lint` without build tags, so the `e2e`-tagged test files are never linted in CI. The files added here are clean under `--build-tags=e2e`, but the package carries pre-existing lint debt on untouched lines that this blind spot hides.
