### PR TITLE
test(conformance): add --use-ci-images mode to conformance-setup.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,6 +564,11 @@ Official Gateway API conformance suite (`sigs.k8s.io/gateway-api/conformance` v1
 # Setup only (reuse for iterative testing)
 ./hack/conformance-setup.sh
 
+# Verify a PR's CI artifact: skip the local build, deploy the PR's published
+# ttl.sh chart+images (the chart already pins the ttl.sh image refs). Add --test
+# to also run the suite. ttl.sh artifacts expire 24h after the PR's CI ran.
+./hack/conformance-setup.sh --use-ci-images <PR-number>
+
 # Run all conformance tests on existing cluster
 go test -v -tags conformance -count=1 -timeout=60m -parallel 10 ./test/conformance/...
 

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -6,17 +6,19 @@
 #   2. Deletes old v2-test-* kind clusters
 #   3. Creates a fresh kind cluster with random suffix
 #   4. Installs Gateway API CRDs (experimental channel)
-#   5. Builds controller + proxy images
-#   6. Loads images into kind
+#   5. Builds controller + proxy images          (skipped in --use-ci-images mode)
+#   6. Loads images into kind                     (skipped in --use-ci-images mode)
 #   7. Creates secrets from .env
-#   8. Deploys controller via helm
+#   8. Deploys controller via helm               (local chart, or PR's ttl.sh chart)
 #   9. Waits for readiness
 #  10. Optionally runs conformance tests
 #
 # Usage:
-#   ./hack/conformance-setup.sh              # full setup (fresh cluster)
-#   ./hack/conformance-setup.sh --test       # setup + run tests
-#   ./hack/conformance-setup.sh --skip-build # skip image build (reuse existing)
+#   ./hack/conformance-setup.sh                  # full setup (fresh cluster, local build)
+#   ./hack/conformance-setup.sh --test           # setup + run tests
+#   ./hack/conformance-setup.sh --skip-build     # skip image build (reuse existing)
+#   ./hack/conformance-setup.sh --use-ci-images N  # deploy PR #N's published ttl.sh
+#                                                  # chart+images (no local build)
 #
 # Prerequisites:
 #   - .env file in repo root with: CF_API_TOKEN, CF_ACCOUNT_ID, V2_TUNNEL_ID, V2_TUNNEL_TOKEN
@@ -41,14 +43,7 @@ GATEWAY_API_VERSION="v1.5.1"
 # --- Flags ---
 RUN_TESTS=false
 SKIP_BUILD=false
-
-for arg in "$@"; do
-  case "${arg}" in
-    --test) RUN_TESTS=true ;;
-    --skip-build) SKIP_BUILD=true ;;
-    *) echo "Unknown flag: ${arg}"; exit 1 ;;
-  esac
-done
+CI_PR_NUMBER=""
 
 # --- Helpers ---
 info()  { echo "==> $*"; }
@@ -58,6 +53,26 @@ die()   { echo "ERROR: $*" >&2; exit 1; }
 check_tool() {
   command -v "$1" >/dev/null 2>&1 || die "$1 is not installed"
 }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --test) RUN_TESTS=true ;;
+    --skip-build) SKIP_BUILD=true ;;
+    --use-ci-images)
+      shift
+      [[ $# -gt 0 ]] || die "--use-ci-images requires a PR number"
+      CI_PR_NUMBER="$1"
+      [[ "${CI_PR_NUMBER}" =~ ^[0-9]+$ ]] || die "--use-ci-images PR number must be numeric, got '${CI_PR_NUMBER}'"
+      ;;
+    *) die "Unknown flag: $1" ;;
+  esac
+  shift
+done
+
+# --use-ci-images is itself a no-build path; combining with --skip-build is contradictory.
+if [[ -n "${CI_PR_NUMBER}" && "${SKIP_BUILD}" == "true" ]]; then
+  die "--use-ci-images and --skip-build are mutually exclusive"
+fi
 
 # --- Pre-flight checks ---
 info "Checking prerequisites..."
@@ -79,6 +94,15 @@ for var in CF_API_TOKEN CF_ACCOUNT_ID V2_TUNNEL_ID V2_TUNNEL_TOKEN; do
     die "Required variable ${var} is not set in .env"
   fi
 done
+
+# --- CI-images mode: fail fast if the PR chart is gone before building a cluster ---
+if [[ -n "${CI_PR_NUMBER}" ]]; then
+  CI_CHART_VERSION="0.0.0-pr.${CI_PR_NUMBER}-1d"
+  info "Checking ttl.sh chart for PR #${CI_PR_NUMBER} (${CI_CHART_VERSION})..."
+  helm show chart "oci://ttl.sh/cloudflare-tunnel-gateway-controller" \
+    --version "${CI_CHART_VERSION}" >/dev/null 2>&1 \
+    || die "Chart ${CI_CHART_VERSION} not found on ttl.sh. ttl.sh artifacts expire after 24h (the '1d' tag) — re-run PR #${CI_PR_NUMBER}'s CI to republish."
+fi
 
 # --- Step 1: Ensure colima is running ---
 info "Checking colima..."
@@ -113,7 +137,9 @@ kubectl --context "${KUBE_CONTEXT}" apply \
   --filename "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/experimental-install.yaml"
 
 # --- Step 5: Build images ---
-if [[ "${SKIP_BUILD}" == "false" ]]; then
+if [[ -n "${CI_PR_NUMBER}" ]]; then
+  info "Using CI images from PR #${CI_PR_NUMBER} (ttl.sh) — skipping local build + kind load"
+elif [[ "${SKIP_BUILD}" == "false" ]]; then
   info "Building controller image..."
   docker build --tag "${CONTROLLER_IMAGE}" --file Containerfile .
 
@@ -124,9 +150,13 @@ else
 fi
 
 # --- Step 6: Load images into kind ---
-info "Loading images into kind cluster..."
-kind load docker-image "${CONTROLLER_IMAGE}" --name "${CLUSTER_NAME}"
-kind load docker-image "${PROXY_IMAGE}" --name "${CLUSTER_NAME}"
+# In --use-ci-images mode there are no local images; kind nodes pull from
+# ttl.sh at pod start (the PR chart ships pullPolicy=Always).
+if [[ -z "${CI_PR_NUMBER}" ]]; then
+  info "Loading images into kind cluster..."
+  kind load docker-image "${CONTROLLER_IMAGE}" --name "${CLUSTER_NAME}"
+  kind load docker-image "${PROXY_IMAGE}" --name "${CLUSTER_NAME}"
+fi
 
 # --- Step 7: Create namespace and secrets ---
 info "Creating namespace '${NAMESPACE}'..."
@@ -153,20 +183,40 @@ kubectl --context "${KUBE_CONTEXT}" create secret generic cloudflare-tunnel-toke
   | kubectl --context "${KUBE_CONTEXT}" apply --filename -
 
 # --- Step 8: Deploy via helm ---
+# Default: install the local chart and point it at the locally-built images.
+# --use-ci-images: install the PR's published ttl.sh chart, which already
+# carries the ttl.sh image refs + pullPolicy=Always baked into its values.yaml,
+# so no --set image.* overrides are needed (or wanted) in that mode.
+HELM_CHART_REF="${REPO_ROOT}/charts/cloudflare-tunnel-gateway-controller"
+HELM_VERSION_ARGS=()
+HELM_IMAGE_ARGS=(
+  --set image.repository="${CONTROLLER_IMAGE%%:*}"
+  --set image.tag="${CONTROLLER_IMAGE##*:}"
+  --set image.pullPolicy=Never
+  --set proxy.image.repository="${PROXY_IMAGE%%:*}"
+  --set proxy.image.tag="${PROXY_IMAGE##*:}"
+  --set proxy.image.pullPolicy=Never
+)
+if [[ -n "${CI_PR_NUMBER}" ]]; then
+  HELM_CHART_REF="oci://ttl.sh/cloudflare-tunnel-gateway-controller"
+  HELM_VERSION_ARGS=(--version "${CI_CHART_VERSION}")
+  HELM_IMAGE_ARGS=()
+fi
+
+# proxy.tunnel.protocol=http2 is mandatory in both modes: the chart defaults to
+# "auto" (QUIC-first) and kind/Colima blocks QUIC egress to the CF edge (530/1033).
+# The "${arr[@]+...}" idiom expands an empty array to nothing without tripping
+# `set -u` on bash < 4.4 (stock macOS ships 3.2).
 info "Deploying controller via helm..."
 helm upgrade --install "${RELEASE_NAME}" \
-  "${REPO_ROOT}/charts/cloudflare-tunnel-gateway-controller" \
+  "${HELM_CHART_REF}" \
+  "${HELM_VERSION_ARGS[@]+"${HELM_VERSION_ARGS[@]}"}" \
   --kube-context "${KUBE_CONTEXT}" \
   --namespace "${NAMESPACE}" \
   --set gatewayClassConfig.create=true \
   --set gatewayClassConfig.tunnelID="${V2_TUNNEL_ID}" \
   --set gatewayClassConfig.cloudflareCredentialsSecretRef.name=cloudflare-credentials \
-  --set image.repository="${CONTROLLER_IMAGE%%:*}" \
-  --set image.tag="${CONTROLLER_IMAGE##*:}" \
-  --set image.pullPolicy=Never \
-  --set proxy.image.repository="${PROXY_IMAGE%%:*}" \
-  --set proxy.image.tag="${PROXY_IMAGE##*:}" \
-  --set proxy.image.pullPolicy=Never \
+  "${HELM_IMAGE_ARGS[@]+"${HELM_IMAGE_ARGS[@]}"}" \
   --set proxy.tunnelTokenSecretRef.name=cloudflare-tunnel-token \
   --set proxy.tunnel.protocol=http2 \
   --set controller.logLevel=debug \


### PR DESCRIPTION
## Summary

`hack/conformance-setup.sh` always builds the controller and proxy images locally (cross-arch) and loads them into kind. When a PR has already passed CI, the exact same images and Helm chart are published to ttl.sh, so rebuilding locally to verify that artifact wastes ~10 minutes of cross-arch build and is not even bit-identical to what CI shipped. This adds a `--use-ci-images <PR>` mode that skips the local build and deploys the PR's already-published ttl.sh chart instead. Implements #331.

## Changes

- New `--use-ci-images <PR>` mode: installs `oci://ttl.sh/cloudflare-tunnel-gateway-controller:0.0.0-pr.<PR>-1d` and skips both the local image build and `kind load`. The published chart already pins the ttl.sh image references with `pullPolicy=Always`, so no `--set image.*` overrides are passed in this mode.
- Fail-fast pre-check: aborts before creating the kind cluster when the chart is missing on ttl.sh (artifacts expire 24h after the CI run), with a message pointing at re-running the PR's CI.
- The `proxy.tunnel.protocol=http2` override is retained in both modes — the chart defaults to QUIC-first `auto`, and kind/Colima blocks QUIC egress to the Cloudflare edge.
- The argument parser is rewritten from a `for` loop to a `while`/`shift` loop so the flag can take a value; `--use-ci-images` combined with `--skip-build` is rejected as contradictory, and a non-numeric PR number is rejected.
- Helm arguments are spliced via arrays guarded with the `"${arr[@]+...}"` idiom so empty-array expansion does not trip `set -u` on stock macOS bash 3.2.
- The default local-build path is unchanged.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

This is a shell-script change with no Go or chart changes. `go test -race ./...` and `golangci-lint run` are green. `shellcheck hack/conformance-setup.sh` reports 0 issues and `bash -n` is clean on both bash 5.3 and stock macOS bash 3.2. The negative paths (non-numeric PR number, missing value, mutual exclusion with `--skip-build`, unknown flag) and the fail-fast ttl.sh pre-check were exercised on bash 3.2 and all exit non-zero before any cluster or network side effect.

End-to-end positive path verified against this PR's own published artifact: `./hack/conformance-setup.sh --use-ci-images 368` created a fresh kind cluster, skipped the local build + `kind load`, pulled `oci://ttl.sh/cloudflare-tunnel-gateway-controller:0.0.0-pr.368-1d`, and both deployments rolled out and reached Ready (controller and proxy `Running`, GatewayClass `Accepted=True`) in ~115s total. The cold image pull from ttl.sh completed comfortably within the existing 120s readiness budget, so the timeouts are kept identical to the local-build path.

## Documentation

- [ ] README updated (if needed)
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

README does not enumerate the script's flags, so no README change is needed. The `--use-ci-images` example was added to the Conformance Testing section of CLAUDE.md (the only place that documents the script's flags).

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

No changes to CI workflows or the chart — the publishing side already produces the self-contained ttl.sh chart this mode consumes.
