### PR TITLE
test(e2e): stabilize HTTPRouteWeight against sampling variance

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -666,7 +666,18 @@ func testHTTPRouteWeight(
 	createHTTPRoute(t, k8sClient, route)
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/wt-test", "echo-v", 60*time.Second)
 
-	const total = 30
+	// Weighted backend selection is an independent per-request draw: the proxy
+	// re-runs selectBackend on every request, so connection reuse never pins a
+	// backend (the e2e client also sets DisableKeepAlives). With a 90:10 split,
+	// the chance echo-v2 receives zero requests is 0.9^total. At total=150 that
+	// is ~1.4e-7, making the "echo-v2 got at least one" assertion effectively
+	// deterministic. A small sample (e.g. 30 → 0.9^30 ≈ 4.2%) flakes. We
+	// deliberately avoid a tight upper proportion bound (e.g. "echo-v1 ≤ 98%"):
+	// its tail probability (~1e-4 at this sample size) is orders of magnitude
+	// larger and would reintroduce the same sampling flake from the other side.
+	// The majority check on echo-v1 is the symmetric sanity guard against an
+	// inverted-weight routing bug.
+	const total = 150
 
 	v1, v2 := 0, 0
 


### PR DESCRIPTION
## Summary

`testHTTPRouteWeight` sent 30 requests across a 90:10 backend split and required the minority backend (`echo-v2`, weight 10) to receive at least one. Backend selection is an independent per-request weighted draw, so `echo-v2` receiving zero of 30 requests has probability `0.9^30 ≈ 4.2%` — a roughly 1-in-24 flake unrelated to the routing code under test.

## Changes

- Raise the request sample in `testHTTPRouteWeight` from 30 to 150, dropping the zero-`echo-v2` probability to `~1.4e-7` and making the assertion effectively deterministic.
- Keep both existing assertions unchanged: the `echo-v1` majority check guards against an inverted weight, and `echo-v2 >= 1` confirms the minority backend is reachable.
- Deliberately avoid a tight upper proportion bound: at this sample size its tail probability is orders of magnitude larger and would reintroduce the same sampling flake from the opposite direction.
- Document the statistical reasoning in a code comment so a future reader understands why 150 is the right number.

This is the same class of issue as the async request-mirror conformance flake — an assertion whose pass depended on sampling variance rather than the code under test.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [ ] Markdown linting passes (`markdownlint **/*.md`) — no markdown changed
- [x] Manual testing completed (if applicable)

Verified the fix directly against a kind cluster on the in-process test tunnel: `HTTPRouteWeight` passes with distribution `v1=140, v2=10 (total=150)` in ~35s, well under a minute. Also lint-checked the e2e suite with `--build-tags e2e` (which CI does not pass) to confirm no new findings are introduced.

## Documentation

- [ ] README updated (if needed) — not needed
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed) — not needed

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [ ] Related issues referenced (if any)

## Additional Notes

Runtime cost: this single test now performs 150 sequential round-trips through the real Cloudflare edge (5x the prior count). At the measured ~35s it stays well within the e2e suite's 15-minute budget.