### PR TITLE
fix(controller): count ListenerSet attached routes independent of listener status

### DIFF
--- a/docs/gateway-api/listenerset.md
+++ b/docs/gateway-api/listenerset.md
@@ -148,6 +148,10 @@ spec:
 | `ResolvedRefs` | `False` | `RefNotPermitted` | Cross-namespace cert ref denied by missing ReferenceGrant |
 | `ResolvedRefs` | `False` | `InvalidCertificateRef` | Cert Secret missing, wrong type, or missing data |
 
+## AttachedRoutes
+
+Each per-entry status reports `attachedRoutes` — the number of Routes bound to that listener entry. Per the Gateway API spec, attachment depends solely on the entry's `allowedRoutes` and the Route's `parentRefs` (plus the Route's own `Accepted` state); the listener's own status does not change the count. A Route attached to an entry that is `Conflicted`, or whose `Programmed` is `False` because its TLS certificate ref failed to resolve, is still counted — the spec requires `attachedRoutes` to be set even when the entry's own `Accepted` condition is `False`. The field therefore measures binding and blast radius, not whether the entry currently serves traffic. A ListenerSet rejected at the resource level (not permitted by the parent Gateway's `allowedListeners`) reports `attachedRoutes: 0` for every entry, because the entries are not part of any merged Gateway.
+
 ## DNS automation (external-dns)
 
 If you rely on [external-dns](https://github.com/kubernetes-sigs/external-dns) to publish the tunnel CNAME for your hostnames, note that a route attached **only** via a `ListenerSet` parentRef needs external-dns to follow that parentRef to the parent Gateway's status address. external-dns supports this through the opt-in `--gateway-listener-sets` flag (available since external-dns v0.21.0). Without the flag, external-dns skips `Kind=ListenerSet` parentRefs and the hostname gets no DNS record even though the controller programs the route correctly.

--- a/internal/controller/listenerset_controller.go
+++ b/internal/controller/listenerset_controller.go
@@ -243,7 +243,7 @@ func (r *ListenerSetReconciler) computeAcceptance(
 
 	accepted, summaryReason, summaryMessage := summariseListenerSet(merged, listenerSet, refChecks)
 
-	attached, attachErr := r.countAttachedRoutesPerEntry(ctx, listenerSet, merged)
+	attached, attachErr := r.countAttachedRoutesPerEntry(ctx, listenerSet)
 	if attachErr != nil {
 		return listenerSetAcceptanceResult{
 			Accepted: false,
@@ -265,14 +265,23 @@ func (r *ListenerSetReconciler) computeAcceptance(
 // countAttachedRoutesPerEntry returns the number of accepted HTTPRoutes (and
 // GRPCRoutes) that bind to each entry of the ListenerSet via parentRef.
 // "Accepted" mirrors RouteSyncer's binding contract: hostname intersects,
-// allowedRoutes.namespaces permits the route, route kind is allowed. Entries
-// marked conflicted in the merged view are excluded — a route that "matches"
-// a conflicted listener is not counted as attached, because the entry will
-// not be programmed.
+// allowedRoutes.namespaces permits the route, route kind is allowed.
+//
+// Per the Gateway API spec (ListenerEntryStatus.AttachedRoutes), attachment
+// depends SOLELY on AllowedRoutes + ParentRefs plus the route's own Accepted
+// state: "the AttachedRoutes field count MUST be set for Listeners, even if the
+// Accepted condition of an individual Listener is set to False". Only the route's
+// binding-Accepted verdict gates the count; a listener's own status — whether
+// Conflicted, or Programmed=False because a TLS cert ref did not resolve — never
+// changes it. The count is observational (blast radius) and intentionally
+// decoupled from programming: a route on a Conflicted entry is counted here even
+// though the data plane drops it (see filterMatchedListenersByConflict in
+// route_parent_binding.go and dropConflictedSections in
+// route_effective_hostnames.go). Do not re-add a listener-status gate to "fix"
+// that apparent mismatch — the divergence is spec-mandated.
 func (r *ListenerSetReconciler) countAttachedRoutesPerEntry(
 	ctx context.Context,
 	listenerSet *gatewayv1.ListenerSet,
-	merged *listenermerge.MergeResult,
 ) (map[gatewayv1.SectionName]int32, error) {
 	out := make(map[gatewayv1.SectionName]int32, len(listenerSet.Spec.Listeners))
 	for i := range listenerSet.Spec.Listeners {
@@ -281,11 +290,11 @@ func (r *ListenerSetReconciler) countAttachedRoutesPerEntry(
 
 	validator := routebinding.NewValidator(r.Client)
 
-	if err := r.countAttachedHTTPRoutes(ctx, listenerSet, merged, validator, out); err != nil {
+	if err := r.countAttachedHTTPRoutes(ctx, listenerSet, validator, out); err != nil {
 		return nil, err
 	}
 
-	if err := r.countAttachedGRPCRoutes(ctx, listenerSet, merged, validator, out); err != nil {
+	if err := r.countAttachedGRPCRoutes(ctx, listenerSet, validator, out); err != nil {
 		return nil, err
 	}
 
@@ -296,7 +305,6 @@ func (r *ListenerSetReconciler) countAttachedRoutesPerEntry(
 func (r *ListenerSetReconciler) countAttachedHTTPRoutes(
 	ctx context.Context,
 	listenerSet *gatewayv1.ListenerSet,
-	merged *listenermerge.MergeResult,
 	validator *routebinding.Validator,
 	counts map[gatewayv1.SectionName]int32,
 ) error {
@@ -308,7 +316,7 @@ func (r *ListenerSetReconciler) countAttachedHTTPRoutes(
 	for i := range routes.Items {
 		route := &routes.Items[i]
 		incrementListenerSetAttachedRoutes(
-			ctx, validator, listenerSet, merged,
+			ctx, validator, listenerSet,
 			route.Namespace, route.Name, route.Spec.Hostnames,
 			routebinding.KindHTTPRoute, route.Spec.ParentRefs, counts,
 		)
@@ -321,7 +329,6 @@ func (r *ListenerSetReconciler) countAttachedHTTPRoutes(
 func (r *ListenerSetReconciler) countAttachedGRPCRoutes(
 	ctx context.Context,
 	listenerSet *gatewayv1.ListenerSet,
-	merged *listenermerge.MergeResult,
 	validator *routebinding.Validator,
 	counts map[gatewayv1.SectionName]int32,
 ) error {
@@ -333,7 +340,7 @@ func (r *ListenerSetReconciler) countAttachedGRPCRoutes(
 	for i := range routes.Items {
 		route := &routes.Items[i]
 		incrementListenerSetAttachedRoutes(
-			ctx, validator, listenerSet, merged,
+			ctx, validator, listenerSet,
 			route.Namespace, route.Name, route.Spec.Hostnames,
 			routebinding.KindGRPCRoute, route.Spec.ParentRefs, counts,
 		)
@@ -346,7 +353,6 @@ func incrementListenerSetAttachedRoutes(
 	ctx context.Context,
 	validator *routebinding.Validator,
 	listenerSet *gatewayv1.ListenerSet,
-	merged *listenermerge.MergeResult,
 	routeNamespace, routeName string,
 	hostnames []gatewayv1.Hostname,
 	kind gatewayv1.Kind,
@@ -372,19 +378,17 @@ func incrementListenerSetAttachedRoutes(
 			Port:        ref.Port,
 		}
 
+		// Count is gated only by the route's binding-Accepted verdict — the
+		// Gateway API "Routes with the Accepted condition set to True" rule. A
+		// listener's own status (Conflicted, or Programmed=False from an
+		// unresolved TLS cert ref) is never consulted; the spec requires the
+		// count to be set even when the listener is not Accepted.
 		result, err := validator.ValidateBindingForListenerSet(ctx, listenerSet, routeInfo)
 		if err != nil || !result.Accepted {
 			continue
 		}
 
 		for _, section := range result.MatchedListeners {
-			// Skip conflicted entries — the merge view says they will not
-			// be programmed, so a route nominally "matching" them is not
-			// actually attached.
-			if entry := findMergedEntry(merged, listenerSet, section); entry != nil && entry.ConflictReason != "" {
-				continue
-			}
-
 			if _, already := countedThisRoute[section]; already {
 				continue
 			}
@@ -677,6 +681,11 @@ func buildListenerSetRejectedEntryStatuses(
 		out = append(out, gatewayv1.ListenerEntryStatus{
 			Name:           entry.Name,
 			SupportedKinds: supportedKinds,
+			// Zero, not a real count: a resource-level-rejected ListenerSet is
+			// not part of any merged Gateway, so its entries are not valid
+			// attachment points and no route can be Accepted on them. The spec
+			// counts only Accepted routes, so zero is correct here — unlike a
+			// conflicted entry on an accepted ListenerSet, which does count.
 			AttachedRoutes: 0,
 			Conditions: []metav1.Condition{
 				{

--- a/internal/controller/listenerset_controller_test.go
+++ b/internal/controller/listenerset_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -213,6 +214,229 @@ func TestListenerSetReconciler_MarksAllListenersValidNotValidWhenAllConflict(t *
 	assert.Equal(t, string(gatewayv1.ListenerReasonHostnameConflict), entryConflicted.Reason)
 }
 
+// TestListenerSetReconciler_ConflictedEntryStillCountsAttachedRoutes pins that a
+// route attached to a conflicted ListenerSet entry is still counted in
+// AttachedRoutes. Per the Gateway API spec, attachment depends solely on
+// AllowedRoutes + ParentRefs; the listener's own status (here Conflicted /
+// Programmed=False) MUST NOT reduce the count.
+func TestListenerSetReconciler_ConflictedEntryStillCountsAttachedRoutes(t *testing.T) {
+	t.Parallel()
+
+	from := gatewayv1.NamespacesFromSame
+	conflictHost := gatewayv1.Hostname("conflict.example.com")
+	section := gatewayv1.SectionName("only")
+	lsKind := gatewayv1.Kind(kindListenerSet)
+
+	gc := managedGatewayClass()
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "infra"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(gc.Name),
+			AllowedListeners: &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{From: &from},
+			},
+			Listeners: []gatewayv1.Listener{
+				{Name: "gw-l1", Port: 80, Protocol: gatewayv1.HTTPProtocolType, Hostname: &conflictHost},
+			},
+		},
+	}
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "infra"},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{Name: gatewayv1.ObjectName(gw.Name)},
+			Listeners: []gatewayv1.ListenerEntry{
+				{
+					Name: section, Port: 80, Protocol: gatewayv1.HTTPProtocolType, Hostname: &conflictHost,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+			},
+		},
+	}
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "infra"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Kind: &lsKind, Name: gatewayv1.ObjectName(ls.Name), SectionName: &section},
+				},
+			},
+		},
+	}
+
+	r, cli := newListenerSetReconcilerWithObjects(t, newListenerSetScheme(t), gc, gw, ls, route)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: ls.Name, Namespace: ls.Namespace},
+	})
+	require.NoError(t, err)
+
+	updated := getListenerSet(t, cli, ls.Name, ls.Namespace)
+	require.Len(t, updated.Status.Listeners, 1)
+	entry := updated.Status.Listeners[0]
+
+	// The entry IS conflicted (and therefore not programmed)...
+	entryConflicted := findCondition(entry.Conditions, string(gatewayv1.ListenerConditionConflicted))
+	require.NotNil(t, entryConflicted)
+	assert.Equal(t, metav1.ConditionTrue, entryConflicted.Status)
+
+	// ...yet the attached route is still counted.
+	assert.Equal(t, int32(1), entry.AttachedRoutes,
+		"a route attached to a conflicted listener is still counted per Gateway API AttachedRoutes semantics")
+}
+
+// TestListenerSetReconciler_UnresolvedTLSRefStillCountsAttachedRoutes pins that
+// a route attached to an HTTPS ListenerSet entry whose TLS certificate ref fails
+// to resolve (ResolvedRefs=False, Programmed=False) is still counted in
+// AttachedRoutes. The Gateway API spec makes attachment depend solely on
+// AllowedRoutes + ParentRefs, independent of the listener's own status, so the
+// non-zero count is correct, not a defect.
+func TestListenerSetReconciler_UnresolvedTLSRefStillCountsAttachedRoutes(t *testing.T) {
+	t.Parallel()
+
+	from := gatewayv1.NamespacesFromSame
+	section := gatewayv1.SectionName("https")
+	lsKind := gatewayv1.Kind(kindListenerSet)
+
+	gc := managedGatewayClass()
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "infra"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(gc.Name),
+			AllowedListeners: &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{From: &from},
+			},
+			Listeners: []gatewayv1.Listener{
+				{Name: "gw-l1", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "infra"},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{Name: gatewayv1.ObjectName(gw.Name)},
+			Listeners: []gatewayv1.ListenerEntry{
+				{
+					Name: section, Port: 443, Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "missing"}},
+					},
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+			},
+		},
+	}
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "infra"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Kind: &lsKind, Name: gatewayv1.ObjectName(ls.Name), SectionName: &section},
+				},
+			},
+		},
+	}
+
+	scheme := newListenerSetScheme(t)
+	require.NoError(t, corev1.AddToScheme(scheme))
+	r, cli := newListenerSetReconcilerWithObjects(t, scheme, gc, gw, ls, route)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: ls.Name, Namespace: ls.Namespace},
+	})
+	require.NoError(t, err)
+
+	updated := getListenerSet(t, cli, ls.Name, ls.Namespace)
+	require.Len(t, updated.Status.Listeners, 1)
+	entry := updated.Status.Listeners[0]
+
+	// The cert ref did not resolve, so the entry is not programmed...
+	entryResolved := findCondition(entry.Conditions, string(gatewayv1.ListenerConditionResolvedRefs))
+	require.NotNil(t, entryResolved)
+	assert.Equal(t, metav1.ConditionFalse, entryResolved.Status)
+
+	entryProgrammed := findCondition(entry.Conditions, string(gatewayv1.ListenerConditionProgrammed))
+	require.NotNil(t, entryProgrammed)
+	assert.Equal(t, metav1.ConditionFalse, entryProgrammed.Status)
+
+	// ...yet the attached route is still counted.
+	assert.Equal(t, int32(1), entry.AttachedRoutes,
+		"a route attached to a listener with unresolved TLS refs is still counted per Gateway API AttachedRoutes semantics")
+}
+
+// TestListenerSetReconciler_RejectedListenerSetReportsZeroAttachedRoutes pins
+// that a ListenerSet rejected at the resource level (NotAllowed by the parent
+// Gateway's allowedListeners) reports AttachedRoutes=0 for its entries even when
+// a route targets them. The entries are not part of any merged Gateway, so no
+// route can be Accepted on them, and the spec counts only Accepted routes — this
+// is deliberately different from a conflicted entry on an accepted ListenerSet,
+// which does count its attached routes.
+func TestListenerSetReconciler_RejectedListenerSetReportsZeroAttachedRoutes(t *testing.T) {
+	t.Parallel()
+
+	section := gatewayv1.SectionName("only")
+	lsKind := gatewayv1.Kind(kindListenerSet)
+
+	gc := managedGatewayClass()
+	// No AllowedListeners on the Gateway → the ListenerSet is NotAllowed.
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "infra"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(gc.Name),
+			Listeners: []gatewayv1.Listener{
+				{Name: "gw-l1", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "infra"},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{Name: gatewayv1.ObjectName(gw.Name)},
+			Listeners: []gatewayv1.ListenerEntry{
+				{
+					Name: section, Port: 80, Protocol: gatewayv1.HTTPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: namespacesFromAllPtr()},
+					},
+				},
+			},
+		},
+	}
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "infra"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Kind: &lsKind, Name: gatewayv1.ObjectName(ls.Name), SectionName: &section},
+				},
+			},
+		},
+	}
+
+	r, cli := newListenerSetReconcilerWithObjects(t, newListenerSetScheme(t), gc, gw, ls, route)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: ls.Name, Namespace: ls.Namespace},
+	})
+	require.NoError(t, err)
+
+	updated := getListenerSet(t, cli, ls.Name, ls.Namespace)
+
+	// The ListenerSet is rejected at the resource level...
+	accepted := findCondition(updated.Status.Conditions, string(gatewayv1.ListenerSetConditionAccepted))
+	require.NotNil(t, accepted)
+	assert.Equal(t, metav1.ConditionFalse, accepted.Status)
+	assert.Equal(t, string(gatewayv1.ListenerSetReasonNotAllowed), accepted.Reason)
+
+	// ...so its entries report zero attached routes despite the targeting route.
+	require.Len(t, updated.Status.Listeners, 1)
+	assert.Equal(t, int32(0), updated.Status.Listeners[0].AttachedRoutes,
+		"a route targeting a resource-level-rejected ListenerSet is not Accepted and must not be counted")
+}
+
 func TestListenerSetReconciler_SkipsWhenParentNotManaged(t *testing.T) {
 	t.Parallel()
 
@@ -267,6 +491,26 @@ func newListenerSetReconciler(
 	cli := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(gc, gw, ls).
+		WithStatusSubresource(&gatewayv1.ListenerSet{}, &gatewayv1.Gateway{}).
+		Build()
+
+	return &ListenerSetReconciler{
+		Client:         cli,
+		Scheme:         scheme,
+		ControllerName: testListenerSetController,
+	}, cli
+}
+
+func newListenerSetReconcilerWithObjects(
+	t *testing.T,
+	scheme *runtime.Scheme,
+	objs ...client.Object,
+) (*ListenerSetReconciler, client.Client) {
+	t.Helper()
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
 		WithStatusSubresource(&gatewayv1.ListenerSet{}, &gatewayv1.Gateway{}).
 		Build()
 

--- a/internal/controller/listenerset_route_mapper_test.go
+++ b/internal/controller/listenerset_route_mapper_test.go
@@ -315,7 +315,7 @@ func TestIncrementListenerSetAttachedRoutes_DeduplicatesDuplicateParentRefs(t *t
 	counts := map[gatewayv1.SectionName]int32{"entry": 0}
 
 	incrementListenerSetAttachedRoutes(
-		context.Background(), validator, ls, nil,
+		context.Background(), validator, ls,
 		"team-a", "r", nil, routebinding.KindHTTPRoute, dupRefs, counts,
 	)
 


### PR DESCRIPTION
# Pull Request

## Summary

ListenerSet per-entry `attachedRoutes` excluded routes bound to a conflicted listener entry, which contradicts the Gateway API spec: attachment is based solely on a listener's `allowedRoutes` and a Route's `parentRefs` (plus the Route's own `Accepted` state), and the count MUST be set even when the listener's own `Accepted` condition is `False`. This change makes the count depend only on binding acceptance, never on the listener's own status.

## Changes

- Drop the conflicted-entry exclusion from per-entry `attachedRoutes` counting, so a route bound to a conflicted entry is counted (it is still not served — the data plane continues to drop conflicted sections).
- Remove the now-unused merge view from the counting call chain.
- Keep `attachedRoutes: 0` for a resource-level-rejected ListenerSet (not permitted by the parent Gateway's `allowedListeners`), because its listeners are not part of any merged Gateway and no route can be `Accepted` on them.
- Document the counting semantics and the count-vs-serve divergence.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [ ] Manual testing completed (if applicable)

## Documentation

- [ ] README updated (if needed)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [ ] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

Three new tests pin the distinct branches: a conflicted entry still counts its attached routes, an entry with an unresolved TLS certificate ref still counts, and a resource-level-rejected ListenerSet reports zero. The Gateway-level `attachedRoutes` counter was checked and already gates purely on binding acceptance, so it needs no change. Addresses the decision raised in #333.

Pre-merge conformance and end-to-end verification against a real tunnel remain maintainer-side per the project's pre-merge requirements.
