### PR TITLE
fix(proxy): retry transient mirror dispatch and gate readiness on the tunnel

### DIFF
--- a/charts/cloudflare-tunnel-gateway-controller/README.md
+++ b/charts/cloudflare-tunnel-gateway-controller/README.md
@@ -295,8 +295,8 @@ spec:
 | proxy.configAPIPort | int | `8081` | Config API port (controller pushes config here) |
 | proxy.healthProbes | object | `{"livenessProbe":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":15,"periodSeconds":20,"timeoutSeconds":5},"readinessProbe":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":3},"startupProbe":{"enabled":true,"failureThreshold":30,"initialDelaySeconds":0,"periodSeconds":5,"timeoutSeconds":3}}` | Health probes configuration |
 | proxy.healthProbes.livenessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":15,"periodSeconds":20,"timeoutSeconds":5}` | Liveness probe |
-| proxy.healthProbes.readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":3}` | Readiness probe (ready when config loaded) |
-| proxy.healthProbes.startupProbe | object | `{"enabled":true,"failureThreshold":30,"initialDelaySeconds":0,"periodSeconds":5,"timeoutSeconds":3}` | Startup probe (gives tunnel time to connect) |
+| proxy.healthProbes.readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":3}` | Readiness probe (ready when config is loaded and, in tunnel mode, the tunnel has connected to the edge) |
+| proxy.healthProbes.startupProbe | object | `{"enabled":true,"failureThreshold":30,"initialDelaySeconds":0,"periodSeconds":5,"timeoutSeconds":3}` | Startup probe (hits /healthz; gives the process time to start serving — waiting for the tunnel is the readiness probe's job) |
 | proxy.image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-proxy","tag":""}` | Proxy container image |
 | proxy.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | proxy.image.repository | string | `"ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller-proxy"` | Proxy image repository |

--- a/charts/cloudflare-tunnel-gateway-controller/values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/values.yaml
@@ -385,7 +385,7 @@ proxy:
     readOnlyRootFilesystem: true
   # -- Health probes configuration
   healthProbes:
-    # -- Startup probe (gives tunnel time to connect)
+    # -- Startup probe (hits /healthz; gives the process time to start serving — waiting for the tunnel is the readiness probe's job)
     startupProbe:
       enabled: true
       initialDelaySeconds: 0
@@ -399,7 +399,7 @@ proxy:
       periodSeconds: 20
       timeoutSeconds: 5
       failureThreshold: 3
-    # -- Readiness probe (ready when config loaded)
+    # -- Readiness probe (ready when config is loaded and, in tunnel mode, the tunnel has connected to the edge)
     readinessProbe:
       enabled: true
       initialDelaySeconds: 5

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -109,11 +109,15 @@ func runTunnelMode(logger *slog.Logger, token string) {
 
 	logger.Info("starting cloudflared tunnel with in-process proxy", "protocol", effectiveProtocol)
 
-	err := tunnel.StartTunnel(ctx, tunnel.Config{
+	err := tunnel.StartTunnel(ctx, &tunnel.Config{
 		Token:       token,
 		Logger:      logger,
 		OriginProxy: originProxy,
 		Protocol:    effectiveProtocol,
+		// Flip readiness only once the tunnel registers with the edge, so the
+		// pod reports Ready when it can actually receive traffic (before that
+		// the edge returns 530). Combined with config presence in /readyz.
+		OnConnected: router.SetTunnelConnected,
 	})
 
 	gracefulShutdown(logger, configServer)
@@ -134,6 +138,11 @@ func runStandaloneMode(logger *slog.Logger) {
 	router := proxy.NewRouter()
 	proxyHandler := proxy.NewHandler(router, handlerOptions(logger)...)
 	router.SetHandler(proxyHandler)
+
+	// Standalone mode has no tunnel to wait for, so readiness gates on config
+	// alone — latch the tunnel-connected state up front. (Tunnel mode flips it
+	// from the cloudflared connected-signal instead.)
+	router.SetTunnelConnected()
 
 	authToken := os.Getenv("PROXY_AUTH_TOKEN")
 	warnIfNoAuth(logger, authToken)

--- a/docs/configuration/helm-values.md
+++ b/docs/configuration/helm-values.md
@@ -126,7 +126,7 @@ The `proxy` section configures the in-process L7 reverse proxy. The proxy embeds
 | `proxy.healthProbes.startupProbe.failureThreshold` | int | `30` | Startup probe failure threshold |
 | `proxy.healthProbes.livenessProbe.enabled` | bool | `true` | Enable liveness probe |
 | `proxy.healthProbes.livenessProbe.periodSeconds` | int | `20` | Liveness probe interval |
-| `proxy.healthProbes.readinessProbe.enabled` | bool | `true` | Enable readiness probe (ready when config loaded) |
+| `proxy.healthProbes.readinessProbe.enabled` | bool | `true` | Enable readiness probe (ready when config is loaded and, in tunnel mode, the tunnel has connected to the edge) |
 | `proxy.healthProbes.readinessProbe.periodSeconds` | int | `10` | Readiness probe interval |
 
 ### Access Log

--- a/docs/guides/l7-proxy.md
+++ b/docs/guides/l7-proxy.md
@@ -116,7 +116,7 @@ The proxy binary accepts the following environment variables:
 | Endpoint | Port | Description |
 | --- | --- | --- |
 | `/healthz` | Config API | Liveness check |
-| `/readyz` | Config API | Readiness (config loaded at least once) |
+| `/readyz` | Config API | Readiness: config loaded at least once AND, in tunnel mode, the tunnel has connected to the Cloudflare edge (standalone mode latches the tunnel condition at startup) |
 
 ## Example HTTPRoute
 

--- a/internal/proxy/api.go
+++ b/internal/proxy/api.go
@@ -115,10 +115,9 @@ func (a *ConfigAPI) handleGetConfig(writer http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	version := a.router.ConfigVersion()
 	status := ConfigStatus{
-		Version: version,
-		Ready:   version > 0,
+		Version: a.router.ConfigVersion(),
+		Ready:   a.router.IsReady(),
 	}
 
 	data, err := json.Marshal(status)
@@ -161,6 +160,16 @@ func (a *ConfigAPI) handleHealthz(writer http.ResponseWriter, _ *http.Request) {
 func (a *ConfigAPI) handleReadyz(writer http.ResponseWriter, _ *http.Request) {
 	if a.router.ConfigVersion() == 0 {
 		http.Error(writer, "not ready: no config loaded", http.StatusServiceUnavailable)
+
+		return
+	}
+
+	// The proxy can have config yet still be unable to serve: in tunnel mode
+	// the edge returns 530 until cloudflared registers a connection. Gate
+	// readiness on the real tunnel state so the pod goes Ready only when it can
+	// actually receive traffic. Standalone mode latches this at startup.
+	if !a.router.TunnelConnected() {
+		http.Error(writer, "not ready: tunnel not connected to edge", http.StatusServiceUnavailable)
 
 		return
 	}

--- a/internal/proxy/api_test.go
+++ b/internal/proxy/api_test.go
@@ -252,14 +252,20 @@ func TestConfigAPI_ReadyEndpoint(t *testing.T) {
 	router := proxy.NewRouter()
 	api := proxy.NewConfigAPI(router, "")
 
+	readyz := func() int {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
+		recorder := httptest.NewRecorder()
+		api.ServeHTTP(recorder, req)
+
+		return recorder.Code
+	}
+
 	// Not ready before config is loaded.
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
-	recorder := httptest.NewRecorder()
+	assert.Equal(t, http.StatusServiceUnavailable, readyz(), "no config and no tunnel must not be ready")
 
-	api.ServeHTTP(recorder, req)
-	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
-
-	// Ready after config loaded.
+	// Still not ready with config but no tunnel connection: the pod would go
+	// Ready while cloudflared is still dialing the edge, and the edge returns
+	// 530 until the tunnel registers.
 	cfg := &proxy.Config{
 		Version: 1,
 		Rules:   []proxy.RouteRule{{Backends: []proxy.BackendRef{{URL: "http://svc:80", Weight: 1}}}},
@@ -268,11 +274,29 @@ func TestConfigAPI_ReadyEndpoint(t *testing.T) {
 	err := router.UpdateConfig(cfg)
 	require.NoError(t, err)
 
-	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
-	recorder = httptest.NewRecorder()
+	assert.Equal(t, http.StatusServiceUnavailable, readyz(), "config present but tunnel not connected must not be ready")
 
+	// Ready once the tunnel has connected to the edge as well.
+	router.SetTunnelConnected()
+
+	assert.Equal(t, http.StatusOK, readyz(), "config present and tunnel connected must be ready")
+}
+
+func TestConfigAPI_ReadyEndpoint_TunnelWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	router := proxy.NewRouter()
+	api := proxy.NewConfigAPI(router, "")
+
+	// Tunnel connected but no config yet: still not ready — the proxy has
+	// nothing to route with.
+	router.SetTunnelConnected()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
+	recorder := httptest.NewRecorder()
 	api.ServeHTTP(recorder, req)
-	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
 }
 
 func TestConfigAPI_OversizeBody(t *testing.T) {

--- a/internal/proxy/filter.go
+++ b/internal/proxy/filter.go
@@ -23,6 +23,20 @@ const (
 	mirrorMaxIdlePerHost  = 10
 	mirrorMaxConnsPerHost = 50
 	mirrorIdleTimeout     = 30 * time.Second
+
+	// mirrorMaxAttempts bounds the total number of dispatch attempts for a
+	// single mirrored request. A 100% mirror is expected to be delivered (the
+	// conformance suite sends one request and polls the mirror backend), so a
+	// transient transport failure — connection reset, stale idle-conn reuse, a
+	// backend that is momentarily not ready — on the first attempt must not
+	// drop the only copy. Each attempt has its own mirrorTimeout context.
+	mirrorMaxAttempts = 3
+
+	// mirrorRetryBaseBackoff is the unit delay before a retried dispatch;
+	// attempt N waits (N-1) × base. Short and bounded — the mirror leg is
+	// cluster-internal, so the worst-case added latency stays well under both
+	// mirrorTimeout and the conformance poll budget.
+	mirrorRetryBaseBackoff = 100 * time.Millisecond
 )
 
 // mirrorClient is a shared HTTP client for all mirror filter instances.
@@ -367,21 +381,24 @@ func (f *requestMirror) ProcessRequest(req *http.Request) *http.Response {
 		return nil
 	}
 
-	// Use a detached context so the mirror is fire-and-forget,
-	// not cancelled when the original request completes.
-	mirrorCtx, cancel := context.WithTimeout(context.Background(), mirrorTimeout)
-	mirrorReq := req.Clone(mirrorCtx)
-	mirrorReq.URL = mirrorURL
-	mirrorReq.Host = mirrorURL.Host
-	mirrorReq.RequestURI = ""
+	// Build a template for the mirror leg before returning: the primary handler
+	// will consume and mutate req, so the mirror must snapshot what it needs
+	// now (URL, Host, and any headers a preceding modify-headers filter set).
+	// Each dispatch attempt derives its own context and body from this template
+	// inside dispatchWithRetry, so a retry never reuses a consumed body or a
+	// cancelled context. The context is detached (Background) so the mirror is
+	// fire-and-forget — not cancelled when the original request completes.
+	tmpl := req.Clone(context.Background())
+	tmpl.URL = mirrorURL
+	tmpl.Host = mirrorURL.Host
+	tmpl.RequestURI = ""
 
-	// After Clone, both req and mirrorReq share the same body reader.
-	// Give each its own independent reader from the buffered data.
+	// After Clone, req and the template share the same body reader. Give the
+	// primary leg its own independent reader from the buffered data; each
+	// mirror attempt gets a fresh reader inside dispatchWithRetry.
 	if bodyBuf != nil {
 		req.Body = io.NopCloser(bytes.NewReader(bodyBuf))
 		req.ContentLength = int64(len(bodyBuf))
-		mirrorReq.Body = io.NopCloser(bytes.NewReader(bodyBuf))
-		mirrorReq.ContentLength = int64(len(bodyBuf))
 	}
 
 	client := f.client
@@ -389,27 +406,7 @@ func (f *requestMirror) ProcessRequest(req *http.Request) *http.Response {
 		client = mirrorClient
 	}
 
-	go func() {
-		defer cancel()
-		defer func() {
-			if recovered := recover(); recovered != nil {
-				slog.Error("mirror: panic in mirror request goroutine", "panic", recovered)
-			}
-		}()
-
-		resp, doErr := client.Do(mirrorReq)
-		if doErr != nil {
-			// Mirroring is fire-and-forget, so a failed dial must not affect
-			// the primary leg — but it must be visible in the logs, otherwise
-			// a mirror-delivery problem is undiagnosable from the proxy.
-			f.logger.Warn("mirror: request dispatch failed",
-				"backend", f.backendURL, "error", doErr)
-
-			return
-		}
-
-		resp.Body.Close()
-	}()
+	go f.dispatchWithRetry(client, tmpl, bodyBuf)
 
 	return nil
 }
@@ -480,6 +477,73 @@ func (f *requestMirror) shouldMirror() bool {
 	}
 	//nolint:gosec // math/rand is fine for traffic mirroring sampling
 	return rand.Int32N(100) < pct
+}
+
+// dispatchWithRetry delivers the mirrored request, retrying a transient
+// transport failure up to mirrorMaxAttempts times. Mirroring is fire-and-forget
+// and best-effort, but a 100% mirror is expected to be delivered (the
+// conformance suite sends one request and polls the mirror backend), so a
+// transient dial failure on the first attempt must not drop the only copy.
+//
+// Retrying changes delivery from at-most-once to bounded at-least-once: a copy
+// whose request reached the backend but whose response was lost may be sent
+// twice. That is acceptable for mirror (shadow) traffic and is what the
+// conformance "copy arrived" assertion expects. Only transport-level failures
+// retry — an HTTP error status is a delivered copy and is left alone.
+func (f *requestMirror) dispatchWithRetry(client *http.Client, tmpl *http.Request, bodyBuf []byte) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			slog.Error("mirror: panic in mirror request goroutine", "panic", recovered)
+		}
+	}()
+
+	var lastErr error
+
+	for attempt := 1; attempt <= mirrorMaxAttempts; attempt++ {
+		if attempt > 1 {
+			time.Sleep(time.Duration(attempt-1) * mirrorRetryBaseBackoff)
+		}
+
+		err := dispatchMirrorOnce(client, tmpl, bodyBuf)
+		if err != nil {
+			lastErr = err
+
+			continue
+		}
+
+		return
+	}
+
+	// All attempts failed — fire-and-forget, so this never affects the primary
+	// leg, but it must be visible: a mirror-delivery problem is otherwise
+	// undiagnosable from the proxy.
+	f.logger.Warn("mirror: request dispatch failed after retries",
+		"backend", f.backendURL, "attempts", mirrorMaxAttempts, "error", lastErr)
+}
+
+// dispatchMirrorOnce performs a single mirror dispatch with its own
+// mirrorTimeout context and a fresh body reader from bodyBuf, so it is safe to
+// call repeatedly for retries. It returns a non-nil error only on a
+// transport-level failure; a delivered response (any status) is drained and
+// reported as success.
+func dispatchMirrorOnce(client *http.Client, tmpl *http.Request, bodyBuf []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), mirrorTimeout)
+	defer cancel()
+
+	mirrorReq := tmpl.Clone(ctx)
+	if bodyBuf != nil {
+		mirrorReq.Body = io.NopCloser(bytes.NewReader(bodyBuf))
+		mirrorReq.ContentLength = int64(len(bodyBuf))
+	}
+
+	resp, err := client.Do(mirrorReq)
+	if err != nil {
+		return errors.Wrap(err, "mirror dispatch")
+	}
+
+	resp.Body.Close()
+
+	return nil
 }
 
 // CompileFilters converts RouteFilter specs into executable Filter instances.

--- a/internal/proxy/filter_internal_test.go
+++ b/internal/proxy/filter_internal_test.go
@@ -2,14 +2,24 @@ package proxy
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// errSimulatedTransientFailure is the transport-level error flakyRoundTripper
+// returns for the attempts it is configured to fail. A package-level sentinel
+// keeps err113 satisfied (no dynamically constructed errors).
+var errSimulatedTransientFailure = errors.New("simulated transient transport failure")
 
 // chanHandler is a minimal slog.Handler that forwards every record to a
 // channel. It lets tests deterministically observe a fire-and-forget
@@ -78,6 +88,123 @@ func TestRequestMirror_DispatchError_LogsWarn(t *testing.T) {
 		assert.NotEmpty(t, attrs["error"], "log must include the dial error")
 	case <-time.After(2 * time.Second):
 		t.Fatal("mirror dispatch error was not logged")
+	}
+}
+
+// flakyRoundTripper fails the first failFirst RoundTrip calls with a
+// transport-level error, then delegates to inner. It models a transient
+// proxy → mirror-backend dispatch failure (connection reset, stale idle-conn
+// reuse, momentary backend unreadiness) deterministically, without depending
+// on TCP timing.
+type flakyRoundTripper struct {
+	failFirst int32
+	attempts  atomic.Int32
+	inner     http.RoundTripper
+}
+
+func (f *flakyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if f.attempts.Add(1) <= f.failFirst {
+		// A real transport consumes/closes the body on the attempt; drop it so
+		// a retry that does not supply a fresh reader would observe an empty
+		// body (and fail the body-replay assertions below).
+		if req.Body != nil {
+			_ = req.Body.Close()
+		}
+
+		return nil, errSimulatedTransientFailure
+	}
+
+	resp, err := f.inner.RoundTrip(req)
+	if err != nil {
+		return nil, fmt.Errorf("flaky inner roundtrip: %w", err)
+	}
+
+	return resp, nil
+}
+
+// TestRequestMirror_TransientDispatchFailure_Retries pins the #361 fix: a 100%
+// mirror whose first dispatch attempt fails with a transient transport error
+// must still be delivered. The conformance suite sends a single request and
+// polls the mirror backend, so a one-shot fire-and-forget dispatch that drops
+// the only copy on a transient failure flakes deterministically. With the
+// bounded retry the copy lands on a later attempt. Before the fix this test is
+// RED — the single client.Do drops the copy and the backend never sees it.
+func TestRequestMirror_TransientDispatchFailure_Retries(t *testing.T) {
+	t.Parallel()
+
+	records := make(chan slog.Record, 8)
+	logger := slog.New(&chanHandler{records: records})
+
+	received := make(chan struct{}, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		received <- struct{}{}
+	}))
+	defer backend.Close()
+
+	mirror := &requestMirror{
+		backendURL: backend.URL,
+		client: &http.Client{
+			Timeout:   mirrorTimeout,
+			Transport: &flakyRoundTripper{failFirst: 1, inner: http.DefaultTransport},
+		},
+		logger: logger,
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/test", nil)
+
+	resp := mirror.ProcessRequest(req) //nolint:bodyclose // mirror returns a nil response
+	assert.Nil(t, resp, "mirror filter must not short-circuit the primary leg")
+
+	select {
+	case <-received:
+	case <-time.After(3 * time.Second):
+		t.Fatal("mirror copy was dropped after a transient dispatch failure; expected a retry to deliver it")
+	}
+}
+
+// TestRequestMirror_TransientDispatchFailure_RetriesWithBody pins that a retry
+// supplies a fresh body reader from the buffered data, not the consumed reader
+// from the failed attempt. Without per-attempt body replay the retried request
+// would carry an empty body, so the backend must observe the full payload.
+func TestRequestMirror_TransientDispatchFailure_RetriesWithBody(t *testing.T) {
+	t.Parallel()
+
+	const payload = "mirror-body-payload"
+
+	gotBody := make(chan string, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		gotBody <- string(body)
+	}))
+	defer backend.Close()
+
+	mirror := &requestMirror{
+		backendURL: backend.URL,
+		client: &http.Client{
+			Timeout:   mirrorTimeout,
+			Transport: &flakyRoundTripper{failFirst: 1, inner: http.DefaultTransport},
+		},
+		logger: slog.New(&chanHandler{records: make(chan slog.Record, 8)}),
+	}
+
+	req := httptest.NewRequestWithContext(
+		context.Background(), http.MethodPost, "http://example.com/test", strings.NewReader(payload),
+	)
+
+	resp := mirror.ProcessRequest(req) //nolint:bodyclose // mirror returns a nil response
+	assert.Nil(t, resp, "mirror filter must not short-circuit the primary leg")
+
+	// The primary leg must still see the full body after buffering.
+	primaryBody, _ := io.ReadAll(req.Body)
+	assert.Equal(t, payload, string(primaryBody), "primary leg body must be restored after mirror buffering")
+
+	select {
+	case got := <-gotBody:
+		assert.Equal(t, payload, got, "retried mirror copy must carry the full body, not an empty reader")
+	case <-time.After(3 * time.Second):
+		t.Fatal("mirror copy with body was dropped after a transient dispatch failure")
 	}
 }
 

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -81,6 +81,16 @@ type Router struct {
 	// grpcRestartWarned makes the restart-needed warning fire at most once
 	// rather than on every config push.
 	grpcRestartWarned atomic.Bool
+	// tunnelConnected latches true once the edge transport has registered a
+	// tunnel connection (tunnel mode) or immediately at startup (standalone
+	// mode, no tunnel to wait for). Readiness gates on it so the proxy reports
+	// Ready only when it can actually receive traffic — without it the pod goes
+	// Ready while cloudflared is still dialing the edge and the edge returns 530.
+	// One-shot: the cloudflared connected-signal fires once on first
+	// registration and the proxy is the tunnel origin (traffic arrives via the
+	// tunnel, not a Service), so a later drop is not tracked here — flapping
+	// readiness would not change traffic delivery and would only churn rollouts.
+	tunnelConnected atomic.Bool
 }
 
 // NewRouter creates a Router with an empty routing table.
@@ -126,6 +136,28 @@ func (r *Router) SetHandler(h *Handler) {
 // ConfigVersion returns the version of the currently loaded configuration.
 func (r *Router) ConfigVersion() int64 {
 	return r.table.Load().version
+}
+
+// SetTunnelConnected latches the tunnel-connected state to true. Tunnel mode
+// calls it from the cloudflared connected-signal hook on first edge
+// registration; standalone mode calls it at startup (no tunnel to wait for).
+// It only ever transitions false→true (see the tunnelConnected field comment).
+func (r *Router) SetTunnelConnected() {
+	r.tunnelConnected.Store(true)
+}
+
+// TunnelConnected reports whether the edge transport has registered a tunnel
+// connection (or, in standalone mode, whether startup latched it).
+func (r *Router) TunnelConnected() bool {
+	return r.tunnelConnected.Load()
+}
+
+// IsReady reports whether the proxy can serve traffic: it has a config to route
+// with AND the tunnel has connected to the edge. Readiness (GET /readyz) and the
+// GET /config status both derive from this single definition so they never
+// disagree.
+func (r *Router) IsReady() bool {
+	return r.ConfigVersion() > 0 && r.TunnelConnected()
 }
 
 // RouteResult contains the result of a routing decision.

--- a/internal/tunnel/bootstrap.go
+++ b/internal/tunnel/bootstrap.go
@@ -71,6 +71,12 @@ type Config struct {
 	// fallback), "http2", or "quic". gRPC requires "http2" because cloudflared
 	// does not forward HTTP trailers over QUIC (grpc-status is dropped).
 	Protocol string
+	// OnConnected, when set, is invoked once when cloudflared registers its
+	// first connection with the Cloudflare edge. The proxy entrypoint uses it to
+	// flip readiness, so the pod reports Ready only after the tunnel can actually
+	// receive traffic (before that the edge returns 530). Runs on the signal
+	// goroutine; keep it non-blocking.
+	OnConnected func()
 }
 
 // Token mirrors the cloudflared token JSON structure.
@@ -116,7 +122,7 @@ func ParseTunnelToken(tokenStr string) (*Token, error) {
 
 // StartTunnel starts a cloudflared tunnel daemon with the given configuration.
 // It blocks until the context is cancelled or the tunnel fails.
-func StartTunnel(ctx context.Context, cfg Config) error {
+func StartTunnel(ctx context.Context, cfg *Config) error {
 	token, err := ParseTunnelToken(cfg.Token)
 	if err != nil {
 		return errors.Wrap(err, "parse tunnel token")
@@ -127,7 +133,7 @@ func StartTunnel(ctx context.Context, cfg Config) error {
 		logger = slog.Default()
 	}
 
-	orchestrator, tunnelCfg, err := buildOrchestrator(ctx, &cfg, token, logger)
+	orchestrator, tunnelCfg, err := buildOrchestrator(ctx, cfg, token, logger)
 	if err != nil {
 		return err
 	}
@@ -141,13 +147,7 @@ func StartTunnel(ctx context.Context, cfg Config) error {
 		close(graceShutdownC)
 	}()
 
-	go func() {
-		select {
-		case <-connectedSignal.Wait():
-			logger.Info("tunnel connected to Cloudflare edge")
-		case <-ctx.Done():
-		}
-	}()
+	go waitConnected(ctx, connectedSignal, logger, cfg.OnConnected)
 
 	logger.Info("starting tunnel daemon",
 		"tunnelID", token.TunnelID.String(),
@@ -164,6 +164,24 @@ func StartTunnel(ctx context.Context, cfg Config) error {
 	)
 
 	return errors.Wrap(err, "tunnel daemon")
+}
+
+// waitConnected blocks until the tunnel registers its first connection with the
+// Cloudflare edge or the context is cancelled. On connection it logs and invokes
+// onConnected (when non-nil) exactly once — the proxy entrypoint passes a
+// callback that flips readiness, so the pod reports Ready only after the edge is
+// reachable. On context cancellation it returns without invoking onConnected, so
+// a tunnel that never connects never reports ready.
+func waitConnected(ctx context.Context, connected *cfdsignal.Signal, logger *slog.Logger, onConnected func()) {
+	select {
+	case <-connected.Wait():
+		logger.Info("tunnel connected to Cloudflare edge")
+
+		if onConnected != nil {
+			onConnected()
+		}
+	case <-ctx.Done():
+	}
 }
 
 // buildOrchestrator creates the orchestration.Orchestrator and tunnel config.

--- a/internal/tunnel/bootstrap_internal_test.go
+++ b/internal/tunnel/bootstrap_internal_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cloudflare/cloudflared/connection"
 	"github.com/cloudflare/cloudflared/orchestration"
+	cfdsignal "github.com/cloudflare/cloudflared/signal"
 )
 
 func TestBuildCatchAllIngress(t *testing.T) {
@@ -298,7 +299,7 @@ func TestStartTunnel_InvalidToken_ErrorPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	err := StartTunnel(ctx, Config{
+	err := StartTunnel(ctx, &Config{
 		Token:    "not-valid-base64!!!",
 		ProxyURL: "http://localhost:8080",
 	})
@@ -312,13 +313,50 @@ func TestStartTunnel_InvalidToken_ErrorPath(t *testing.T) {
 func TestStartTunnel_EmptyToken_ErrorPath(t *testing.T) {
 	t.Parallel()
 
-	err := StartTunnel(t.Context(), Config{
+	err := StartTunnel(t.Context(), &Config{
 		Token:    "",
 		ProxyURL: "http://localhost:8080",
 	})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tunnel token is empty")
+}
+
+// TestWaitConnected_FiresCallbackOnConnect pins that the connected-signal hook
+// invokes OnConnected exactly once when the tunnel registers with the edge.
+// This is the half of the readiness feature that flips a tunnel-mode pod to
+// Ready; without it the pod would never become Ready.
+func TestWaitConnected_FiresCallbackOnConnect(t *testing.T) {
+	t.Parallel()
+
+	sig := cfdsignal.New(make(chan struct{}))
+	sig.Notify() // edge connection registered
+
+	calls := 0
+
+	// ctx stays live, so only the connected branch is ready and is selected
+	// deterministically. waitConnected returns after invoking the callback.
+	waitConnected(t.Context(), sig, slog.Default(), func() { calls++ })
+
+	assert.Equal(t, 1, calls, "OnConnected must fire exactly once when the tunnel connects")
+}
+
+// TestWaitConnected_NoCallbackOnContextCancel pins that a tunnel which never
+// connects (context cancelled first) does not flip readiness — OnConnected must
+// not fire, so the pod stays NotReady.
+func TestWaitConnected_NoCallbackOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancelled before any connection
+
+	sig := cfdsignal.New(make(chan struct{})) // never notified
+
+	calls := 0
+
+	waitConnected(ctx, sig, slog.Default(), func() { calls++ })
+
+	assert.Equal(t, 0, calls, "OnConnected must not fire when the context is cancelled before connecting")
 }
 
 func TestConstants(t *testing.T) {
@@ -423,7 +461,7 @@ func TestParseTunnelToken_MalformedInputs(t *testing.T) {
 func TestStartTunnel_NilLogger_BuildOrchestratorError(t *testing.T) {
 	t.Parallel()
 
-	err := StartTunnel(t.Context(), Config{
+	err := StartTunnel(t.Context(), &Config{
 		Token:    validTestTokenBase64(),
 		Logger:   nil,
 		ProxyURL: "",
@@ -439,7 +477,7 @@ func TestStartTunnel_NilLogger_BuildOrchestratorError(t *testing.T) {
 func TestStartTunnel_ExplicitLogger_BuildOrchestratorError(t *testing.T) {
 	t.Parallel()
 
-	err := StartTunnel(t.Context(), Config{
+	err := StartTunnel(t.Context(), &Config{
 		Token:    validTestTokenBase64(),
 		Logger:   slog.Default(),
 		ProxyURL: "",
@@ -455,7 +493,7 @@ func TestStartTunnel_ValidBase64InvalidJSON_ErrorPath(t *testing.T) {
 	t.Parallel()
 
 	// "not json" in base64
-	err := StartTunnel(t.Context(), Config{
+	err := StartTunnel(t.Context(), &Config{
 		Token:    "bm90IGpzb24=",
 		ProxyURL: "http://localhost:8080",
 	})
@@ -471,7 +509,7 @@ func TestStartTunnel_EmptyJSONObject_ErrorPath(t *testing.T) {
 	t.Parallel()
 
 	// "{}" in base64
-	err := StartTunnel(t.Context(), Config{
+	err := StartTunnel(t.Context(), &Config{
 		Token:    "e30=",
 		ProxyURL: "http://localhost:8080",
 	})
@@ -487,7 +525,7 @@ func TestStartTunnel_PartialFields_ErrorPath(t *testing.T) {
 	t.Parallel()
 
 	// {"a":"acct"} in base64 — has account but no tunnel ID or secret
-	err := StartTunnel(t.Context(), Config{
+	err := StartTunnel(t.Context(), &Config{
 		Token:    "eyJhIjoiYWNjdCJ9",
 		ProxyURL: "http://localhost:8080",
 	})
@@ -806,7 +844,7 @@ func TestStartTunnel_SuccessPath_CancelledContext(t *testing.T) {
 	cancel()
 
 	withFreshRegisterer(func() {
-		err := StartTunnel(ctx, Config{
+		err := StartTunnel(ctx, &Config{
 			Token:    validTestTokenBase64(),
 			Logger:   slog.Default(),
 			ProxyURL: "http://localhost:8080",
@@ -829,7 +867,7 @@ func TestStartTunnel_NilLogger_SuccessPath_CancelledContext(t *testing.T) {
 	cancel()
 
 	withFreshRegisterer(func() {
-		err := StartTunnel(ctx, Config{
+		err := StartTunnel(ctx, &Config{
 			Token:    validTestTokenBase64(),
 			Logger:   nil,
 			ProxyURL: "http://localhost:8080",

--- a/internal/tunnel/bootstrap_test.go
+++ b/internal/tunnel/bootstrap_test.go
@@ -104,7 +104,7 @@ func TestParseTunnelToken_MissingSecret(t *testing.T) {
 func TestStartTunnel_InvalidToken(t *testing.T) {
 	t.Parallel()
 
-	err := tunnel.StartTunnel(t.Context(), tunnel.Config{
+	err := tunnel.StartTunnel(t.Context(), &tunnel.Config{
 		Token: "invalid",
 	})
 


### PR DESCRIPTION
## Summary

Two related fixes that make the proxy serve reliably right after a rollout, instead of reporting healthy while it cannot yet deliver traffic.

1. **Retry transient mirror dispatch failures.** A 100% `RequestMirror` copy could be dropped when the single fire-and-forget dispatch hit a transient transport error (connection reset, stale idle-connection reuse, a momentarily-unready backend). A 100% mirror is expected to be delivered, so one dropped copy fails non-deterministically.

2. **Gate readiness on the tunnel connection.** The proxy reported Ready as soon as it had config, before cloudflared registered a connection with the Cloudflare edge. During that window the edge returns HTTP 530 (error 1033), so a freshly rolled-out pod counted as Ready while it could not serve traffic — and anything waiting on rollout readiness (a deploy, a conformance run) started against a cold tunnel.

## Changes

- **Mirror:** retry the dispatch up to three times with a short bounded backoff, each attempt with its own timeout context and a fresh body reader from the buffered payload. Only transport-level failures retry; a delivered response of any status is left alone. One Warn after all attempts are exhausted.
- **Readiness:** latch a tunnel-connected flag from cloudflared's connected-signal; `/readyz` now requires config presence AND a connected tunnel. Standalone mode (no tunnel) latches it at startup. Liveness (`/healthz`) is unchanged so a pod whose tunnel is still dialing is not killed. The headless config-push Service already publishes not-ready addresses, so the controller still reaches a not-yet-ready pod to deliver config — no startup deadlock.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run` — 0 issues)
- [ ] Markdown linting passes (no markdown changed)
- [x] Manual testing completed (if applicable)

Deterministic unit tests cover both fixes: the mirror retry (fault-injecting `RoundTripper` that fails the first attempt; RED without the fix, including a body-replay case) and the three readiness states (no config → 503, config without tunnel → 503, config + tunnel → 200). Maintainer-side conformance on a real tunnel is pending re-run.

## Documentation

- [ ] README updated (not needed — mirror is already documented as best-effort; readiness change is internal)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (no workflow/standards change)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (none)
- [x] Related issues referenced

## Additional Notes

Relates to #361.

- The mirror leg is cluster-internal (proxy → backend) and does not touch the edge tunnel transport, so the in-process `httptest` / `RoundTripper` model is the production path for it.
- Mirror delivery semantics change from at-most-once to bounded at-least-once: a copy whose request reached the backend but whose response was lost may be sent twice — acceptable for shadow traffic, and what the conformance "copy arrived" assertion expects.
- Readiness gating is one-shot (latches on first edge registration): the proxy is the tunnel origin, so traffic arrives via the tunnel rather than a Service, and tracking later drops would only churn rollouts without changing delivery. A tunnel that never connects now surfaces as a stalled rollout instead of a silently-broken Ready pod.
