### PR TITLE
feat(controller): surface silently-unsupported/dropped config on resource status

### DIFF
--- a/charts/cloudflare-tunnel-gateway-controller/templates/clusterrole.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/templates/clusterrole.yaml
@@ -64,7 +64,14 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
+  # Events: the route reconcilers emit Kubernetes Events for benign config
+  # overrides via controller-runtime's EventRecorder. The new (events.k8s.io)
+  # recorder writes to events.k8s.io/v1; the legacy broadcaster controller-runtime
+  # also starts writes core v1 events. Grant both so neither path is denied.
   - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create", "patch"]
   # GatewayClassConfig CRD

--- a/charts/cloudflare-tunnel-gateway-controller/templates/clusterrole.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/templates/clusterrole.yaml
@@ -66,8 +66,9 @@ rules:
     verbs: ["get", "list", "watch"]
   # Events: the route reconcilers emit Kubernetes Events for benign config
   # overrides via controller-runtime's EventRecorder. The new (events.k8s.io)
-  # recorder writes to events.k8s.io/v1; the legacy broadcaster controller-runtime
-  # also starts writes core v1 events. Grant both so neither path is denied.
+  # recorder writes to events.k8s.io/v1; the legacy broadcaster that
+  # controller-runtime also starts writes core v1 events. Grant both so
+  # neither path is denied.
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]

--- a/charts/cloudflare-tunnel-gateway-controller/tests/rbac_test.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/tests/rbac_test.yaml
@@ -196,6 +196,26 @@ tests:
             resources: ["gatewayclassconfigs/status"]
             verbs: ["get", "update", "patch"]
 
+  - it: should grant event create/patch on both core and events.k8s.io groups
+    asserts:
+      # controller-runtime's GetEventRecorder writes to events.k8s.io/v1; the
+      # legacy broadcaster it also starts writes core v1 events. Both groups must
+      # be granted or the EventRecorder is denied at runtime.
+      - template: clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["events"]
+            verbs: ["create", "patch"]
+      - template: clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups: ["events.k8s.io"]
+            resources: ["events"]
+            verbs: ["create", "patch"]
+
   - it: should create a cluster role binding
     asserts:
       - template: clusterrolebinding.yaml

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -62,7 +62,14 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
+  # Events: the route reconcilers emit Kubernetes Events for benign config
+  # overrides via controller-runtime's EventRecorder. The new (events.k8s.io)
+  # recorder writes to events.k8s.io/v1; the legacy broadcaster controller-runtime
+  # also starts writes core v1 events. Grant both so neither path is denied.
   - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create", "patch"]
   # GatewayClassConfig CRD

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -64,8 +64,9 @@ rules:
     verbs: ["get", "list", "watch"]
   # Events: the route reconcilers emit Kubernetes Events for benign config
   # overrides via controller-runtime's EventRecorder. The new (events.k8s.io)
-  # recorder writes to events.k8s.io/v1; the legacy broadcaster controller-runtime
-  # also starts writes core v1 events. Grant both so neither path is denied.
+  # recorder writes to events.k8s.io/v1; the legacy broadcaster that
+  # controller-runtime also starts writes core v1 events. Grant both so
+  # neither path is denied.
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -41,7 +41,7 @@ When the controller will not serve a piece of route config exactly as written, i
 
 Separately, Gateway and ListenerSet listeners whose protocol this controller cannot serve (`TCP`, `TLS`, `UDP`) are marked `Accepted=False, Reason=UnsupportedProtocol` on the listener status.
 
-Unsupported filters fail closed: per the Gateway API spec an `ExtensionRef`, `ExternalAuth`, or unknown HTTPRoute filter type — and any GRPCRoute filter, none of which are served yet — must not be silently skipped. Requests matching the affected rule receive HTTP 500 (a rule-level filter takes the whole rule down; a per-backend filter fails only that backend's traffic fraction) rather than being served without the dropped filter.
+Unsupported filters fail closed: per the Gateway API spec an `ExtensionRef`, `ExternalAuth`, or unknown HTTPRoute filter type — and any GRPCRoute filter, none of which are served yet — must not be silently skipped. Requests matching the affected rule (or backend) receive HTTP 500 rather than being served without the dropped filter. A rule-level filter takes the whole rule down; a per-backend filter (HTTPRoute or GRPCRoute `backendRef.filters`) fails only that backend's traffic fraction while the rule keeps serving its other backends.
 
 A TLS `appProtocol` (`https`, `kubernetes.io/wss`) without a `BackendTLSPolicy` fails the backend closed (HTTP 502) rather than dialing plaintext to a TLS backend. An unrecognised `appProtocol` is report-only: the proxy keeps serving over HTTP/1.1 and records the diagnostic so the ignored hint is visible.
 

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -30,6 +30,18 @@ In the v1/v2 chart line, several HTTPRoute features required opting into the L7 
 | No cross-cluster | Only in-cluster services supported |
 | Service only | Only `Service` kind backends (ClusterIP, NodePort, LoadBalancer, ExternalName); evaluating non-Service kinds is tracked in [#337](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/337) |
 
+## Unsupported config is surfaced on resource status
+
+When the controller will not serve a piece of route config exactly as written, it surfaces the decision on the resource's status conditions — not only in a log line — so `kubectl describe httproute` / `grpcroute` shows the problem and the fix. Three shapes are used, chosen per the Gateway API spec:
+
+- **`Accepted=False` / `UnsupportedValue`** — the whole route cannot be served. This fires when every rule of the route is unservable, e.g. each rule carries an unsupported filter type.
+- **`PartiallyInvalid=True`** (alongside `Accepted=True`) — some rules or backends are dropped while the route still serves the rest. The message starts with the spec-mandated `Dropped Rule` prefix and names the affected rule indices. This covers a single unsupported filter among several rules, an unsupported per-backend filter (only that backend's traffic fraction fails closed), and an unparseable rule `timeouts` value (the rule serves without it).
+- **`ResolvedRefs=False`** — a backend or object reference cannot be resolved or declares an unsupported app protocol. This covers the existing missing-Service / wrong-kind / unauthorized-cross-namespace `backendRef` failures, plus `appProtocol: https`/`wss` without a `BackendTLSPolicy` (`Reason=UnsupportedProtocol`), an unrecognised `appProtocol`, and a dropped `RequestMirror` backendRef.
+
+Unsupported filters fail closed: per the Gateway API spec an `ExtensionRef`, `ExternalAuth`, or unknown HTTPRoute filter type — and any GRPCRoute filter, none of which are served yet — must not be silently skipped. Requests matching the affected rule receive HTTP 500 (a rule-level filter takes the whole rule down; a per-backend filter fails only that backend's traffic fraction) rather than being served without the dropped filter.
+
+A TLS `appProtocol` (`https`, `kubernetes.io/wss`) without a `BackendTLSPolicy` fails the backend closed (HTTP 502) rather than dialing plaintext to a TLS backend. An unrecognised `appProtocol` is report-only: the proxy keeps serving over HTTP/1.1 and records the diagnostic so the ignored hint is visible.
+
 ## Traffic Splitting and Load Balancing
 
 The in-process L7 proxy performs weighted traffic splitting across the `backendRefs` of a rule, for both HTTPRoute and GRPCRoute. Each backend's `weight` is honoured by a weighted-random selection at request time: traffic is distributed in proportion to the weights, and a backend with `weight: 0` receives no traffic (a rule whose backends all have weight 0 serves nothing).
@@ -106,8 +118,8 @@ The L7 proxy reads the backend Service port's `appProtocol` to pick the upstream
 | _(unset)_ | Yes | Default — proxy speaks HTTP/1.1 to the backend |
 | `kubernetes.io/h2c` | Yes | Proxy speaks HTTP/2 cleartext (prior knowledge) |
 | `kubernetes.io/ws` | Yes | The proxy detects `Connection: Upgrade` + `Upgrade: websocket` headers and routes the request through a dedicated WebSocket upgrade path that dials the backend, forwards the upgrade, writes the 101 to the response writer, and bidirectionally copies bytes after hijack. Plain HTTP requests to the same backend continue to use the default HTTP/1.1 transport |
-| `kubernetes.io/wss` | Yes | Requires a `BackendTLSPolicy` targeting the Service (same precondition as `appProtocol: https`); without one the proxy logs a WARN and falls back to plaintext, which the backend will refuse |
-| any other value | No | Logged with a warning at conversion time; proxy falls back to default HTTP/1.1 |
+| `kubernetes.io/wss` | Yes | Requires a `BackendTLSPolicy` targeting the Service (same precondition as `appProtocol: https`); without one the proxy fails the backend closed (HTTP 502) and sets `ResolvedRefs=False, Reason=UnsupportedProtocol` on the route — dialing plaintext to a TLS backend would silently fail |
+| any other value | No | Report-only: the proxy serves over HTTP/1.1 (a safe default the backend may speak) and sets `ResolvedRefs=False, Reason=UnsupportedProtocol` on the route so the ignored hint is visible |
 
 The upstream conformance test `HTTPRouteBackendProtocolWebSocket` is not testable through Cloudflare Tunnel: it dials the Gateway address directly via `golang.org/x/net/websocket.Dial`, and our Gateway address is `<tunnel-id>.cfargotunnel.com` whose AAAA records point at Cloudflare's ULA (`fd10::/8`), which is unreachable from any test runner. Unlike the HTTP suite (custom `RoundTripper`) and the gRPC suite (custom gRPC client) — both of which let us redirect the dial to the Cloudflare edge — the WebSocket test exposes no injection point for a custom dialer, so it cannot be redirected and stays skipped. This gap is filed upstream as [kubernetes-sigs/gateway-api#4925](https://github.com/kubernetes-sigs/gateway-api/issues/4925). `test/e2e/e2e_backend_protocol_websocket_test.go` is the substitute proof — it runs an end-to-end WebSocket round trip against the real tunnel hostname.
 
@@ -138,6 +150,8 @@ The same shift removes the slow-loris-upload protection the old context-based de
 WebSocket routes are naturally exempt: WS upgrades flow through the dedicated `proxyWebSocketUpgrade` path (because cloudflared's HTTP/2 response writer cannot be hijacked the way stdlib `httputil.ReverseProxy` expects), and that path bypasses the cached transport entirely. Once the upgrade completes, two `io.Copy` goroutines pipe bytes bidirectionally between the hijacked client conn and the backend conn; they run until either side closes its conn.
 
 The `BackendProtocol: H2C` path uses `golang.org/x/net/http2.Transport`, which does not expose a `ResponseHeaderTimeout` knob. The proxy synthesises one by wrapping the h2c transport with a `headerTimeoutRoundTripper` that cancels the request context if response headers do not arrive within the per-rule deadline, then releases the cancellation on body Close so streaming bodies (SSE / chunked / gRPC server-streaming) survive past the deadline. The h2c dialer's own connect timeout still catches a fully dead backend.
+
+When a rule's `timeouts` value cannot be parsed (not a valid GEP-2257 duration), the rule is still served without the timeout and the route is marked `PartiallyInvalid=True` with a `Dropped Rule` message naming the rule, so the dropped timeout is visible on `kubectl describe httproute` rather than only in a log line.
 
 ## Backend mTLS (BackendTLSPolicy)
 
@@ -189,14 +203,14 @@ Frontend listener `certificateRefs` are not in scope — Cloudflare terminates T
 
 The Gateway API `RequestMirror` filter sends a fire-and-forget copy of the request to a secondary backend. When a `BackendTLSPolicy` targets the mirror destination Service, the converter stamps the resulting `BackendTLSConfig` on the filter's `MirrorConfig` and the proxy borrows a per-cert `RoundTripper` from the same transport pool the main leg uses. The mirror dial then completes a TLS handshake exactly the way the main leg would, so a TLS-only mirror backend receives the mirrored copy correctly and the operator's TLS expectation is preserved on both legs.
 
-Cross-namespace mirror destinations follow the same `ReferenceGrant` rule as cross-namespace `backendRefs` — without a permitting grant the mirror is dropped entirely.
+Cross-namespace mirror destinations follow the same `ReferenceGrant` rule as cross-namespace `backendRefs` — without a permitting grant the mirror is dropped entirely. A dropped mirror (non-Service kind, out-of-range port, or unauthorized cross-namespace ref) is surfaced as `ResolvedRefs=False` on the route with the mirror-specific reason (`InvalidKind` / `UnsupportedValue` / `RefNotPermitted`); the main request is unaffected, so the route stays `Accepted`.
 
 ### Interaction with `appProtocol: https` / `HTTPS`
 
 `appProtocol: https` (or `HTTPS`) is treated as a hint that the backend expects TLS — but the proxy cannot dial TLS on its own without a CA to verify against. The behaviour:
 
 - With a matching `BackendTLSPolicy`: the policy provides the CA, the proxy dials TLS, and the request goes through normally. The `appProtocol` hint is redundant but accepted silently.
-- Without a matching `BackendTLSPolicy`: the proxy logs a WARN and falls back to plaintext HTTP/1.1. The misconfiguration is visible in logs so operators don't ship a broken TLS expectation. Attach a `BackendTLSPolicy` to upgrade the hop to authenticated TLS.
+- Without a matching `BackendTLSPolicy`: the backend fails closed — requests routed to it receive HTTP 502 instead of being dialed in plaintext — and the route's `ResolvedRefs` condition is set to `False, Reason=UnsupportedProtocol` with a message naming the fix. `kubectl describe httproute` shows the dropped backend; attach a `BackendTLSPolicy` to upgrade the hop to authenticated TLS.
 
 ## HTTP CORS filter (`HTTPRouteCORS`)
 

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -37,6 +37,9 @@ When the controller will not serve a piece of route config exactly as written, i
 - **`Accepted=False` / `UnsupportedValue`** — the whole route cannot be served. This fires when every rule of the route is unservable, e.g. each rule carries an unsupported filter type.
 - **`PartiallyInvalid=True`** (alongside `Accepted=True`) — some rules or backends are dropped while the route still serves the rest. The message starts with the spec-mandated `Dropped Rule` prefix and names the affected rule indices. This covers a single unsupported filter among several rules, an unsupported per-backend filter (only that backend's traffic fraction fails closed), and an unparseable rule `timeouts` value (the rule serves without it).
 - **`ResolvedRefs=False`** — a backend or object reference cannot be resolved or declares an unsupported app protocol. This covers the existing missing-Service / wrong-kind / unauthorized-cross-namespace `backendRef` failures, plus `appProtocol: https`/`wss` without a `BackendTLSPolicy` (`Reason=UnsupportedProtocol`), an unrecognised `appProtocol`, and a dropped `RequestMirror` backendRef.
+- **Kubernetes Event** (`reason=ConfigOverridden`) — config applied successfully but a redundant or conflicting hint was overridden, where no standard condition fits. A Normal event covers a cleartext `appProtocol` (`h2c`, `ws`) superseded by a `BackendTLSPolicy` ("TLS wins"); a Warning event covers a `ResponseHeaderModifier` that strips a WebSocket handshake header (honored as written, but it breaks the upgrade).
+
+Separately, Gateway and ListenerSet listeners whose protocol this controller cannot serve (`TCP`, `TLS`, `UDP`) are marked `Accepted=False, Reason=UnsupportedProtocol` on the listener status.
 
 Unsupported filters fail closed: per the Gateway API spec an `ExtensionRef`, `ExternalAuth`, or unknown HTTPRoute filter type — and any GRPCRoute filter, none of which are served yet — must not be silently skipped. Requests matching the affected rule receive HTTP 500 (a rule-level filter takes the whole rule down; a per-backend filter fails only that backend's traffic fraction) rather than being served without the dropped filter.
 
@@ -102,12 +105,12 @@ Gateway listeners follow Gateway API specification. Some fields are ignored beca
 | Field | Status | Notes |
 |-------|--------|-------|
 | `port` | Ignored | Cloudflare uses 443/80 |
-| `protocol` | Ignored | Cloudflare handles protocols |
+| `protocol` | Validated | Only `HTTP` and `HTTPS` listeners are served (they carry HTTPRoute / GRPCRoute). A `TCP`, `TLS`, or `UDP` listener has no data plane here and is marked `Accepted=False, Reason=UnsupportedProtocol` (and not Programmed) on its listener status |
 | `hostname` | Supported | Routes must have intersecting hostnames |
 | `tls` | Ignored | Cloudflare manages TLS |
 | `allowedRoutes` | Supported | Namespace (Same/All/Selector) and kind filtering |
 
-This is because Cloudflare Tunnel terminates TLS at Cloudflare's edge, not in the cluster. However, `hostname` and `allowedRoutes` are validated per Gateway API specification.
+This is because Cloudflare Tunnel terminates TLS at Cloudflare's edge, not in the cluster. However, `hostname` and `allowedRoutes` are validated per Gateway API specification. The same `Accepted=False, Reason=UnsupportedProtocol` listener verdict applies to ListenerSet entries.
 
 ## Backend Protocol (`Service.spec.ports[].appProtocol`)
 
@@ -125,13 +128,13 @@ The upstream conformance test `HTTPRouteBackendProtocolWebSocket` is not testabl
 
 ### Interaction with `appProtocol: kubernetes.io/ws`
 
-When a backend Service carries both `appProtocol: kubernetes.io/ws` AND a `BackendTLSPolicy` targeting the same Service, the TLS policy wins: `resolveBackendTLS` rewrites the URL to `https://`, the proxy completes a TLS handshake, and the WebSocket upgrade runs over TLS regardless of the cleartext appProtocol hint. A WARN surfaces the suppressed `ws` hint so operators can either drop the BackendTLSPolicy (if they actually wanted cleartext WebSocket) or flip the hint to `kubernetes.io/wss` (if they wanted the TLS-protected variant all along).
+When a backend Service carries both `appProtocol: kubernetes.io/ws` AND a `BackendTLSPolicy` targeting the same Service, the TLS policy wins: `resolveBackendTLS` rewrites the URL to `https://`, the proxy completes a TLS handshake, and the WebSocket upgrade runs over TLS regardless of the cleartext appProtocol hint. The config is applied successfully, so this is surfaced as a Normal Kubernetes Event (reason `ConfigOverridden`) on the route — not a condition — so operators can either drop the BackendTLSPolicy (if they actually wanted cleartext WebSocket) or flip the hint to `kubernetes.io/wss` (if they wanted the TLS-protected variant all along). The same Normal event fires for `appProtocol: kubernetes.io/h2c` suppressed by a BackendTLSPolicy.
 
 ### `ResponseHeaderModifier` MUST preserve WebSocket handshake headers
 
 The L7 proxy applies route-level + per-backend `ResponseHeaderModifier` filters to every backend response, including the 101 Switching Protocols response that carries the WebSocket handshake. Per Gateway API spec the filter pipeline runs unconditionally; the proxy makes no exception for upgrade responses. The operator-facing consequence: a `Remove` list that strips `Sec-WebSocket-Accept`, `Upgrade`, or `Connection` on a route whose backend is WS-marked silently breaks every upgrade on that route. The 101 reaches the client missing a header the RFC 6455 handshake requires, and the client just disconnects.
 
-The converter scans rule-level and per-backend `ResponseHeaderModifier` filters at HTTPRoute apply time. If a `Remove` list on a WS-marked route intersects `{Sec-WebSocket-Accept, Upgrade, Connection}`, the controller logs a WARN naming the offending header(s) and the filter scope (`rule` or `backend`). The filter still applies as configured — the warning is a diagnostic, not a hard rejection, because the misconfiguration is operator-fixable and bypassing the filter would silently violate spec.
+The converter scans rule-level and per-backend `ResponseHeaderModifier` filters at HTTPRoute apply time. If a `Remove` list on a WS-marked route intersects `{Sec-WebSocket-Accept, Upgrade, Connection}`, the controller emits a Warning Kubernetes Event (reason `ConfigOverridden`) on the route naming the offending header(s) and the filter scope (`rule` or `backend`). The filter still applies as configured — the event is a diagnostic, not a hard rejection, because the misconfiguration is operator-fixable and bypassing the filter would silently violate spec.
 
 Same guidance applies symmetrically to `Set` overriding these headers with a non-handshake-compatible value, though that is rarer and not currently checked.
 

--- a/internal/controller/diagnostic_events_test.go
+++ b/internal/controller/diagnostic_events_test.go
@@ -71,6 +71,29 @@ func TestEmitDiagnosticEvents_NormalAndWarning(t *testing.T) {
 	assert.Contains(t, warning, "Sec-WebSocket-Accept", "Warning event must carry the conflict message")
 }
 
+// TestEmitDiagnosticEvents_MessageWithPercentIsLiteral pins that a diagnostic
+// message containing a literal % is emitted verbatim. Eventf treats its note as
+// a format string, so passing diag.Message as the format (instead of a "%s"
+// argument) would render "50%!(NOVERB)" garbage for any future message that
+// embeds user-controlled data with a percent sign.
+func TestEmitDiagnosticEvents_MessageWithPercentIsLiteral(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"}}
+	diagnostics := []proxy.RouteDiagnostic{
+		{Target: proxy.DiagnosticEvent, EventType: proxy.EventTypeNormal, Message: "appProtocol foo%bar overridden; 50% applied"},
+	}
+
+	rec := events.NewFakeRecorder(5)
+	emitDiagnosticEvents(rec, route, diagnostics)
+
+	got := drainEvents(rec)
+	require.Len(t, got, 1)
+	assert.Contains(t, got[0], "foo%bar", "a literal %% in the message must survive verbatim")
+	assert.Contains(t, got[0], "50% applied")
+	assert.NotContains(t, got[0], "NOVERB", "the message must not be mis-parsed as a format string")
+}
+
 // TestEmitDiagnosticEvents_NilRecorder is a no-op-safety pin: a nil recorder
 // (e.g. a reconciler constructed in a test without one) must not panic.
 func TestEmitDiagnosticEvents_NilRecorder(t *testing.T) {

--- a/internal/controller/diagnostic_events_test.go
+++ b/internal/controller/diagnostic_events_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -8,9 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/api/v1alpha1"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
 )
 
@@ -78,4 +82,77 @@ func TestEmitDiagnosticEvents_NilRecorder(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() { emitDiagnosticEvents(nil, route, diagnostics) })
+}
+
+// eventDiagSchemeAndClient builds the scheme and a fake client builder with the
+// API types the reconciler event-emission tests need.
+func eventDiagSchemeAndClient(t *testing.T) (*runtime.Scheme, *fake.ClientBuilder) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	return scheme, fake.NewClientBuilder().WithScheme(scheme)
+}
+
+// TestHTTPRouteReconciler_updateRouteStatus_EmitsEvent pins that the HTTPRoute
+// reconciler routes an Event-target diagnostic to its Recorder during status
+// update. This guards against the recorder being left unwired (the bug where
+// the reconciler is constructed without a Recorder would silently swallow every
+// benign-override Event in production).
+func TestHTTPRouteReconciler_updateRouteStatus_EmitsEvent(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"}}
+	scheme, builder := eventDiagSchemeAndClient(t)
+	cli := builder.WithObjects(route).WithStatusSubresource(route).Build()
+
+	rec := events.NewFakeRecorder(5)
+	r := &HTTPRouteReconciler{
+		Client:         cli,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		Recorder:       rec,
+	}
+
+	diagnostics := []proxy.RouteDiagnostic{
+		{Namespace: "default", Name: "web", Target: proxy.DiagnosticEvent, EventType: proxy.EventTypeNormal, Message: "h2c suppressed by BackendTLSPolicy"},
+	}
+
+	require.NoError(t, r.updateRouteStatus(context.Background(), route, routeBindingInfo{}, nil, diagnostics, nil))
+
+	got := drainEvents(rec)
+	require.Len(t, got, 1, "the HTTPRoute reconciler must emit the Event-target diagnostic")
+	assert.Contains(t, got[0], "h2c suppressed")
+}
+
+// TestGRPCRouteReconciler_updateRouteStatus_EmitsEvent is the same pin for the
+// GRPCRoute reconciler — it caught a real bug where the reconciler was
+// constructed in manager.go without a Recorder, so its Events were dropped.
+func TestGRPCRouteReconciler_updateRouteStatus_EmitsEvent(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.GRPCRoute{ObjectMeta: metav1.ObjectMeta{Name: "grpc", Namespace: "default"}}
+	scheme, builder := eventDiagSchemeAndClient(t)
+	cli := builder.WithObjects(route).WithStatusSubresource(route).Build()
+
+	rec := events.NewFakeRecorder(5)
+	r := &GRPCRouteReconciler{
+		Client:         cli,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		Recorder:       rec,
+	}
+
+	diagnostics := []proxy.RouteDiagnostic{
+		{Namespace: "default", Name: "grpc", Target: proxy.DiagnosticEvent, EventType: proxy.EventTypeNormal, Message: "h2c suppressed by BackendTLSPolicy"},
+	}
+
+	require.NoError(t, r.updateRouteStatus(context.Background(), route, routeBindingInfo{}, nil, diagnostics, nil))
+
+	got := drainEvents(rec)
+	require.Len(t, got, 1, "the GRPCRoute reconciler must emit the Event-target diagnostic")
+	assert.Contains(t, got[0], "h2c suppressed")
 }

--- a/internal/controller/diagnostic_events_test.go
+++ b/internal/controller/diagnostic_events_test.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// drainEvents collects everything currently buffered on a FakeRecorder without
+// blocking once the channel is empty.
+func drainEvents(rec *events.FakeRecorder) []string {
+	var got []string
+
+	for {
+		select {
+		case e := <-rec.Events:
+			got = append(got, e)
+		default:
+			return got
+		}
+	}
+}
+
+// TestEmitDiagnosticEvents_NormalAndWarning pins that Event-target diagnostics
+// are emitted to the recorder with the right type (Normal / Warning) and the
+// diagnostic message, and that non-Event diagnostics (Accepted / ResolvedRefs)
+// produce no events — those are conditions, not events.
+func TestEmitDiagnosticEvents_NormalAndWarning(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+	}
+
+	diagnostics := []proxy.RouteDiagnostic{
+		{Target: proxy.DiagnosticEvent, EventType: proxy.EventTypeNormal, Message: "h2c suppressed by BackendTLSPolicy"},
+		{Target: proxy.DiagnosticEvent, EventType: proxy.EventTypeWarning, Message: "ResponseHeaderModifier strips Sec-WebSocket-Accept"},
+		{Target: proxy.DiagnosticAccepted, Reason: string(gatewayv1.RouteReasonUnsupportedValue), Message: "a condition, not an event"},
+	}
+
+	rec := events.NewFakeRecorder(10)
+	emitDiagnosticEvents(rec, route, diagnostics)
+
+	got := drainEvents(rec)
+	require.Len(t, got, 2, "only the two Event-target diagnostics must produce events")
+
+	var normal, warning string
+
+	for _, e := range got {
+		switch {
+		case strings.HasPrefix(e, corev1.EventTypeNormal+" "):
+			normal = e
+		case strings.HasPrefix(e, corev1.EventTypeWarning+" "):
+			warning = e
+		}
+	}
+
+	assert.Contains(t, normal, "h2c suppressed", "Normal event must carry the benign-override message")
+	assert.Contains(t, warning, "Sec-WebSocket-Accept", "Warning event must carry the conflict message")
+}
+
+// TestEmitDiagnosticEvents_NilRecorder is a no-op-safety pin: a nil recorder
+// (e.g. a reconciler constructed in a test without one) must not panic.
+func TestEmitDiagnosticEvents_NilRecorder(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"}}
+	diagnostics := []proxy.RouteDiagnostic{
+		{Target: proxy.DiagnosticEvent, EventType: proxy.EventTypeNormal, Message: "no recorder"},
+	}
+
+	assert.NotPanics(t, func() { emitDiagnosticEvents(nil, route, diagnostics) })
+}

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -274,19 +274,22 @@ func (r *GatewayReconciler) updateStatus(
 				programmedCondition.Message = listenerMsgInvalidUnresolved
 			}
 
+			acceptedCondition := buildListenerAcceptedCondition(listener.Protocol, freshGateway.Generation, now)
+
+			// A listener this controller cannot serve at all (unsupported
+			// protocol) is not programmed either.
+			if acceptedCondition.Status == metav1.ConditionFalse {
+				programmedCondition.Status = metav1.ConditionFalse
+				programmedCondition.Reason = string(gatewayv1.ListenerReasonInvalid)
+				programmedCondition.Message = acceptedCondition.Message
+			}
+
 			listenerStatuses = append(listenerStatuses, gatewayv1.ListenerStatus{
 				Name:           listener.Name,
 				SupportedKinds: supportedKinds,
 				AttachedRoutes: attachedRoutes[listener.Name],
 				Conditions: []metav1.Condition{
-					{
-						Type:               string(gatewayv1.ListenerConditionAccepted),
-						Status:             metav1.ConditionTrue,
-						ObservedGeneration: freshGateway.Generation,
-						LastTransitionTime: now,
-						Reason:             string(gatewayv1.ListenerReasonAccepted),
-						Message:            listenerMsgAccepted,
-					},
+					acceptedCondition,
 					programmedCondition,
 					resolvedRefsCondition,
 				},
@@ -768,6 +771,38 @@ func (r *GatewayReconciler) gatewayReferencesSecretsInNamespace(
 	}
 
 	return false
+}
+
+// buildListenerAcceptedCondition builds the per-listener Accepted condition.
+// This controller serves only HTTP and HTTPS listeners (which carry HTTPRoute /
+// GRPCRoute through the in-process proxy). TCP, TLS, and UDP listeners have no
+// data plane here — Cloudflare Tunnel is HTTP-focused and terminates TLS at the
+// edge — so they are Accepted=False / UnsupportedProtocol per the Gateway API
+// spec rather than the misleading Accepted=True they would otherwise get.
+func buildListenerAcceptedCondition(protocol gatewayv1.ProtocolType, generation int64, now metav1.Time) metav1.Condition {
+	condition := metav1.Condition{
+		Type:               string(gatewayv1.ListenerConditionAccepted),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: generation,
+		LastTransitionTime: now,
+		Reason:             string(gatewayv1.ListenerReasonAccepted),
+		Message:            listenerMsgAccepted,
+	}
+
+	switch protocol {
+	case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
+		return condition
+	case gatewayv1.TCPProtocolType, gatewayv1.TLSProtocolType, gatewayv1.UDPProtocolType:
+		// No TCP/TLS/UDPRoute data plane — fall through to unsupported below.
+	}
+
+	condition.Status = metav1.ConditionFalse
+	condition.Reason = string(gatewayv1.ListenerReasonUnsupportedProtocol)
+	condition.Message = "Listener protocol " + string(protocol) + " is not supported; " +
+		"this controller serves only HTTP and HTTPS listeners (HTTPRoute / GRPCRoute) through Cloudflare Tunnel. " +
+		"Use an HTTP or HTTPS listener."
+
+	return condition
 }
 
 // validateTLSCertificateRefs validates TLS certificate references for a listener.

--- a/internal/controller/gateway_listener_protocol_test.go
+++ b/internal/controller/gateway_listener_protocol_test.go
@@ -1,0 +1,135 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/api/v1alpha1"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/cfmetrics"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/config"
+)
+
+// gatewayWithListeners builds a managed Gateway with the given listeners and the
+// minimal GatewayClass/Config/Secret fixtures the reconciler needs.
+func gatewayWithListenersFixture(listeners []gatewayv1.Listener) (*gatewayv1.Gateway, *corev1.Secret, *v1alpha1.GatewayClassConfig, *gatewayv1.GatewayClass) {
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cloudflare-tunnel",
+			Listeners:        listeners,
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cf-credentials", Namespace: "default"},
+		Data:       map[string][]byte{"api-token": []byte("test-token")},
+	}
+	gcc := &v1alpha1.GatewayClassConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
+		Spec: v1alpha1.GatewayClassConfigSpec{
+			CloudflareCredentialsSecretRef: v1alpha1.SecretReference{Name: "cf-credentials", Namespace: "default"},
+			TunnelID:                       "12345678-1234-1234-1234-123456789abc",
+		},
+	}
+	gc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-tunnel"},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "test-controller",
+			ParametersRef: &gatewayv1.ParametersReference{
+				Group: config.ParametersRefGroup,
+				Kind:  config.ParametersRefKind,
+				Name:  "test-config",
+			},
+		},
+	}
+
+	return gateway, secret, gcc, gc
+}
+
+// reconcileGatewayListeners reconciles the fixture and returns the listener
+// statuses written to the Gateway.
+func reconcileGatewayListeners(t *testing.T, listeners []gatewayv1.Listener) []gatewayv1.ListenerStatus {
+	t.Helper()
+
+	gateway, secret, gcc, gc := gatewayWithListenersFixture(listeners)
+	fakeClient := setupGatewayFakeClient(gateway, secret, gcc, gc)
+	reconciler := &GatewayReconciler{
+		Client:         fakeClient,
+		Scheme:         fakeClient.Scheme(),
+		ControllerName: "test-controller",
+		ConfigResolver: config.NewResolver(fakeClient, "default", cfmetrics.NewNoopCollector()),
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-gateway", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var updated gatewayv1.Gateway
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Name: "test-gateway", Namespace: "default"}, &updated))
+
+	return updated.Status.Listeners
+}
+
+// TestGatewayReconciler_UnsupportedListenerProtocol_AcceptedFalse pins that a
+// listener whose protocol this controller cannot serve (TCP / TLS / UDP — there
+// are no TCP/TLS/UDPRoute data planes; Cloudflare Tunnel is HTTP-focused) is
+// marked Accepted=False / UnsupportedProtocol rather than the misleading
+// Accepted=True it used to get unconditionally.
+func TestGatewayReconciler_UnsupportedListenerProtocol_AcceptedFalse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		protocol gatewayv1.ProtocolType
+	}{
+		{"TCP", gatewayv1.TCPProtocolType},
+		{"TLS", gatewayv1.TLSProtocolType},
+		{"UDP", gatewayv1.UDPProtocolType},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			statuses := reconcileGatewayListeners(t, []gatewayv1.Listener{
+				{Name: "l", Port: 443, Protocol: tc.protocol},
+			})
+
+			require.Len(t, statuses, 1)
+			accepted := findCondition(statuses[0].Conditions, string(gatewayv1.ListenerConditionAccepted))
+			require.NotNil(t, accepted)
+			assert.Equal(t, metav1.ConditionFalse, accepted.Status,
+				"a listener with an unservable protocol must be Accepted=False")
+			assert.Equal(t, string(gatewayv1.ListenerReasonUnsupportedProtocol), accepted.Reason)
+			assert.Contains(t, accepted.Message, string(tc.protocol), "message must name the unsupported protocol")
+		})
+	}
+}
+
+// TestGatewayReconciler_HTTPListener_Accepted confirms the happy path: an HTTP
+// (and HTTPS) listener stays Accepted=True — those carry HTTPRoute / GRPCRoute
+// which the in-process proxy serves.
+func TestGatewayReconciler_HTTPListener_Accepted(t *testing.T) {
+	t.Parallel()
+
+	for _, proto := range []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType} {
+		statuses := reconcileGatewayListeners(t, []gatewayv1.Listener{
+			{Name: "l", Port: 80, Protocol: proto},
+		})
+
+		require.Len(t, statuses, 1)
+		accepted := findCondition(statuses[0].Conditions, string(gatewayv1.ListenerConditionAccepted))
+		require.NotNil(t, accepted)
+		assert.Equal(t, metav1.ConditionTrue, accepted.Status,
+			"%s listener must stay Accepted=True", proto)
+	}
+}

--- a/internal/controller/grpcroute_controller.go
+++ b/internal/controller/grpcroute_controller.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/ingress"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/logging"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/routebinding"
 )
 
@@ -131,8 +132,8 @@ func (r *GRPCRouteReconciler) syncAndUpdateStatus(ctx context.Context) (ctrl.Res
 		// route — same model as the HTTPRoute reconciler.
 		pushProxy:      true,
 		tunnelProtocol: r.TunnelProtocol,
-		statusEntries: func(sr *SyncResult) []routeStatusEntry {
-			return sr.grpcStatusEntries(r.updateRouteStatus)
+		statusEntries: func(sr *SyncResult, diags []proxy.RouteDiagnostic) []routeStatusEntry {
+			return sr.grpcStatusEntries(diags, r.updateRouteStatus)
 		},
 	})
 }
@@ -146,11 +147,13 @@ func (r *GRPCRouteReconciler) updateRouteStatus(
 	route *gatewayv1.GRPCRoute,
 	bindingInfo routeBindingInfo,
 	failedRefs []ingress.BackendRefError,
+	diagnostics []proxy.RouteDiagnostic,
 	syncErr error,
 ) error {
 	params := routeStatusUpdateParams{
 		k8sClient:      r.Client,
 		controllerName: r.ControllerName,
+		diagnostics:    diagnostics,
 	}
 
 	// gRPC over an explicit quic tunnel cannot be served (cloudflared drops HTTP

--- a/internal/controller/grpcroute_controller.go
+++ b/internal/controller/grpcroute_controller.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -97,6 +98,10 @@ type GRPCRouteReconciler struct {
 	// ProxyEndpoints is the list of L7 proxy config-API URLs to push to.
 	ProxyEndpoints []string
 
+	// Recorder emits Kubernetes Events for benign config overrides. May be nil
+	// in unit tests, in which case event emission is a no-op.
+	Recorder events.EventRecorder
+
 	// TunnelProtocol is the configured edge transport (auto|http2|quic). Used
 	// to warn when GRPCRoutes are present on an explicit quic tunnel, where
 	// cloudflared drops the grpc-status trailer. auto/unset is upgraded to http2
@@ -150,6 +155,8 @@ func (r *GRPCRouteReconciler) updateRouteStatus(
 	diagnostics []proxy.RouteDiagnostic,
 	syncErr error,
 ) error {
+	emitDiagnosticEvents(r.Recorder, route, diagnostics)
+
 	params := routeStatusUpdateParams{
 		k8sClient:      r.Client,
 		controllerName: r.ControllerName,

--- a/internal/controller/grpcroute_controller_test.go
+++ b/internal/controller/grpcroute_controller_test.go
@@ -969,7 +969,7 @@ func TestGRPCRouteReconciler_UpdateRouteStatus_Integration(t *testing.T) {
 			},
 		},
 	}
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.GRPCRoute
@@ -1112,7 +1112,7 @@ func TestGRPCRouteReconciler_UpdateRouteStatus_QuicUnsupportedProtocol(t *testin
 				bindingResults: map[int]routebinding.BindingResult{0: binding},
 			}
 
-			require.NoError(t, r.updateRouteStatus(context.Background(), route, bindingInfo, nil, tt.syncErr))
+			require.NoError(t, r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, tt.syncErr))
 
 			var updated gatewayv1.GRPCRoute
 			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "test-route", Namespace: "default"}, &updated))
@@ -1207,7 +1207,7 @@ func TestGRPCRouteReconciler_UpdateRouteStatus_NotAccepted(t *testing.T) {
 			},
 		},
 	}
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.GRPCRoute
@@ -1443,7 +1443,7 @@ func TestGRPCRouteReconciler_UpdateRouteStatus_WithSyncError(t *testing.T) {
 			0: {Accepted: true, Reason: gatewayv1.RouteReasonAccepted, Message: "Accepted"},
 		},
 	}
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, syncErr)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, syncErr)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.GRPCRoute
@@ -1538,7 +1538,7 @@ func TestGRPCRouteReconciler_UpdateRouteStatus_WithFailedBackendRefs(t *testing.
 		},
 	}
 
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, failedRefs, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, failedRefs, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.GRPCRoute
@@ -1606,7 +1606,7 @@ func TestGRPCRouteReconciler_UpdateRouteStatus_NonGatewayParentRef(t *testing.T)
 	}
 
 	bindingInfo := routeBindingInfo{bindingResults: map[int]routebinding.BindingResult{}}
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.GRPCRoute
@@ -1814,7 +1814,7 @@ func TestGRPCRouteReconciler_UpdateRouteStatus_MultipleParents(t *testing.T) {
 		},
 	}
 
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.GRPCRoute
@@ -1915,7 +1915,7 @@ func TestGRPCRouteReconciler_UpdateRouteStatus_ExplicitNamespace(t *testing.T) {
 		},
 	}
 
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.GRPCRoute
@@ -1993,7 +1993,7 @@ func TestGRPCRouteReconciler_UpdateRouteStatus_MultipleFailedBackendRefs(t *test
 		{RouteNamespace: "default", RouteName: "test-route", BackendNS: "ns2", BackendName: "svc2"},
 	}
 
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, failedRefs, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, failedRefs, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.GRPCRoute

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/ingress"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/logging"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/routebinding"
 )
 
@@ -97,8 +98,8 @@ func (r *HTTPRouteReconciler) syncAndUpdateStatus(ctx context.Context) (ctrl.Res
 		proxySyncer:    r.ProxySyncer,
 		proxyEndpoints: r.ProxyEndpoints,
 		pushProxy:      true,
-		statusEntries: func(sr *SyncResult) []routeStatusEntry {
-			return sr.httpStatusEntries(r.updateRouteStatus)
+		statusEntries: func(sr *SyncResult, diags []proxy.RouteDiagnostic) []routeStatusEntry {
+			return sr.httpStatusEntries(diags, r.updateRouteStatus)
 		},
 	})
 }
@@ -132,6 +133,7 @@ func (r *HTTPRouteReconciler) updateRouteStatus(
 	route *gatewayv1.HTTPRoute,
 	bindingInfo routeBindingInfo,
 	failedRefs []ingress.BackendRefError,
+	diagnostics []proxy.RouteDiagnostic,
 	syncErr error,
 ) error {
 	return updateRouteStatusGeneric(
@@ -139,6 +141,7 @@ func (r *HTTPRouteReconciler) updateRouteStatus(
 		routeStatusUpdateParams{
 			k8sClient:      r.Client,
 			controllerName: r.ControllerName,
+			diagnostics:    diagnostics,
 		},
 		types.NamespacedName{Name: route.Name, Namespace: route.Namespace},
 		newHTTPRouteAccessor,

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -73,6 +74,11 @@ type HTTPRouteReconciler struct {
 	// ProxyEndpoints is the list of L7 proxy config-API URLs.
 	ProxyEndpoints []string
 
+	// Recorder emits Kubernetes Events for benign config overrides (e.g. an
+	// appProtocol cleartext hint superseded by a BackendTLSPolicy). May be nil
+	// in unit tests, in which case event emission is a no-op.
+	Recorder events.EventRecorder
+
 	// bindingValidator validates route binding to Gateway listeners.
 	bindingValidator *routebinding.Validator
 
@@ -136,6 +142,8 @@ func (r *HTTPRouteReconciler) updateRouteStatus(
 	diagnostics []proxy.RouteDiagnostic,
 	syncErr error,
 ) error {
+	emitDiagnosticEvents(r.Recorder, route, diagnostics)
+
 	return updateRouteStatusGeneric(
 		ctx,
 		routeStatusUpdateParams{

--- a/internal/controller/httproute_controller_test.go
+++ b/internal/controller/httproute_controller_test.go
@@ -1153,7 +1153,7 @@ func TestHTTPRouteReconciler_UpdateRouteStatus_Integration(t *testing.T) {
 			},
 		},
 	}
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Verify status was updated
@@ -1248,7 +1248,7 @@ func TestHTTPRouteReconciler_UpdateRouteStatus_NotAccepted(t *testing.T) {
 			},
 		},
 	}
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Verify status was updated
@@ -1493,7 +1493,7 @@ func TestHTTPRouteReconciler_UpdateRouteStatus_WithSyncError(t *testing.T) {
 	}
 
 	syncErr := assert.AnError
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, syncErr)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, syncErr)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.HTTPRoute
@@ -1589,7 +1589,7 @@ func TestHTTPRouteReconciler_UpdateRouteStatus_WithFailedBackendRefs(t *testing.
 		},
 	}
 
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, failedRefs, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, failedRefs, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.HTTPRoute
@@ -1690,7 +1690,7 @@ func TestHTTPRouteReconciler_UpdateRouteStatus_MultipleParents(t *testing.T) {
 		},
 	}
 
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.HTTPRoute
@@ -1749,7 +1749,7 @@ func TestHTTPRouteReconciler_UpdateRouteStatus_NonGatewayParentRef(t *testing.T)
 		bindingResults: map[int]routebinding.BindingResult{},
 	}
 
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.HTTPRoute
@@ -1989,7 +1989,7 @@ func TestHTTPRouteReconciler_UpdateRouteStatus_ParentRefWithExplicitNamespace(t 
 		},
 	}
 
-	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil)
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
 	require.NoError(t, err)
 
 	var updatedRoute gatewayv1.HTTPRoute

--- a/internal/controller/listenerset_controller.go
+++ b/internal/controller/listenerset_controller.go
@@ -640,7 +640,7 @@ func buildListenerSetEntryStatuses(
 			SupportedKinds: supportedKinds,
 			AttachedRoutes: attached,
 			Conditions: listenerEntryConditions(
-				generation, now, merge, hasValidKind, hasInvalidKind, refCheck, hasRefCheck,
+				generation, now, merge, entry.Protocol, hasValidKind, hasInvalidKind, refCheck, hasRefCheck,
 			),
 		})
 	}
@@ -800,6 +800,7 @@ func listenerEntryConditions(
 	generation int64,
 	now metav1.Time,
 	merge *listenermerge.MergedListener,
+	protocol gatewayv1.ProtocolType,
 	hasValidKind, hasInvalidKind bool,
 	refCheck listenerEntryRefsCheck,
 	hasRefCheck bool,
@@ -821,7 +822,7 @@ func listenerEntryConditions(
 		return conflictedEntryConditions(generation, now, merge, &resolvedRefsCondition)
 	}
 
-	return acceptedEntryConditions(generation, now, &resolvedRefsCondition)
+	return acceptedEntryConditions(generation, now, protocol, &resolvedRefsCondition)
 }
 
 func conflictedEntryConditions(
@@ -864,27 +865,30 @@ func conflictedEntryConditions(
 func acceptedEntryConditions(
 	generation int64,
 	now metav1.Time,
+	protocol gatewayv1.ProtocolType,
 	resolvedRefs *metav1.Condition,
 ) []metav1.Condition {
+	acceptedCondition := buildListenerAcceptedCondition(protocol, generation, now)
+
 	programmedStatus := metav1.ConditionTrue
 	programmedReason := string(gatewayv1.ListenerReasonProgrammed)
 	programmedMessage := listenerMsgProgrammed
 
-	if resolvedRefs.Status == metav1.ConditionFalse {
+	// An unservable protocol or an unresolved ref both mean the entry is not
+	// programmed; the protocol rejection is the more fundamental of the two.
+	switch {
+	case acceptedCondition.Status == metav1.ConditionFalse:
+		programmedStatus = metav1.ConditionFalse
+		programmedReason = string(gatewayv1.ListenerReasonInvalid)
+		programmedMessage = acceptedCondition.Message
+	case resolvedRefs.Status == metav1.ConditionFalse:
 		programmedStatus = metav1.ConditionFalse
 		programmedReason = string(gatewayv1.ListenerReasonInvalid)
 		programmedMessage = listenerMsgInvalidUnresolved
 	}
 
 	return []metav1.Condition{
-		{
-			Type:               string(gatewayv1.ListenerConditionAccepted),
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: generation,
-			LastTransitionTime: now,
-			Reason:             string(gatewayv1.ListenerReasonAccepted),
-			Message:            listenerMsgAccepted,
-		},
+		acceptedCondition,
 		{
 			Type:               string(gatewayv1.ListenerConditionProgrammed),
 			Status:             programmedStatus,

--- a/internal/controller/listenerset_protocol_test.go
+++ b/internal/controller/listenerset_protocol_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// resolvedRefsTrue is the "all refs resolved" condition the accepted-entry path
+// receives when an entry's kinds and TLS refs are clean.
+func resolvedRefsTrue() *metav1.Condition {
+	return &metav1.Condition{
+		Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+		Status: metav1.ConditionTrue,
+		Reason: string(gatewayv1.ListenerReasonResolvedRefs),
+	}
+}
+
+// TestAcceptedEntryConditions_UnsupportedProtocol pins that a ListenerSet entry
+// whose protocol this controller cannot serve is Accepted=False /
+// UnsupportedProtocol and not Programmed, mirroring the Gateway listener path.
+func TestAcceptedEntryConditions_UnsupportedProtocol(t *testing.T) {
+	t.Parallel()
+
+	for _, proto := range []gatewayv1.ProtocolType{
+		gatewayv1.TCPProtocolType, gatewayv1.TLSProtocolType, gatewayv1.UDPProtocolType,
+	} {
+		conds := acceptedEntryConditions(1, metav1.Now(), proto, resolvedRefsTrue())
+
+		accepted := findCondition(conds, string(gatewayv1.ListenerConditionAccepted))
+		require.NotNil(t, accepted)
+		assert.Equal(t, metav1.ConditionFalse, accepted.Status, "%s entry must be Accepted=False", proto)
+		assert.Equal(t, string(gatewayv1.ListenerReasonUnsupportedProtocol), accepted.Reason)
+
+		programmed := findCondition(conds, string(gatewayv1.ListenerConditionProgrammed))
+		require.NotNil(t, programmed)
+		assert.Equal(t, metav1.ConditionFalse, programmed.Status,
+			"an unservable-protocol entry must not be Programmed")
+	}
+}
+
+// TestAcceptedEntryConditions_HTTPStaysAccepted confirms an HTTP entry with
+// resolved refs stays Accepted=True and Programmed=True.
+func TestAcceptedEntryConditions_HTTPStaysAccepted(t *testing.T) {
+	t.Parallel()
+
+	conds := acceptedEntryConditions(1, metav1.Now(), gatewayv1.HTTPProtocolType, resolvedRefsTrue())
+
+	accepted := findCondition(conds, string(gatewayv1.ListenerConditionAccepted))
+	require.NotNil(t, accepted)
+	assert.Equal(t, metav1.ConditionTrue, accepted.Status)
+
+	programmed := findCondition(conds, string(gatewayv1.ListenerConditionProgrammed))
+	require.NotNil(t, programmed)
+	assert.Equal(t, metav1.ConditionTrue, programmed.Status)
+}

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -207,6 +207,7 @@ func Run(ctx context.Context, cfg *Config) error {
 		RouteSyncer:    routeSyncer,
 		ProxySyncer:    proxySyncer,
 		ProxyEndpoints: proxyEndpoints,
+		Recorder:       mgr.GetEventRecorder("httproute-controller"),
 	}
 
 	if err := httpRouteReconciler.SetupWithManager(mgr); err != nil {

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -222,6 +222,7 @@ func Run(ctx context.Context, cfg *Config) error {
 		ProxySyncer:    proxySyncer,
 		ProxyEndpoints: proxyEndpoints,
 		TunnelProtocol: cfg.TunnelProtocol,
+		Recorder:       mgr.GetEventRecorder("grpcroute-controller"),
 	}
 
 	if err := grpcRouteReconciler.SetupWithManager(mgr); err != nil {

--- a/internal/controller/proxy_syncer.go
+++ b/internal/controller/proxy_syncer.go
@@ -592,7 +592,7 @@ func (s *ProxySyncer) SyncRoutes(
 	grpcRoutes []*gatewayv1.GRPCRoute,
 	failedRefs []ingress.BackendRefError,
 	grpcFailedRefs []ingress.BackendRefError,
-) error {
+) ([]proxy.RouteDiagnostic, error) {
 	// Resolve headless service DNS names before acquiring the lock
 	// to avoid blocking concurrent reconciles during slow DNS lookups.
 	resolved := resolveEndpoints(ctx, endpoints)
@@ -608,6 +608,12 @@ func (s *ProxySyncer) SyncRoutes(
 	logger.Info("syncing proxy config", "httpRoutes", len(routes), "grpcRoutes", len(grpcRoutes))
 
 	cfg := s.buildProxyConfig(ctx, routes, grpcRoutes, failedRefs, grpcFailedRefs)
+
+	// Diagnostics are computed by the converter and are valid regardless of
+	// whether the push below succeeds — they describe the route specs, not the
+	// push. Capture them up front so a push failure still surfaces config the
+	// controller will not serve as written on the route status.
+	diagnostics := cfg.Diagnostics
 
 	logger.Info("resolved endpoints",
 		"original", len(endpoints),
@@ -631,7 +637,7 @@ func (s *ProxySyncer) SyncRoutes(
 	}
 
 	if len(pushErrors) > 0 {
-		return fmt.Errorf("failed to push config to %d/%d endpoints: %w",
+		return diagnostics, fmt.Errorf("failed to push config to %d/%d endpoints: %w",
 			len(pushErrors), len(resolved), errors.Join(pushErrors...))
 	}
 
@@ -647,7 +653,7 @@ func (s *ProxySyncer) SyncRoutes(
 	// the cache with a config the replicas never actually received.
 	s.lastCfg = cfg
 
-	return nil
+	return diagnostics, nil
 }
 
 // buildProxyConfig converts the HTTP and gRPC route sets into a single merged
@@ -700,6 +706,7 @@ func (s *ProxySyncer) buildProxyConfig(
 
 		grpcCfg := proxy.ConvertGRPCRoutes(ctx, grpcRoutes, s.clusterDomain, s.grpcBackendValidator, s.tlsResolver, s.gatewayCertResolver)
 		cfg.Rules = append(cfg.Rules, grpcCfg.Rules...)
+		cfg.Diagnostics = append(cfg.Diagnostics, grpcCfg.Diagnostics...)
 
 		// Mark invalid gRPC backendRefs the same way as HTTP. Matching is by
 		// service host:port across all rules, so no rule-offset bookkeeping is

--- a/internal/controller/proxy_syncer_test.go
+++ b/internal/controller/proxy_syncer_test.go
@@ -112,7 +112,7 @@ func TestProxySyncer_SyncRoutes(t *testing.T) {
 
 	endpoints := []string{configServer.URL + "/config"}
 
-	err := syncer.SyncRoutes(context.Background(), endpoints, routes, nil, nil, nil)
+	_, err := syncer.SyncRoutes(context.Background(), endpoints, routes, nil, nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), pushCount.Load())
@@ -154,7 +154,7 @@ func TestProxySyncer_NoRoutes_PushesEmptyConfig(t *testing.T) {
 
 	// Zero routes should still push a valid config with empty rules.
 	// The proxy will return 404 for all requests until routes are added.
-	err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, nil, nil, nil, nil)
+	_, err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), pushCount.Load())
@@ -262,7 +262,9 @@ func TestProxySyncer_ResyncEndpoints_ReplaysLastConfig(t *testing.T) {
 
 	endpoint := configServer.URL + "/config"
 
-	require.NoError(t, syncer.SyncRoutes(context.Background(), []string{endpoint}, routes, nil, nil, nil))
+	_, syncErr := syncer.SyncRoutes(context.Background(), []string{endpoint}, routes, nil, nil, nil)
+
+	require.NoError(t, syncErr)
 	require.Equal(t, int32(1), pushCount.Load(), "first sync must push once")
 	require.NotEmpty(t, firstReceived.Rules, "first push must carry the built config")
 
@@ -338,7 +340,7 @@ func TestProxySyncer_SyncRoutes_H2CBackend(t *testing.T) {
 		},
 	}
 
-	err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, routes, nil, nil, nil)
+	_, err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, routes, nil, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, int32(1), pushCount.Load())
@@ -411,7 +413,7 @@ func TestProxySyncer_SyncRoutes_GRPCRoute(t *testing.T) {
 		},
 	}
 
-	err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, nil, grpcRoutes, nil, nil)
+	_, err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, nil, grpcRoutes, nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, int32(1), pushCount.Load())
@@ -488,7 +490,7 @@ func TestProxySyncer_SyncRoutes_GRPCFailedRefMarked(t *testing.T) {
 		{RouteNamespace: "default", RouteName: "echo", BackendName: "missing-svc", BackendNS: "default", Port: 9000, Reason: "BackendNotFound"},
 	}
 
-	err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, nil, grpcRoutes, nil, grpcFailedRefs)
+	_, err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, nil, grpcRoutes, nil, grpcFailedRefs)
 	require.NoError(t, err)
 
 	require.Len(t, receivedConfig.Rules, 1)
@@ -556,7 +558,7 @@ func TestProxySyncer_SyncRoutes_InvalidPortBackendMarked500(t *testing.T) {
 		{RouteNamespace: "default", RouteName: "bad-port", BackendName: "svc", BackendNS: "default", Port: 70000, Reason: "InvalidPort"},
 	}
 
-	err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, httpRoutes, nil, httpFailedRefs, nil)
+	_, err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, httpRoutes, nil, httpFailedRefs, nil)
 	require.NoError(t, err)
 
 	require.Len(t, receivedConfig.Rules, 1)
@@ -635,7 +637,7 @@ func grpcCrossNamespaceBackendSurvives(t *testing.T, grantFromKind gatewayv1.Kin
 		},
 	}
 
-	err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, nil, grpcRoutes, nil, nil)
+	_, err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, nil, grpcRoutes, nil, nil)
 	require.NoError(t, err)
 
 	require.Len(t, receivedConfig.Rules, 1)
@@ -742,7 +744,9 @@ func TestProxySyncer_SyncRoutes_BackendTLSPolicyMissingCA_FailsClosed(t *testing
 		},
 	}
 
-	require.NoError(t, syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, routes, nil, nil, nil))
+	_, syncErr := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, routes, nil, nil, nil)
+
+	require.NoError(t, syncErr)
 
 	require.Len(t, receivedConfig.Rules, 1)
 	require.Len(t, receivedConfig.Rules[0].Backends, 1)
@@ -835,7 +839,9 @@ func TestProxySyncer_SyncRoutes_BackendTLSPolicy_URISubjectAltName_PushesURIList
 		},
 	}
 
-	require.NoError(t, syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, routes, nil, nil, nil))
+	_, syncErr := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, routes, nil, nil, nil)
+
+	require.NoError(t, syncErr)
 
 	require.Len(t, receivedConfig.Rules, 1)
 	require.Len(t, receivedConfig.Rules[0].Backends, 1)

--- a/internal/controller/route_status.go
+++ b/internal/controller/route_status.go
@@ -7,8 +7,11 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -431,6 +434,41 @@ func firstResolvedRefsDiagnostic(diagnostics []proxy.RouteDiagnostic) (proxy.Rou
 	}
 
 	return proxy.RouteDiagnostic{}, false
+}
+
+// Event reason / action tokens for a benign config override. Kubernetes Events
+// require CamelCase machine-readable reason and action tokens distinct from the
+// human-readable note.
+const (
+	eventReasonConfigOverridden = "ConfigOverridden"
+	eventActionConvert          = "Convert"
+)
+
+// emitDiagnosticEvents emits a Kubernetes Event for each Event-target
+// diagnostic — benign overrides that applied successfully but ignored or
+// superseded a hint (e.g. an appProtocol cleartext hint overridden by a
+// BackendTLSPolicy, or a ResponseHeaderModifier that strips a WebSocket
+// handshake header). These have no standard Gateway API condition, so an Event
+// is the surface. Non-Event diagnostics are skipped — they drive conditions.
+// A nil recorder is a no-op so reconcilers constructed without one (e.g. in
+// unit tests) do not panic.
+func emitDiagnosticEvents(recorder events.EventRecorder, route runtime.Object, diagnostics []proxy.RouteDiagnostic) {
+	if recorder == nil {
+		return
+	}
+
+	for _, diag := range diagnostics {
+		if diag.Target != proxy.DiagnosticEvent {
+			continue
+		}
+
+		eventType := diag.EventType
+		if eventType != corev1.EventTypeWarning {
+			eventType = corev1.EventTypeNormal
+		}
+
+		recorder.Eventf(route, nil, eventType, eventReasonConfigOverridden, eventActionConvert, diag.Message)
+	}
 }
 
 func buildFailedRefsMessage(failedRefs []ingress.BackendRefError) string {

--- a/internal/controller/route_status.go
+++ b/internal/controller/route_status.go
@@ -425,7 +425,13 @@ func buildResolvedRefsCondition(
 }
 
 // firstResolvedRefsDiagnostic returns the first ResolvedRefs-target diagnostic,
-// if any. The status writer surfaces it on the ResolvedRefs condition.
+// if any. The status writer surfaces it on the ResolvedRefs condition. A single
+// condition carries one reason/message, so when a route has several ResolvedRefs
+// problems (e.g. a dropped mirror and an unpoliced TLS appProtocol) only the
+// first is surfaced on the condition — the rest remain in the converter logs.
+// This mirrors the existing failedRefs[0] behaviour for the ingress-builder
+// reasons; the Accepted/PartiallyInvalid path, by contrast, does aggregate all
+// of its messages.
 func firstResolvedRefsDiagnostic(diagnostics []proxy.RouteDiagnostic) (proxy.RouteDiagnostic, bool) {
 	for _, diag := range diagnostics {
 		if diag.Target == proxy.DiagnosticResolvedRefs {

--- a/internal/controller/route_status.go
+++ b/internal/controller/route_status.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"context"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/ingress"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/logging"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
 )
 
 // routeAccessor provides type-agnostic access to Gateway API route fields
@@ -23,6 +26,7 @@ type routeAccessor struct {
 	parentRefs  func() []gatewayv1.ParentReference
 	routeStatus func() *gatewayv1.RouteStatus
 	generation  func() int64
+	ruleCount   func() int
 }
 
 // routeStatusUpdateParams holds the common parameters for updating route status.
@@ -36,6 +40,16 @@ type routeStatusUpdateParams struct {
 	// rejection is a more specific problem and takes precedence, so the override
 	// only applies when the route would otherwise be Accepted=True.
 	acceptedOverride *acceptedConditionOverride
+	// diagnostics are the converter's per-route findings about config that will
+	// not be served exactly as written (e.g. unsupported filters). The status
+	// writer turns them into an Accepted=False/UnsupportedValue override (when
+	// every rule is wholly unservable) or a PartiallyInvalid=True condition
+	// (when only some rules/backends are affected and the route still serves).
+	diagnostics []proxy.RouteDiagnostic
+	// ruleCount is the number of rules in the route spec. It lets the status
+	// writer tell "every rule is unservable" (Accepted=False) apart from "some
+	// rules dropped" (PartiallyInvalid=True).
+	ruleCount int
 }
 
 // acceptedConditionOverride carries the reason/message used to downgrade an
@@ -94,6 +108,10 @@ func updateRouteParentStatuses(
 	routeStatus := accessor.routeStatus()
 	routeStatus.Parents = nil
 
+	// ruleCount comes from the freshly-fetched spec so the diagnostic
+	// aggregation can tell "every rule unservable" from "some rules dropped".
+	params.ruleCount = accessor.ruleCount()
+
 	for refIdx, ref := range accessor.parentRefs() {
 		parentStatus := resolveParentRefStatus(
 			ctx, params, accessor, ref, refIdx, classNames, now, bindingInfo, failedRefs, syncErr,
@@ -140,6 +158,7 @@ func resolveParentRefStatus(
 		bindingInfo, refIdx,
 		failedRefs, syncErr,
 		params.acceptedOverride,
+		params.diagnostics, params.ruleCount,
 	)
 
 	return &parentStatus
@@ -178,8 +197,33 @@ func buildParentStatus(
 	failedRefs []ingress.BackendRefError,
 	syncErr error,
 	acceptedOverride *acceptedConditionOverride,
+	diagnostics []proxy.RouteDiagnostic,
+	ruleCount int,
 ) gatewayv1.RouteParentStatus {
 	parentNS := gatewayv1.Namespace(namespace)
+
+	// Derive the Accepted override and the optional PartiallyInvalid condition
+	// from the converter diagnostics. A caller-supplied override (e.g. the
+	// GRPCRoute reconciler's gRPC-over-quic case) is more specific, so it wins
+	// over a diagnostic-derived whole-route override.
+	diagOverride, partiallyInvalid := diagnosticConditions(diagnostics, ruleCount, generation, now)
+	if acceptedOverride == nil {
+		acceptedOverride = diagOverride
+	}
+
+	accepted := buildAcceptedCondition(generation, now, bindingInfo, refIdx, syncErr, acceptedOverride)
+
+	conditions := []metav1.Condition{
+		accepted,
+		buildResolvedRefsCondition(generation, now, failedRefs),
+	}
+
+	// PartiallyInvalid is only meaningful when the route is otherwise accepted —
+	// the spec mandates it be set only to True, alongside Accepted=True. If the
+	// whole route was rejected, the rejection already tells the full story.
+	if partiallyInvalid != nil && accepted.Status == metav1.ConditionTrue {
+		conditions = append(conditions, *partiallyInvalid)
+	}
 
 	return gatewayv1.RouteParentStatus{
 		ParentRef: gatewayv1.ParentReference{
@@ -191,11 +235,100 @@ func buildParentStatus(
 			SectionName: ref.SectionName,
 		},
 		ControllerName: gatewayv1.GatewayController(controllerName),
-		Conditions: []metav1.Condition{
-			buildAcceptedCondition(generation, now, bindingInfo, refIdx, syncErr, acceptedOverride),
-			buildResolvedRefsCondition(generation, now, failedRefs),
-		},
+		Conditions:     conditions,
 	}
+}
+
+// diagnosticConditions derives, from the converter's per-route Accepted-target
+// diagnostics, either an Accepted=False/UnsupportedValue override (when every
+// rule of the route is wholly unservable) or a PartiallyInvalid=True condition
+// (when only some rules or backend fractions are affected and the route still
+// serves the rest). Returns (nil, nil) when there are no Accepted-target
+// diagnostics. At most one of the two results is non-nil.
+func diagnosticConditions(
+	diagnostics []proxy.RouteDiagnostic,
+	ruleCount int,
+	generation int64,
+	now metav1.Time,
+) (*acceptedConditionOverride, *metav1.Condition) {
+	var accepted []proxy.RouteDiagnostic
+
+	wholeRuleIdx := make(map[int]struct{})
+
+	for _, diag := range diagnostics {
+		if diag.Target != proxy.DiagnosticAccepted {
+			continue
+		}
+
+		accepted = append(accepted, diag)
+
+		if diag.WholeRule {
+			wholeRuleIdx[diag.RuleIndex] = struct{}{}
+		}
+	}
+
+	if len(accepted) == 0 {
+		return nil, nil
+	}
+
+	// Every rule wholly unservable → the route cannot be served at all.
+	if ruleCount > 0 && len(wholeRuleIdx) >= ruleCount {
+		return &acceptedConditionOverride{
+			reason:  string(gatewayv1.RouteReasonUnsupportedValue),
+			message: droppedConfigMessage(accepted, false),
+		}, nil
+	}
+
+	// Otherwise some rules/backends are dropped but the route still serves.
+	return nil, &metav1.Condition{
+		Type:               string(gatewayv1.RouteConditionPartiallyInvalid),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: generation,
+		LastTransitionTime: now,
+		Reason:             string(gatewayv1.RouteReasonUnsupportedValue),
+		Message:            droppedConfigMessage(accepted, true),
+	}
+}
+
+// droppedConfigMessage builds the human-facing condition message for a set of
+// Accepted-target diagnostics. When partial is true the message starts with the
+// "Dropped Rule" prefix the Gateway API spec mandates for the drop-rule
+// PartiallyInvalid approach and lists the affected rule indices; the per-cause
+// detail follows so the operator sees both which rules and why.
+func droppedConfigMessage(diagnostics []proxy.RouteDiagnostic, partial bool) string {
+	ruleIdx := make([]int, 0, len(diagnostics))
+	seenIdx := make(map[int]struct{})
+
+	details := make([]string, 0, len(diagnostics))
+	seenMsg := make(map[string]struct{})
+
+	for _, diag := range diagnostics {
+		if _, ok := seenIdx[diag.RuleIndex]; !ok {
+			seenIdx[diag.RuleIndex] = struct{}{}
+
+			ruleIdx = append(ruleIdx, diag.RuleIndex)
+		}
+
+		if _, ok := seenMsg[diag.Message]; !ok {
+			seenMsg[diag.Message] = struct{}{}
+
+			details = append(details, diag.Message)
+		}
+	}
+
+	slices.Sort(ruleIdx)
+
+	idxStrs := make([]string, 0, len(ruleIdx))
+	for _, idx := range ruleIdx {
+		idxStrs = append(idxStrs, strconv.Itoa(idx))
+	}
+
+	detail := strings.Join(details, " ")
+	if !partial {
+		return detail
+	}
+
+	return "Dropped Rule " + strings.Join(idxStrs, ", ") + ": " + detail
 }
 
 func buildAcceptedCondition(
@@ -290,7 +423,8 @@ type routeStatusEntry struct {
 	namespace   string
 	bindingInfo routeBindingInfo
 	failedRefs  []ingress.BackendRefError
-	update      func(ctx context.Context, bindingInfo routeBindingInfo, failedRefs []ingress.BackendRefError, syncErr error) error
+	diagnostics []proxy.RouteDiagnostic
+	update      func(ctx context.Context, bindingInfo routeBindingInfo, failedRefs []ingress.BackendRefError, diagnostics []proxy.RouteDiagnostic, syncErr error) error
 }
 
 // updateRoutesStatus iterates over route entries and updates status for each.
@@ -304,7 +438,7 @@ func updateRoutesStatus(
 	var firstErr error
 
 	for _, entry := range entries {
-		if err := entry.update(ctx, entry.bindingInfo, entry.failedRefs, syncErr); err != nil {
+		if err := entry.update(ctx, entry.bindingInfo, entry.failedRefs, entry.diagnostics, syncErr); err != nil {
 			logger.Error("failed to update route status", "error", err, "route", entry.namespace+"/"+entry.name)
 
 			if firstErr == nil {
@@ -329,6 +463,19 @@ func filterFailedRefs(allFailedRefs []ingress.BackendRefError, routeNamespace, r
 	return result
 }
 
+// filterDiagnostics returns converter diagnostics that belong to the specified route.
+func filterDiagnostics(all []proxy.RouteDiagnostic, routeNamespace, routeName string) []proxy.RouteDiagnostic {
+	var result []proxy.RouteDiagnostic
+
+	for _, diag := range all {
+		if diag.Namespace == routeNamespace && diag.Name == routeName {
+			result = append(result, diag)
+		}
+	}
+
+	return result
+}
+
 func newHTTPRouteAccessor() routeAccessor {
 	route := &gatewayv1.HTTPRoute{}
 
@@ -337,6 +484,7 @@ func newHTTPRouteAccessor() routeAccessor {
 		parentRefs:  func() []gatewayv1.ParentReference { return route.Spec.ParentRefs },
 		routeStatus: func() *gatewayv1.RouteStatus { return &route.Status.RouteStatus },
 		generation:  func() int64 { return route.Generation },
+		ruleCount:   func() int { return len(route.Spec.Rules) },
 	}
 }
 
@@ -348,5 +496,6 @@ func newGRPCRouteAccessor() routeAccessor {
 		parentRefs:  func() []gatewayv1.ParentReference { return route.Spec.ParentRefs },
 		routeStatus: func() *gatewayv1.RouteStatus { return &route.Status.RouteStatus },
 		generation:  func() int64 { return route.Generation },
+		ruleCount:   func() int { return len(route.Spec.Rules) },
 	}
 }

--- a/internal/controller/route_status.go
+++ b/internal/controller/route_status.go
@@ -215,7 +215,7 @@ func buildParentStatus(
 
 	conditions := []metav1.Condition{
 		accepted,
-		buildResolvedRefsCondition(generation, now, failedRefs),
+		buildResolvedRefsCondition(generation, now, failedRefs, diagnostics),
 	}
 
 	// PartiallyInvalid is only meaningful when the route is otherwise accepted —
@@ -374,21 +374,41 @@ func buildResolvedRefsCondition(
 	generation int64,
 	now metav1.Time,
 	failedRefs []ingress.BackendRefError,
+	diagnostics []proxy.RouteDiagnostic,
 ) metav1.Condition {
 	status := metav1.ConditionTrue
 	reason := string(gatewayv1.RouteReasonResolvedRefs)
 	message := resolvedRefsMessage
 
-	if len(failedRefs) > 0 {
+	switch {
+	case len(failedRefs) > 0:
+		// A hard unresolved backend reference (missing Service, bad kind/port,
+		// unauthorized cross-namespace) is the most fundamental problem and
+		// outranks softer converter diagnostics. Gateway API spec requires
+		// specific reasons like InvalidKind, RefNotPermitted, BackendNotFound.
 		status = metav1.ConditionFalse
-		// Use the reason from the first failed ref — Gateway API spec requires
-		// specific reasons like InvalidKind, RefNotPermitted, BackendNotFound, etc.
 		reason = failedRefs[0].Reason
+
 		if reason == "" {
 			reason = string(gatewayv1.RouteReasonRefNotPermitted)
 		}
 
 		message = buildFailedRefsMessage(failedRefs)
+	default:
+		// Otherwise fold in any ResolvedRefs-target converter diagnostic (e.g. a
+		// backend declaring a TLS appProtocol with no BackendTLSPolicy, or an
+		// unrecognised appProtocol). These reach the status only via the
+		// converter — the ingress builder does not see them.
+		if diag, ok := firstResolvedRefsDiagnostic(diagnostics); ok {
+			status = metav1.ConditionFalse
+			reason = diag.Reason
+
+			if reason == "" {
+				reason = string(gatewayv1.RouteReasonUnsupportedProtocol)
+			}
+
+			message = diag.Message
+		}
 	}
 
 	return metav1.Condition{
@@ -399,6 +419,18 @@ func buildResolvedRefsCondition(
 		Reason:             reason,
 		Message:            message,
 	}
+}
+
+// firstResolvedRefsDiagnostic returns the first ResolvedRefs-target diagnostic,
+// if any. The status writer surfaces it on the ResolvedRefs condition.
+func firstResolvedRefsDiagnostic(diagnostics []proxy.RouteDiagnostic) (proxy.RouteDiagnostic, bool) {
+	for _, diag := range diagnostics {
+		if diag.Target == proxy.DiagnosticResolvedRefs {
+			return diag, true
+		}
+	}
+
+	return proxy.RouteDiagnostic{}, false
 }
 
 func buildFailedRefsMessage(failedRefs []ingress.BackendRefError) string {

--- a/internal/controller/route_status.go
+++ b/internal/controller/route_status.go
@@ -467,7 +467,10 @@ func emitDiagnosticEvents(recorder events.EventRecorder, route runtime.Object, d
 			eventType = corev1.EventTypeNormal
 		}
 
-		recorder.Eventf(route, nil, eventType, eventReasonConfigOverridden, eventActionConvert, diag.Message)
+		// Eventf treats the note as a format string. diag.Message is already
+		// fully formatted (and may contain a literal %), so pass it as a "%s"
+		// argument rather than as the format itself.
+		recorder.Eventf(route, nil, eventType, eventReasonConfigOverridden, eventActionConvert, "%s", diag.Message)
 	}
 }
 

--- a/internal/controller/route_status_diagnostics_test.go
+++ b/internal/controller/route_status_diagnostics_test.go
@@ -1,0 +1,148 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// buildParentStatusForDiag calls buildParentStatus with the defaults the
+// diagnostic tests don't vary (no binding rejection, no failed refs, no sync
+// error, no caller override). It reuses the package-level findCondition helper
+// (gateway_controller_test.go) to assert on the resulting conditions.
+func buildParentStatusForDiag(diagnostics []proxy.RouteDiagnostic, ruleCount int) gatewayv1.RouteParentStatus {
+	ref := gatewayv1.ParentReference{Name: "test-gateway"}
+
+	return buildParentStatus(
+		ref, "default", "example.com/controller",
+		1, metav1.Now(),
+		routeBindingInfo{}, 0,
+		nil, nil,
+		nil,
+		diagnostics, ruleCount,
+	)
+}
+
+// TestDiagnostics_EveryRuleUnservable_AcceptedFalse pins that when every rule of
+// the route is wholly unservable, the route is Accepted=False/UnsupportedValue
+// and no PartiallyInvalid is set — the route serves nothing, so the Accepted
+// rejection tells the whole story.
+func TestDiagnostics_EveryRuleUnservable_AcceptedFalse(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := []proxy.RouteDiagnostic{
+		{Namespace: "default", Name: "web", RuleIndex: 0, Target: proxy.DiagnosticAccepted, Reason: string(gatewayv1.RouteReasonUnsupportedValue), Message: "rule 0 bad", WholeRule: true},
+		{Namespace: "default", Name: "web", RuleIndex: 1, Target: proxy.DiagnosticAccepted, Reason: string(gatewayv1.RouteReasonUnsupportedValue), Message: "rule 1 bad", WholeRule: true},
+	}
+
+	status := buildParentStatusForDiag(diagnostics, 2)
+
+	accepted := findCondition(status.Conditions, string(gatewayv1.RouteConditionAccepted))
+	require.NotNil(t, accepted)
+	assert.Equal(t, metav1.ConditionFalse, accepted.Status, "all-rules-unservable route must be Accepted=False")
+	assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), accepted.Reason)
+
+	assert.Nil(t, findCondition(status.Conditions, string(gatewayv1.RouteConditionPartiallyInvalid)),
+		"PartiallyInvalid must not be set when the whole route is rejected")
+}
+
+// TestDiagnostics_SomeRulesDropped_PartiallyInvalid pins that when only some
+// rules are unservable, the route stays Accepted=True and gets a
+// PartiallyInvalid=True condition whose message starts with the spec-mandated
+// "Dropped Rule" prefix and names the affected rule index.
+func TestDiagnostics_SomeRulesDropped_PartiallyInvalid(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := []proxy.RouteDiagnostic{
+		{Namespace: "default", Name: "web", RuleIndex: 1, Target: proxy.DiagnosticAccepted, Reason: string(gatewayv1.RouteReasonUnsupportedValue), Message: "rule 1 filter unsupported", WholeRule: true},
+	}
+
+	status := buildParentStatusForDiag(diagnostics, 3)
+
+	accepted := findCondition(status.Conditions, string(gatewayv1.RouteConditionAccepted))
+	require.NotNil(t, accepted)
+	assert.Equal(t, metav1.ConditionTrue, accepted.Status, "route with surviving rules stays Accepted=True")
+
+	partial := findCondition(status.Conditions, string(gatewayv1.RouteConditionPartiallyInvalid))
+	require.NotNil(t, partial, "a partially-unservable route must carry PartiallyInvalid")
+	assert.Equal(t, metav1.ConditionTrue, partial.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), partial.Reason)
+	assert.True(t, strings.HasPrefix(partial.Message, "Dropped Rule"),
+		"PartiallyInvalid message must start with the spec-mandated 'Dropped Rule' prefix, got: %q", partial.Message)
+	assert.Contains(t, partial.Message, "1", "message must name the dropped rule index")
+}
+
+// TestDiagnostics_BackendLevel_PartiallyInvalidNotAcceptedFalse pins that a
+// backend-level diagnostic (WholeRule=false) on the route's only rule yields
+// PartiallyInvalid — not Accepted=False — because the rule still serves its
+// other backends; only one backend fraction fails closed.
+func TestDiagnostics_BackendLevel_PartiallyInvalidNotAcceptedFalse(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := []proxy.RouteDiagnostic{
+		{Namespace: "default", Name: "web", RuleIndex: 0, Target: proxy.DiagnosticAccepted, Reason: string(gatewayv1.RouteReasonUnsupportedValue), Message: "backend filter unsupported", WholeRule: false},
+	}
+
+	status := buildParentStatusForDiag(diagnostics, 1)
+
+	accepted := findCondition(status.Conditions, string(gatewayv1.RouteConditionAccepted))
+	require.NotNil(t, accepted)
+	assert.Equal(t, metav1.ConditionTrue, accepted.Status,
+		"a backend-only fail-closed must not reject the whole route")
+
+	partial := findCondition(status.Conditions, string(gatewayv1.RouteConditionPartiallyInvalid))
+	require.NotNil(t, partial, "backend-level drop still warrants PartiallyInvalid")
+	assert.Equal(t, metav1.ConditionTrue, partial.Status)
+}
+
+// TestDiagnostics_None_NoExtraConditions confirms the happy path: no
+// diagnostics → Accepted=True and no PartiallyInvalid condition at all.
+func TestDiagnostics_None_NoExtraConditions(t *testing.T) {
+	t.Parallel()
+
+	status := buildParentStatusForDiag(nil, 2)
+
+	accepted := findCondition(status.Conditions, string(gatewayv1.RouteConditionAccepted))
+	require.NotNil(t, accepted)
+	assert.Equal(t, metav1.ConditionTrue, accepted.Status)
+
+	assert.Nil(t, findCondition(status.Conditions, string(gatewayv1.RouteConditionPartiallyInvalid)),
+		"a fully-valid route must not carry PartiallyInvalid")
+}
+
+// TestDiagnostics_CallerOverrideWins pins that an explicit caller override (the
+// GRPCRoute reconciler's gRPC-over-quic UnsupportedProtocol) takes precedence
+// over a diagnostic-derived whole-route override: the more specific reason is
+// preserved on the Accepted condition.
+func TestDiagnostics_CallerOverrideWins(t *testing.T) {
+	t.Parallel()
+
+	ref := gatewayv1.ParentReference{Name: "test-gateway"}
+	diagnostics := []proxy.RouteDiagnostic{
+		{Namespace: "default", Name: "grpc", RuleIndex: 0, Target: proxy.DiagnosticAccepted, Reason: string(gatewayv1.RouteReasonUnsupportedValue), Message: "filters unsupported", WholeRule: true},
+	}
+
+	status := buildParentStatus(
+		ref, "default", "example.com/controller",
+		1, metav1.Now(),
+		routeBindingInfo{}, 0,
+		nil, nil,
+		&acceptedConditionOverride{
+			reason:  string(gatewayv1.RouteReasonUnsupportedProtocol),
+			message: "gRPC over quic unsupported",
+		},
+		diagnostics, 1,
+	)
+
+	accepted := findCondition(status.Conditions, string(gatewayv1.RouteConditionAccepted))
+	require.NotNil(t, accepted)
+	assert.Equal(t, metav1.ConditionFalse, accepted.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedProtocol), accepted.Reason,
+		"the caller's more-specific override must win over the diagnostic-derived one")
+}

--- a/internal/controller/route_status_resolvedrefs_diag_test.go
+++ b/internal/controller/route_status_resolvedrefs_diag_test.go
@@ -1,0 +1,87 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/ingress"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// TestDiagnostics_ResolvedRefsTarget_SetsResolvedRefsFalse pins that a
+// ResolvedRefs-target diagnostic (e.g. a backend declaring a TLS appProtocol
+// with no BackendTLSPolicy, or an unrecognised appProtocol) sets the
+// ResolvedRefs condition to False with the diagnostic's reason and message —
+// the converter's per-backend protocol findings reach the route status, not
+// just the ingress builder's backend-ref failures.
+func TestDiagnostics_ResolvedRefsTarget_SetsResolvedRefsFalse(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := []proxy.RouteDiagnostic{
+		{
+			Namespace: "default", Name: "web", RuleIndex: 0,
+			Target:  proxy.DiagnosticResolvedRefs,
+			Reason:  string(gatewayv1.RouteReasonUnsupportedProtocol),
+			Message: "Service \"web-svc\" declares appProtocol \"https\" but no BackendTLSPolicy targets it",
+		},
+	}
+
+	status := buildParentStatusForDiag(diagnostics, 1)
+
+	resolved := findCondition(status.Conditions, string(gatewayv1.RouteConditionResolvedRefs))
+	require.NotNil(t, resolved)
+	assert.Equal(t, metav1.ConditionFalse, resolved.Status,
+		"a ResolvedRefs-target diagnostic must drive ResolvedRefs=False")
+	assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedProtocol), resolved.Reason)
+	assert.Contains(t, resolved.Message, "BackendTLSPolicy", "message must carry the actionable detail")
+
+	// A ResolvedRefs diagnostic alone must not reject the whole route — the
+	// route is still Accepted, the unresolved ref is the specific problem.
+	accepted := findCondition(status.Conditions, string(gatewayv1.RouteConditionAccepted))
+	require.NotNil(t, accepted)
+	assert.Equal(t, metav1.ConditionTrue, accepted.Status)
+}
+
+// TestDiagnostics_ResolvedRefsTarget_BackendRefErrorTakesPrecedence pins that an
+// ingress-builder BackendRefError (a missing Service, etc.) still drives the
+// ResolvedRefs condition when both it and a converter ResolvedRefs diagnostic
+// are present — the hard unresolved reference is the more fundamental problem.
+func TestDiagnostics_ResolvedRefsTarget_BackendRefErrorTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	ref := gatewayv1.ParentReference{Name: "test-gateway"}
+	diagnostics := []proxy.RouteDiagnostic{
+		{
+			Namespace: "default", Name: "web", RuleIndex: 0,
+			Target:  proxy.DiagnosticResolvedRefs,
+			Reason:  string(gatewayv1.RouteReasonUnsupportedProtocol),
+			Message: "appProtocol https without policy",
+		},
+	}
+	failedRefs := []ingress.BackendRefError{
+		{
+			RouteNamespace: "default", RouteName: "web",
+			BackendName: "missing-svc", BackendNS: "default",
+			Reason: string(gatewayv1.RouteReasonBackendNotFound), Message: "Service not found",
+		},
+	}
+
+	status := buildParentStatus(
+		ref, "default", "example.com/controller",
+		1, metav1.Now(),
+		routeBindingInfo{}, 0,
+		failedRefs, nil,
+		nil,
+		diagnostics, 1,
+	)
+
+	resolved := findCondition(status.Conditions, string(gatewayv1.RouteConditionResolvedRefs))
+	require.NotNil(t, resolved)
+	assert.Equal(t, metav1.ConditionFalse, resolved.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonBackendNotFound), resolved.Reason,
+		"a hard unresolved backend ref outranks a softer protocol diagnostic")
+}

--- a/internal/controller/route_status_test.go
+++ b/internal/controller/route_status_test.go
@@ -33,6 +33,7 @@ func TestBuildParentStatus_IncludesPort(t *testing.T) {
 	status := buildParentStatus(
 		ref, "default", "test-controller", 1,
 		metav1.Now(), routeBindingInfo{}, 0, nil, nil, nil,
+		nil, 0,
 	)
 
 	require.NotNil(t, status.ParentRef.Port)
@@ -49,6 +50,7 @@ func TestBuildParentStatus_NilPort(t *testing.T) {
 	status := buildParentStatus(
 		ref, "default", "test-controller", 1,
 		metav1.Now(), routeBindingInfo{}, 0, nil, nil, nil,
+		nil, 0,
 	)
 
 	assert.Nil(t, status.ParentRef.Port)
@@ -84,6 +86,7 @@ func TestBuildParentStatus_NoMatchingParent_ConformancePin(t *testing.T) {
 	status := buildParentStatus(
 		ref, "gateway-conformance-infra", "test-controller", 7,
 		metav1.Now(), bindingInfo, 0, nil, nil, nil,
+		nil, 0,
 	)
 
 	require.NotNil(t, status.ParentRef.Port)

--- a/internal/controller/route_syncer.go
+++ b/internal/controller/route_syncer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/config"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/ingress"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/logging"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/referencegrant"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/routebinding"
 )
@@ -108,11 +109,12 @@ type SyncResult struct {
 // httpStatusEntries builds routeStatusEntry slice for HTTP routes,
 // including rejected routes that need Accepted=False status.
 func (sr *SyncResult) httpStatusEntries(
-	updateFn func(ctx context.Context, route *gatewayv1.HTTPRoute, bi routeBindingInfo, fr []ingress.BackendRefError, se error) error,
+	diagnostics []proxy.RouteDiagnostic,
+	updateFn func(ctx context.Context, route *gatewayv1.HTTPRoute, bi routeBindingInfo, fr []ingress.BackendRefError, diags []proxy.RouteDiagnostic, se error) error,
 ) []routeStatusEntry {
-	entries := buildStatusEntries(sr.HTTPRoutes, sr.HTTPRouteBindings, sr.HTTPFailedRefs, updateFn)
+	entries := buildStatusEntries(sr.HTTPRoutes, sr.HTTPRouteBindings, sr.HTTPFailedRefs, diagnostics, updateFn)
 	// Rejected routes have no failed refs — they were rejected at binding level.
-	entries = append(entries, buildStatusEntries(sr.RejectedHTTPRoutes, sr.HTTPRouteBindings, nil, updateFn)...)
+	entries = append(entries, buildStatusEntries(sr.RejectedHTTPRoutes, sr.HTTPRouteBindings, nil, nil, updateFn)...)
 
 	return entries
 }
@@ -120,10 +122,11 @@ func (sr *SyncResult) httpStatusEntries(
 // grpcStatusEntries builds routeStatusEntry slice for GRPC routes,
 // including rejected routes that need Accepted=False status.
 func (sr *SyncResult) grpcStatusEntries(
-	updateFn func(ctx context.Context, route *gatewayv1.GRPCRoute, bi routeBindingInfo, fr []ingress.BackendRefError, se error) error,
+	diagnostics []proxy.RouteDiagnostic,
+	updateFn func(ctx context.Context, route *gatewayv1.GRPCRoute, bi routeBindingInfo, fr []ingress.BackendRefError, diags []proxy.RouteDiagnostic, se error) error,
 ) []routeStatusEntry {
-	entries := buildStatusEntries(sr.GRPCRoutes, sr.GRPCRouteBindings, sr.GRPCFailedRefs, updateFn)
-	entries = append(entries, buildStatusEntries(sr.RejectedGRPCRoutes, sr.GRPCRouteBindings, nil, updateFn)...)
+	entries := buildStatusEntries(sr.GRPCRoutes, sr.GRPCRouteBindings, sr.GRPCFailedRefs, diagnostics, updateFn)
+	entries = append(entries, buildStatusEntries(sr.RejectedGRPCRoutes, sr.GRPCRouteBindings, nil, nil, updateFn)...)
 
 	return entries
 }
@@ -138,7 +141,8 @@ func buildStatusEntries[T routeObject](
 	routes []T,
 	bindings map[string]routeBindingInfo,
 	failedRefs []ingress.BackendRefError,
-	updateFn func(ctx context.Context, route *T, bi routeBindingInfo, fr []ingress.BackendRefError, se error) error,
+	diagnostics []proxy.RouteDiagnostic,
+	updateFn func(ctx context.Context, route *T, bi routeBindingInfo, fr []ingress.BackendRefError, diags []proxy.RouteDiagnostic, se error) error,
 ) []routeStatusEntry {
 	entries := make([]routeStatusEntry, 0, len(routes))
 
@@ -162,8 +166,9 @@ func buildStatusEntries[T routeObject](
 			namespace:   namespace,
 			bindingInfo: bindings[routeKey],
 			failedRefs:  filterFailedRefs(failedRefs, namespace, name),
-			update: func(ctx context.Context, bi routeBindingInfo, fr []ingress.BackendRefError, se error) error {
-				return updateFn(ctx, route, bi, fr, se)
+			diagnostics: filterDiagnostics(diagnostics, namespace, name),
+			update: func(ctx context.Context, bi routeBindingInfo, fr []ingress.BackendRefError, diags []proxy.RouteDiagnostic, se error) error {
+				return updateFn(ctx, route, bi, fr, diags, se)
 			},
 		})
 	}
@@ -182,7 +187,7 @@ type syncUpdateParams struct {
 	// gRPC needs http2; auto/unset is upgraded to http2 by the proxy, so only an
 	// explicit quic warns.
 	tunnelProtocol string
-	statusEntries  func(*SyncResult) []routeStatusEntry
+	statusEntries  func(*SyncResult, []proxy.RouteDiagnostic) []routeStatusEntry
 }
 
 // syncAndUpdateStatusCommon performs a full route sync, pushes proxy config,
@@ -201,11 +206,18 @@ func syncAndUpdateStatusCommon(ctx context.Context, params syncUpdateParams) (ct
 	// at runtime in v3 — they only populate the Cloudflare dashboard's
 	// edge-routing view. Both route reconcilers set pushProxy=true; each push
 	// rebuilds the full merged config from the SyncResult.
+	var diagnostics []proxy.RouteDiagnostic
+
 	if params.pushProxy && params.proxySyncer != nil && len(params.proxyEndpoints) > 0 && syncResult != nil {
 		httpRoutes := httpRoutePtrs(syncResult.HTTPRoutes)
 		grpcRoutes := grpcRoutePtrs(syncResult.GRPCRoutes)
 
-		if proxyErr := params.proxySyncer.SyncRoutes(ctx, params.proxyEndpoints, httpRoutes, grpcRoutes, syncResult.HTTPFailedRefs, syncResult.GRPCFailedRefs); proxyErr != nil {
+		// Diagnostics are returned even when the push errors: they describe the
+		// route specs, not the push, and must reach the route status regardless.
+		diags, proxyErr := params.proxySyncer.SyncRoutes(ctx, params.proxyEndpoints, httpRoutes, grpcRoutes, syncResult.HTTPFailedRefs, syncResult.GRPCFailedRefs)
+		diagnostics = diags
+
+		if proxyErr != nil {
 			logger.Error("proxy sync failed (non-blocking)", "error", proxyErr)
 			params.routeSyncer.Metrics.RecordSyncError(ctx, "proxy_push")
 		}
@@ -224,7 +236,7 @@ func syncAndUpdateStatusCommon(ctx context.Context, params syncUpdateParams) (ct
 	var statusUpdateErr error
 
 	if syncResult != nil {
-		statusUpdateErr = updateRoutesStatus(ctx, logger, params.statusEntries(syncResult), syncErr)
+		statusUpdateErr = updateRoutesStatus(ctx, logger, params.statusEntries(syncResult, diagnostics), syncErr)
 	}
 
 	if syncErr != nil {

--- a/internal/controller/route_syncer.go
+++ b/internal/controller/route_syncer.go
@@ -206,6 +206,12 @@ func syncAndUpdateStatusCommon(ctx context.Context, params syncUpdateParams) (ct
 	// at runtime in v3 — they only populate the Cloudflare dashboard's
 	// edge-routing view. Both route reconcilers set pushProxy=true; each push
 	// rebuilds the full merged config from the SyncResult.
+	// Converter diagnostics (unsupported/dropped config surfaced on route status)
+	// are produced by buildProxyConfig and returned by SyncRoutes, so they are
+	// only collected on the proxy-push path below. In v3 the proxy is the sole
+	// data plane and there are always proxy endpoints, so this is always taken;
+	// if a deployment ever ran with zero proxy endpoints the status surfacing
+	// would go dark along with the data plane itself.
 	var diagnostics []proxy.RouteDiagnostic
 
 	if params.pushProxy && params.proxySyncer != nil && len(params.proxyEndpoints) > 0 && syncResult != nil {

--- a/internal/controller/route_syncer_test.go
+++ b/internal/controller/route_syncer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/api/v1alpha1"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/cfmetrics"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/config"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
 )
 
 // httpListener creates a standard HTTP listener for testing.
@@ -1448,7 +1449,7 @@ func TestSyncAndUpdateStatusCommon_PropagatesError(t *testing.T) {
 
 	params := syncUpdateParams{
 		routeSyncer: syncer,
-		statusEntries: func(_ *SyncResult) []routeStatusEntry {
+		statusEntries: func(_ *SyncResult, _ []proxy.RouteDiagnostic) []routeStatusEntry {
 			return nil
 		},
 	}
@@ -1503,7 +1504,7 @@ func TestSyncAndUpdateStatusCommon_PropagatesErrorWhenNoRequeue(t *testing.T) {
 
 	params := syncUpdateParams{
 		routeSyncer: syncer,
-		statusEntries: func(_ *SyncResult) []routeStatusEntry {
+		statusEntries: func(_ *SyncResult, _ []proxy.RouteDiagnostic) []routeStatusEntry {
 			return nil
 		},
 	}

--- a/internal/proxy/appprotocol_failclosed_test.go
+++ b/internal/proxy/appprotocol_failclosed_test.go
@@ -1,0 +1,124 @@
+package proxy_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// appProtoTestRoute builds a one-backend HTTPRoute for the appProtocol tests.
+func appProtoTestRoute() *gatewayv1.HTTPRoute {
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Hostnames: []gatewayv1.Hostname{"example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches:     []gatewayv1.HTTPRouteMatch{{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}}},
+					BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("web-svc", 80, 1)},
+				},
+			},
+		},
+	}
+}
+
+// TestConvertHTTPRoutes_AppProtocolHTTPS_WithoutPolicy_FailsClosed pins the
+// spec-mandated behaviour: a backend declaring appProtocol https (or wss)
+// without a BackendTLSPolicy cannot be served — the proxy has no trust anchor,
+// so dialing plaintext to a TLS backend would silently fail. Per the Gateway
+// API spec this is an unsupported app protocol: the backend fails closed (its
+// traffic fraction returns HTTP 502) and a ResolvedRefs-target diagnostic with
+// reason UnsupportedProtocol is recorded with an actionable message naming the
+// fix (attach a BackendTLSPolicy).
+func TestConvertHTTPRoutes_AppProtocolHTTPS_WithoutPolicy_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		appProtocol string
+	}{
+		{"lowercase https", "https"},
+		{"uppercase HTTPS", "HTTPS"},
+		{"wss", "kubernetes.io/wss"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolver := func(_ context.Context, _, _ string, _ int32) string { return tc.appProtocol }
+
+			// tlsResolver = nil → no BackendTLSPolicy applies.
+			cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{appProtoTestRoute()},
+				"cluster.local", nil, resolver, nil, nil)
+
+			require.Len(t, cfg.Rules, 1)
+			require.Len(t, cfg.Rules[0].Backends, 1)
+			assert.Equal(t, http.StatusBadGateway, cfg.Rules[0].Backends[0].UnavailableStatus,
+				"a TLS appProtocol without a BackendTLSPolicy must fail the backend closed")
+
+			require.Len(t, cfg.Diagnostics, 1)
+			diag := cfg.Diagnostics[0]
+			assert.Equal(t, "web", diag.Name)
+			assert.Equal(t, proxy.DiagnosticResolvedRefs, diag.Target)
+			assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedProtocol), diag.Reason)
+			assert.False(t, diag.WholeRule, "only this backend fraction fails, the rule still serves other backends")
+			assert.Contains(t, diag.Message, "BackendTLSPolicy", "message must name the fix")
+		})
+	}
+}
+
+// TestConvertHTTPRoutes_AppProtocolHTTPS_WithPolicy_NoDiagnostic confirms the
+// happy path: with a BackendTLSPolicy attached, appProtocol https is served
+// over TLS — no fail-closed, no diagnostic.
+func TestConvertHTTPRoutes_AppProtocolHTTPS_WithPolicy_NoDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	resolver := func(_ context.Context, _, _ string, _ int32) string { return "https" }
+	tlsResolver := func(_ context.Context, _, _ string, _ int32) *proxy.BackendTLSConfig {
+		return &proxy.BackendTLSConfig{CABundlePEM: "ca", ServerName: "web-svc"}
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{appProtoTestRoute()},
+		"cluster.local", nil, resolver, tlsResolver, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Zero(t, cfg.Rules[0].Backends[0].UnavailableStatus, "a policed TLS backend must serve normally")
+	assert.NotNil(t, cfg.Rules[0].Backends[0].TLS)
+	assert.Empty(t, cfg.Diagnostics)
+}
+
+// TestConvertHTTPRoutes_AppProtocolUnknown_ReportsButServes pins the
+// report-only treatment for an unrecognised appProtocol: the proxy keeps
+// serving over HTTP/1.1 (a safe default the backend may well speak), but
+// records a ResolvedRefs-target UnsupportedProtocol diagnostic so the operator
+// sees the hint was not honoured. The backend is NOT failed closed.
+func TestConvertHTTPRoutes_AppProtocolUnknown_ReportsButServes(t *testing.T) {
+	t.Parallel()
+
+	resolver := func(_ context.Context, _, _ string, _ int32) string { return "my-custom-proto" }
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{appProtoTestRoute()},
+		"cluster.local", nil, resolver, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Equal(t, proxy.BackendProtocolHTTP, cfg.Rules[0].Backends[0].Protocol, "unknown appProtocol falls back to HTTP/1.1")
+	assert.Zero(t, cfg.Rules[0].Backends[0].UnavailableStatus, "unknown appProtocol is report-only, not fail-closed")
+
+	require.Len(t, cfg.Diagnostics, 1)
+	diag := cfg.Diagnostics[0]
+	assert.Equal(t, proxy.DiagnosticResolvedRefs, diag.Target)
+	assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedProtocol), diag.Reason)
+	assert.Contains(t, diag.Message, "my-custom-proto", "message must name the unrecognised value")
+}

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -43,6 +43,13 @@ type Config struct {
 	// indistinguishable from HTTP rules with h2c backends, so the controller
 	// marks the presence of gRPC explicitly rather than having the proxy guess.
 	HasGRPCRoute bool `json:"hasGrpcRoute,omitempty"`
+	// Diagnostics carries the converter's per-route findings about config it
+	// will not serve exactly as written (dropped filters, unsupported app
+	// protocols, fail-closed rules, benign overrides). It is a controller-side
+	// concern only: the json:"-" tag keeps it off the proxy wire so the pushed
+	// payload is byte-identical to before, and the proxy never reads it. The
+	// controller turns each entry into a status condition or a Kubernetes Event.
+	Diagnostics []RouteDiagnostic `json:"-"`
 }
 
 // RouteRule represents a single routing rule derived from a Gateway API HTTPRoute.
@@ -53,6 +60,14 @@ type RouteRule struct {
 	Filters   []RouteFilter  `json:"filters,omitempty"`
 	Backends  []BackendRef   `json:"backends"`
 	Timeouts  *RouteTimeouts `json:"timeouts,omitempty"`
+	// UnavailableStatus, when non-zero, makes the proxy return this HTTP status
+	// for every request matching the rule, short-circuiting backend selection.
+	// The controller sets it when a rule cannot be served as written — for
+	// example a rule carrying an unsupported filter type — so that matched
+	// requests fail closed with an HTTP error instead of being served silently
+	// without the dropped config, as the Gateway API spec requires. This is the
+	// rule-level analogue of BackendRef.UnavailableStatus.
+	UnavailableStatus int `json:"unavailableStatus,omitempty"`
 }
 
 // RouteMatch defines conditions that must all be true for a request to match.

--- a/internal/proxy/converter.go
+++ b/internal/proxy/converter.go
@@ -475,7 +475,7 @@ func convertFilter(
 	case gatewayv1.HTTPRouteFilterURLRewrite:
 		return convertURLRewriteFilter(filter.URLRewrite), false
 	case gatewayv1.HTTPRouteFilterRequestMirror:
-		return convertMirrorFilter(ctx, filter.RequestMirror, namespace, clusterDomain, validator, tlsResolver, clientCert), false
+		return convertMirrorFilter(ctx, filter.RequestMirror, namespace, clusterDomain, validator, tlsResolver, clientCert, sink), false
 	case gatewayv1.HTTPRouteFilterCORS:
 		return convertCORSFilter(filter.CORS), false
 	case gatewayv1.HTTPRouteFilterExtensionRef, gatewayv1.HTTPRouteFilterExternalAuth:
@@ -577,24 +577,39 @@ func IsServiceBackendRef(ref gatewayv1.BackendObjectReference) bool {
 	return true
 }
 
-func convertMirrorFilter(
+// mirrorDropDiagnostic records a ResolvedRefs-target diagnostic for a dropped
+// RequestMirror. The mirror is best-effort — dropping it does not break the
+// main request — so it is report-only (WholeRule=false): the route stays
+// Accepted, the dropped mirror shows on ResolvedRefs.
+func mirrorDropDiagnostic(sink *diagSink, reason gatewayv1.RouteConditionReason, mirrorName, detail string) {
+	sink.add(
+		DiagnosticResolvedRefs,
+		string(reason),
+		fmt.Sprintf("The RequestMirror to Service %q was dropped because %s; the main request is unaffected.", mirrorName, detail),
+		false,
+	)
+}
+
+// validateMirrorBackendRef validates a RequestMirror's backendRef and, on any
+// failure, records a report-only ResolvedRefs diagnostic (a dropped mirror does
+// not break the main request) and returns ok=false. On success it returns the
+// resolved namespace and port for the mirror destination.
+func validateMirrorBackendRef(
 	ctx context.Context,
 	mirror *gatewayv1.HTTPRequestMirrorFilter,
-	namespace, clusterDomain string,
+	namespace string,
 	validator BackendRefValidator,
-	tlsResolver BackendTLSResolver,
-	clientCert *ClientCertConfig,
-) *RouteFilter {
-	if mirror == nil {
-		return nil
-	}
+	sink *diagSink,
+) (string, int32, bool) {
+	mirrorName := string(mirror.BackendRef.Name)
 
 	if !IsServiceBackendRef(mirror.BackendRef) {
+		mirrorDropDiagnostic(sink, gatewayv1.RouteReasonInvalidKind, mirrorName,
+			"its backendRef is not a Service")
 		slog.Warn("skipping mirror with non-Service backend kind",
-			"kind", mirror.BackendRef.Kind,
-			"name", mirror.BackendRef.Name)
+			"kind", mirror.BackendRef.Kind, "name", mirror.BackendRef.Name)
 
-		return nil
+		return "", 0, false
 	}
 
 	mirrorPort := int32(defaultServicePort)
@@ -603,9 +618,11 @@ func convertMirrorFilter(
 	}
 
 	if !validatePort(mirrorPort) {
-		slog.Warn("skipping mirror with invalid port", "service", string(mirror.BackendRef.Name), "port", mirrorPort)
+		mirrorDropDiagnostic(sink, gatewayv1.RouteReasonUnsupportedValue, mirrorName,
+			fmt.Sprintf("its backendRef port %d is out of range", mirrorPort))
+		slog.Warn("skipping mirror with invalid port", "service", mirrorName, "port", mirrorPort)
 
-		return nil
+		return "", 0, false
 	}
 
 	mirrorNS := namespace
@@ -613,7 +630,31 @@ func convertMirrorFilter(
 		mirrorNS = string(*mirror.BackendRef.Namespace)
 	}
 
-	if !validateCrossNamespace(ctx, mirrorNS, namespace, string(mirror.BackendRef.Name), mirror.BackendRef, validator) {
+	if !validateCrossNamespace(ctx, mirrorNS, namespace, mirrorName, mirror.BackendRef, validator) {
+		mirrorDropDiagnostic(sink, gatewayv1.RouteReasonRefNotPermitted, mirrorName,
+			fmt.Sprintf("its cross-namespace backendRef to %q is not permitted by a ReferenceGrant", mirrorNS))
+
+		return "", 0, false
+	}
+
+	return mirrorNS, mirrorPort, true
+}
+
+func convertMirrorFilter(
+	ctx context.Context,
+	mirror *gatewayv1.HTTPRequestMirrorFilter,
+	namespace, clusterDomain string,
+	validator BackendRefValidator,
+	tlsResolver BackendTLSResolver,
+	clientCert *ClientCertConfig,
+	sink *diagSink,
+) *RouteFilter {
+	if mirror == nil {
+		return nil
+	}
+
+	mirrorNS, mirrorPort, ok := validateMirrorBackendRef(ctx, mirror, namespace, validator, sink)
+	if !ok {
 		return nil
 	}
 

--- a/internal/proxy/converter.go
+++ b/internal/proxy/converter.go
@@ -245,7 +245,16 @@ func convertHTTPRouteRule(
 	if rule.Timeouts != nil {
 		timeouts, err := convertTimeouts(rule.Timeouts)
 		if err != nil {
-			slog.Warn("skipping invalid route timeouts", "error", err)
+			// The rule still serves, just without the unparseable timeout, so
+			// this is report-only: WholeRule=false drives PartiallyInvalid, not
+			// Accepted=False.
+			sink.add(
+				DiagnosticAccepted,
+				string(gatewayv1.RouteReasonUnsupportedValue),
+				invalidTimeoutsMessage(err),
+				false,
+			)
+			slog.Warn("dropping invalid route timeouts", "error", err)
 		} else {
 			proxyRule.Timeouts = timeouts
 		}
@@ -1326,6 +1335,16 @@ func buildServiceURL(name, namespace string, port int32, clusterDomain string) s
 // format (only s, ms, h, m are specified). Using time.ParseDuration is
 // intentionally permissive — Kubernetes admission webhooks validate the
 // format before it reaches the controller.
+// invalidTimeoutsMessage builds the actionable status message for a rule whose
+// timeouts could not be parsed. The rule still serves without the timeout.
+func invalidTimeoutsMessage(err error) string {
+	return fmt.Sprintf(
+		"The rule's timeout could not be parsed (%v); the rule is served without it. "+
+			"Use a GEP-2257 duration (e.g. \"10s\", \"500ms\") or remove the timeout.",
+		err,
+	)
+}
+
 func convertTimeouts(timeouts *gatewayv1.HTTPRouteTimeouts) (*RouteTimeouts, error) {
 	result := &RouteTimeouts{}
 

--- a/internal/proxy/converter.go
+++ b/internal/proxy/converter.go
@@ -260,7 +260,7 @@ func convertHTTPRouteRule(
 		}
 	}
 
-	warnIfWSResponseFilterStripsHandshake(&proxyRule)
+	warnIfWSResponseFilterStripsHandshake(&proxyRule, sink)
 
 	return proxyRule
 }
@@ -300,7 +300,7 @@ var wsHandshakeRequiredHeaders = map[string]struct{}{
 // Filters are inspected at both rule scope (proxyRule.Filters) and
 // per-backend scope (backend.Filters); the same shape can land in
 // either place via HTTPRouteRule.Filters or HTTPBackendRef.Filters.
-func warnIfWSResponseFilterStripsHandshake(rule *RouteRule) {
+func warnIfWSResponseFilterStripsHandshake(rule *RouteRule, sink *diagSink) {
 	hasWSBackend := false
 
 	for idx := range rule.Backends {
@@ -317,7 +317,7 @@ func warnIfWSResponseFilterStripsHandshake(rule *RouteRule) {
 
 	// Rule-scope filters apply to every backend on the rule.
 	for idx := range rule.Filters {
-		warnIfHandshakeStrip(&rule.Filters[idx], "rule")
+		warnIfHandshakeStrip(&rule.Filters[idx], filterScopeRule, sink)
 	}
 
 	// Per-backend filters: only check filters on WS-marked backends.
@@ -327,16 +327,19 @@ func warnIfWSResponseFilterStripsHandshake(rule *RouteRule) {
 		}
 
 		for filterIdx := range rule.Backends[backendIdx].Filters {
-			warnIfHandshakeStrip(&rule.Backends[backendIdx].Filters[filterIdx], "backend")
+			warnIfHandshakeStrip(&rule.Backends[backendIdx].Filters[filterIdx], filterScopeBackend, sink)
 		}
 	}
 }
 
-// warnIfHandshakeStrip checks a single RouteFilter for handshake-header
-// removal and emits the WARN. Scope ("rule" or "backend") goes into the
-// log attributes so an operator can correlate the warning back to the
-// exact HTTPRoute field they edited.
-func warnIfHandshakeStrip(filter *RouteFilter, scope string) {
+// warnIfHandshakeStrip checks a single RouteFilter for handshake-header removal.
+// The filter is honored as written (per spec the pipeline runs unconditionally),
+// but stripping a load-bearing WebSocket handshake header silently breaks every
+// upgrade on the route, so it is surfaced as a Warning Event diagnostic — an
+// operator-authored conflict, not a controller-side drop. Scope ("rule" or
+// "backend") goes into the log attributes and the Event message so an operator
+// can correlate it back to the exact HTTPRoute field they edited.
+func warnIfHandshakeStrip(filter *RouteFilter, scope string, sink *diagSink) {
 	if filter.Type != FilterResponseHeaderModifier || filter.ResponseHeaderModifier == nil {
 		return
 	}
@@ -362,6 +365,17 @@ func warnIfHandshakeStrip(filter *RouteFilter, scope string) {
 		"ResponseHeaderModifier removes a WebSocket handshake header on a WS-marked backend; clients will fail to complete the upgrade",
 		"scope", scope,
 		"headers", offending,
+	)
+	sink.event(EventTypeWarning, wsHandshakeStripMessage(scope, offending))
+}
+
+// wsHandshakeStripMessage builds the Event message for a ResponseHeaderModifier
+// that strips WebSocket handshake headers.
+func wsHandshakeStripMessage(scope string, headers []string) string {
+	return fmt.Sprintf(
+		"A %s-scope ResponseHeaderModifier removes WebSocket handshake header(s) %v on a WebSocket backend; "+
+			"clients will fail to complete the upgrade. Remove %v from the filter's removeHeaders to keep WebSocket working.",
+		scope, headers, headers,
 	)
 }
 
@@ -1156,14 +1170,14 @@ func resolveBackendProtocol(
 
 	switch appProto {
 	case appProtocolH2C:
-		proto, u := resolveH2C(rawURL, tlsAttached, namespace, serviceName, port)
+		proto, u := resolveH2C(rawURL, tlsAttached, namespace, serviceName, port, sink)
 
 		return proto, u, false, false
 	case appProtocolWS:
 		if tlsAttached {
 			warnCleartextHintSuppressed(
 				"appProtocol kubernetes.io/ws suppressed by BackendTLSPolicy on the same Service — WebSocket will run over TLS (consider appProtocol kubernetes.io/wss instead)",
-				namespace, serviceName, port)
+				namespace, serviceName, port, sink)
 		}
 
 		return BackendProtocolHTTP, rawURL, true, false
@@ -1261,11 +1275,11 @@ func unknownAppProtocolMessage(serviceName, appProto string) string {
 // suppressed h2c hint so the operator sees the conflict. Otherwise rewrite
 // any https:// URL (which buildServiceURL emits for port 443) back to
 // http:// so the h2c transport dials cleartext.
-func resolveH2C(rawURL string, tlsAttached bool, namespace, serviceName string, port int32) (BackendProtocol, string) {
+func resolveH2C(rawURL string, tlsAttached bool, namespace, serviceName string, port int32, sink *diagSink) (BackendProtocol, string) {
 	if tlsAttached {
 		warnCleartextHintSuppressed(
 			"appProtocol kubernetes.io/h2c suppressed by BackendTLSPolicy on the same Service — HTTP/2 will be negotiated over TLS via ALPN",
-			namespace, serviceName, port)
+			namespace, serviceName, port, sink)
 
 		return BackendProtocolHTTP, rawURL
 	}
@@ -1273,18 +1287,20 @@ func resolveH2C(rawURL string, tlsAttached bool, namespace, serviceName string, 
 	return BackendProtocolH2C, strings.Replace(rawURL, schemeHTTPS+"://", schemeHTTP+"://", 1)
 }
 
-// warnCleartextHintSuppressed logs a WARN when an operator declared a
-// cleartext appProtocol (h2c, ws) but a BackendTLSPolicy attached to the
-// same Service forced TLS anyway. The proxy still does the right thing —
-// TLS wins because it's the higher-priority signal — but surfacing the
-// conflict lets the operator notice the contradictory hint instead of
-// shipping a misleading appProtocol value forever.
-func warnCleartextHintSuppressed(message, namespace, serviceName string, port int32) {
+// warnCleartextHintSuppressed logs a WARN and records a Normal Event diagnostic
+// when an operator declared a cleartext appProtocol (h2c, ws) but a
+// BackendTLSPolicy attached to the same Service forced TLS anyway. The proxy
+// still does the right thing — TLS wins because it's the higher-priority signal
+// — so this is a benign override surfaced as a Kubernetes Event, not a
+// condition: the route is fully Accepted, the operator is just told the
+// contradictory hint was superseded.
+func warnCleartextHintSuppressed(message, namespace, serviceName string, port int32, sink *diagSink) {
 	slog.Warn(message,
 		"namespace", namespace,
 		"service", serviceName,
 		"port", port,
 	)
+	sink.event(EventTypeNormal, message)
 }
 
 // convertBackendFilters converts the per-backend HTTPRouteFilters into proxy

--- a/internal/proxy/converter.go
+++ b/internal/proxy/converter.go
@@ -923,7 +923,17 @@ func convertBackendRef(
 	// (no policy → operator misconfigured a TLS hint with no actual TLS).
 	result.TLS, result.URL = resolveBackendTLS(ctx, tlsResolver, svcNamespace, serviceName, port, result.URL)
 	result.TLS = attachGatewayClientCert(result.TLS, clientCert)
-	result.Protocol, result.URL, result.WebSocket = resolveBackendProtocol(ctx, resolver, svcNamespace, serviceName, port, result.URL, result.TLS != nil)
+
+	var protoFailClosed bool
+
+	result.Protocol, result.URL, result.WebSocket, protoFailClosed = resolveBackendProtocol(
+		ctx, resolver, svcNamespace, serviceName, port, result.URL, result.TLS != nil, sink,
+	)
+	if protoFailClosed {
+		// A TLS appProtocol without a BackendTLSPolicy: dialing plaintext would
+		// fail anyway, so return 502 for this backend's traffic fraction.
+		result.UnavailableStatus = http.StatusBadGateway
+	}
 
 	var backendFiltersFailClosed bool
 
@@ -1086,16 +1096,19 @@ func resolveBackendProtocol(
 	port int32,
 	rawURL string,
 	tlsAttached bool,
-) (BackendProtocol, string, bool) {
+	sink *diagSink,
+) (BackendProtocol, string, bool, bool) {
 	if resolver == nil {
-		return BackendProtocolHTTP, rawURL, false
+		return BackendProtocolHTTP, rawURL, false, false
 	}
 
 	appProto := resolver(ctx, namespace, serviceName, port)
 
 	switch appProto {
 	case appProtocolH2C:
-		return resolveH2C(rawURL, tlsAttached, namespace, serviceName, port)
+		proto, u := resolveH2C(rawURL, tlsAttached, namespace, serviceName, port)
+
+		return proto, u, false, false
 	case appProtocolWS:
 		if tlsAttached {
 			warnCleartextHintSuppressed(
@@ -1103,23 +1116,31 @@ func resolveBackendProtocol(
 				namespace, serviceName, port)
 		}
 
-		return BackendProtocolHTTP, rawURL, true
+		return BackendProtocolHTTP, rawURL, true, false
 	case appProtocolWSS:
-		warnUnpolicedTLSHint(tlsAttached,
-			"backend declares appProtocol wss but no BackendTLSPolicy targets it — WebSocket upgrade will be attempted in plaintext",
-			namespace, serviceName, port, appProto)
+		// TLS-bearing WebSocket: without a BackendTLSPolicy the proxy has no
+		// trust anchor and the upgrade would fail. Fail the backend closed
+		// (502) and surface it, instead of dialing plaintext to a TLS backend.
+		fc := unpolicedTLSAppProtocol(tlsAttached, namespace, serviceName, port, appProto, sink)
 
-		return BackendProtocolHTTP, rawURL, true
+		return BackendProtocolHTTP, rawURL, true, fc
 	case "https", "HTTPS":
-		warnUnpolicedTLSHint(tlsAttached,
-			"backend declares appProtocol https but no BackendTLSPolicy targets it — request will be sent in plaintext",
-			namespace, serviceName, port, appProto)
+		fc := unpolicedTLSAppProtocol(tlsAttached, namespace, serviceName, port, appProto, sink)
 
-		return BackendProtocolHTTP, rawURL, false
+		return BackendProtocolHTTP, rawURL, false, fc
 	case "", "http", "HTTP":
 		// Default / cleartext hints match the default transport — silent.
-		return BackendProtocolHTTP, rawURL, false
+		return BackendProtocolHTTP, rawURL, false, false
 	default:
+		// Unrecognised appProtocol: HTTP/1.1 is a safe default the backend may
+		// well speak, so keep serving (report-only) but surface that the hint
+		// was not honoured.
+		sink.add(
+			DiagnosticResolvedRefs,
+			string(gatewayv1.RouteReasonUnsupportedProtocol),
+			unknownAppProtocolMessage(serviceName, appProto),
+			false,
+		)
 		slog.Warn("unsupported backend appProtocol; falling back to HTTP/1.1",
 			"namespace", namespace,
 			"service", serviceName,
@@ -1127,8 +1148,57 @@ func resolveBackendProtocol(
 			"appProtocol", appProto,
 		)
 
-		return BackendProtocolHTTP, rawURL, false
+		return BackendProtocolHTTP, rawURL, false, false
 	}
+}
+
+// unpolicedTLSAppProtocol handles a TLS-bearing appProtocol (https, wss). When a
+// BackendTLSPolicy is attached the hint is honoured silently. Without one the
+// proxy has no CA to verify against, so per the Gateway API spec this is an
+// unsupported app protocol: the backend fails closed (502) and a
+// ResolvedRefs-target diagnostic is recorded. Returns whether the backend must
+// fail closed.
+func unpolicedTLSAppProtocol(tlsAttached bool, namespace, serviceName string, port int32, appProto string, sink *diagSink) bool {
+	if tlsAttached {
+		return false
+	}
+
+	sink.add(
+		DiagnosticResolvedRefs,
+		string(gatewayv1.RouteReasonUnsupportedProtocol),
+		unpolicedTLSMessage(serviceName, appProto),
+		false,
+	)
+	slog.Warn("failing backend closed: TLS appProtocol without a BackendTLSPolicy",
+		"namespace", namespace,
+		"service", serviceName,
+		"port", port,
+		"appProtocol", appProto,
+	)
+
+	return true
+}
+
+// unpolicedTLSMessage builds the actionable status message for a TLS appProtocol
+// declared without a BackendTLSPolicy.
+func unpolicedTLSMessage(serviceName, appProto string) string {
+	return fmt.Sprintf(
+		"Service %q declares appProtocol %q but no BackendTLSPolicy targets it; "+
+			"the proxy has no CA to verify the backend, so requests to it receive HTTP 502. "+
+			"Attach a BackendTLSPolicy to the Service to enable TLS to this backend.",
+		serviceName, appProto,
+	)
+}
+
+// unknownAppProtocolMessage builds the status message for an unrecognised
+// appProtocol value the proxy falls back to HTTP/1.1 for.
+func unknownAppProtocolMessage(serviceName, appProto string) string {
+	return fmt.Sprintf(
+		"Service %q declares an unsupported appProtocol %q; the proxy serves it over HTTP/1.1. "+
+			"Use a supported value (kubernetes.io/h2c, kubernetes.io/ws, kubernetes.io/wss, https) "+
+			"or remove the appProtocol if HTTP/1.1 is correct.",
+		serviceName, appProto,
+	)
 }
 
 // resolveH2C handles the `kubernetes.io/h2c` branch. Extracted so
@@ -1141,35 +1211,16 @@ func resolveBackendProtocol(
 // suppressed h2c hint so the operator sees the conflict. Otherwise rewrite
 // any https:// URL (which buildServiceURL emits for port 443) back to
 // http:// so the h2c transport dials cleartext.
-func resolveH2C(rawURL string, tlsAttached bool, namespace, serviceName string, port int32) (BackendProtocol, string, bool) {
+func resolveH2C(rawURL string, tlsAttached bool, namespace, serviceName string, port int32) (BackendProtocol, string) {
 	if tlsAttached {
 		warnCleartextHintSuppressed(
 			"appProtocol kubernetes.io/h2c suppressed by BackendTLSPolicy on the same Service — HTTP/2 will be negotiated over TLS via ALPN",
 			namespace, serviceName, port)
 
-		return BackendProtocolHTTP, rawURL, false
+		return BackendProtocolHTTP, rawURL
 	}
 
-	return BackendProtocolH2C, strings.Replace(rawURL, schemeHTTPS+"://", schemeHTTP+"://", 1), false
-}
-
-// warnUnpolicedTLSHint logs a WARN when an operator declared a TLS-bearing
-// appProtocol (https, wss) without attaching a BackendTLSPolicy. Without a
-// CA the proxy cannot verify and will dial plaintext — the backend will
-// reject the request and the operator deserves a clear signal about the
-// misconfiguration. Extracted from resolveBackendProtocol because the
-// pattern is shared by both `https` and `wss`.
-func warnUnpolicedTLSHint(tlsAttached bool, message, namespace, serviceName string, port int32, appProto string) {
-	if tlsAttached {
-		return
-	}
-
-	slog.Warn(message,
-		"namespace", namespace,
-		"service", serviceName,
-		"port", port,
-		"appProtocol", appProto,
-	)
+	return BackendProtocolH2C, strings.Replace(rawURL, schemeHTTPS+"://", schemeHTTP+"://", 1)
 }
 
 // warnCleartextHintSuppressed logs a WARN when an operator declared a

--- a/internal/proxy/converter.go
+++ b/internal/proxy/converter.go
@@ -109,14 +109,18 @@ func ConvertHTTPRoutes(
 		Version: configVersionCounter.Add(1),
 	}
 
+	sink := &diagSink{}
+
 	for _, route := range routes {
+		sink.route(route.Namespace, route.Name)
 		hostnames := convertHostnames(route.Spec.Hostnames)
 		clientCert := resolveFirstParentClientCert(ctx, route, gatewayCertResolver)
 
 		for ruleIdx := range route.Spec.Rules {
+			sink.at(ruleIdx)
 			proxyRule := convertHTTPRouteRule(
 				ctx, &route.Spec.Rules[ruleIdx], hostnames,
-				route.Namespace, clusterDomain, validator, protocolResolver, tlsResolver, clientCert,
+				route.Namespace, clusterDomain, validator, protocolResolver, tlsResolver, clientCert, sink,
 			)
 
 			// Rules with no backends and no redirect filter are kept —
@@ -126,6 +130,8 @@ func ConvertHTTPRoutes(
 			cfg.Rules = append(cfg.Rules, proxyRule)
 		}
 	}
+
+	cfg.Diagnostics = sink.items
 
 	return cfg
 }
@@ -206,6 +212,7 @@ func convertHTTPRouteRule(
 	resolver BackendProtocolResolver,
 	tlsResolver BackendTLSResolver,
 	clientCert *ClientCertConfig,
+	sink *diagSink,
 ) RouteRule {
 	proxyRule := RouteRule{
 		Hostnames: hostnames,
@@ -216,14 +223,20 @@ func convertHTTPRouteRule(
 	}
 
 	for filterIdx := range rule.Filters {
-		converted := convertFilter(ctx, &rule.Filters[filterIdx], namespace, clusterDomain, validator, tlsResolver, clientCert)
+		converted, failClosed := convertFilter(
+			ctx, &rule.Filters[filterIdx], namespace, clusterDomain, validator, tlsResolver, clientCert, sink, filterScopeRule,
+		)
+		if failClosed {
+			proxyRule.UnavailableStatus = http.StatusInternalServerError
+		}
+
 		if converted != nil {
 			proxyRule.Filters = append(proxyRule.Filters, *converted)
 		}
 	}
 
 	for backendIdx := range rule.BackendRefs {
-		backend, ok := convertBackendRef(ctx, &rule.BackendRefs[backendIdx], namespace, clusterDomain, validator, resolver, tlsResolver, clientCert)
+		backend, ok := convertBackendRef(ctx, &rule.BackendRefs[backendIdx], namespace, clusterDomain, validator, resolver, tlsResolver, clientCert, sink)
 		if ok {
 			proxyRule.Backends = append(proxyRule.Backends, backend)
 		}
@@ -416,6 +429,23 @@ func convertQueryMatch(query gatewayv1.HTTPQueryParamMatch) QueryParamMatch {
 	return result
 }
 
+// filterScopeRule and filterScopeBackend label where an unsupported filter was
+// found, for the diagnostic message and to decide whether the whole rule (rule
+// scope) or only a backend fraction (backend scope) fails closed.
+const (
+	filterScopeRule    = "rule"
+	filterScopeBackend = "backend"
+)
+
+// convertFilter maps a single HTTPRouteFilter into the proxy wire shape. The
+// boolean return reports whether the filter type is unsupported and the rule
+// must therefore fail closed: per the Gateway API spec an unresolvable custom
+// filter (ExtensionRef) or unknown filter type MUST NOT be silently skipped —
+// matched requests MUST receive an HTTP error response, and the route's status
+// MUST reflect the UnsupportedValue. The caller stamps the rule (or backend)
+// with UnavailableStatus and the converter records a diagnostic via sink. A nil
+// return with failClosed=false is a benign skip (nil filter payload, which the
+// CRD admission webhook already prevents) and leaves the rule servable.
 func convertFilter(
 	ctx context.Context,
 	filter *gatewayv1.HTTPRouteFilter,
@@ -423,30 +453,52 @@ func convertFilter(
 	validator BackendRefValidator,
 	tlsResolver BackendTLSResolver,
 	clientCert *ClientCertConfig,
-) *RouteFilter {
+	sink *diagSink,
+	scope string,
+) (*RouteFilter, bool) {
 	switch filter.Type {
 	case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
-		return convertRequestHeaderFilter(filter.RequestHeaderModifier)
+		return convertRequestHeaderFilter(filter.RequestHeaderModifier), false
 	case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
-		return convertResponseHeaderFilter(filter.ResponseHeaderModifier)
+		return convertResponseHeaderFilter(filter.ResponseHeaderModifier), false
 	case gatewayv1.HTTPRouteFilterRequestRedirect:
-		return convertRedirectFilter(filter.RequestRedirect)
+		return convertRedirectFilter(filter.RequestRedirect), false
 	case gatewayv1.HTTPRouteFilterURLRewrite:
-		return convertURLRewriteFilter(filter.URLRewrite)
+		return convertURLRewriteFilter(filter.URLRewrite), false
 	case gatewayv1.HTTPRouteFilterRequestMirror:
-		return convertMirrorFilter(ctx, filter.RequestMirror, namespace, clusterDomain, validator, tlsResolver, clientCert)
+		return convertMirrorFilter(ctx, filter.RequestMirror, namespace, clusterDomain, validator, tlsResolver, clientCert), false
 	case gatewayv1.HTTPRouteFilterCORS:
-		return convertCORSFilter(filter.CORS)
-	case gatewayv1.HTTPRouteFilterExtensionRef,
-		gatewayv1.HTTPRouteFilterExternalAuth:
-		slog.Warn("skipping unsupported filter type", "type", filter.Type)
-
-		return nil
+		return convertCORSFilter(filter.CORS), false
+	case gatewayv1.HTTPRouteFilterExtensionRef, gatewayv1.HTTPRouteFilterExternalAuth:
+		// Unsupported: handled by the fail-closed path below. Listed explicitly so
+		// the exhaustive linter confirms every enum value is accounted for.
 	}
 
-	slog.Warn("skipping unknown filter type", "type", filter.Type)
+	// ExtensionRef, ExternalAuth, and any unknown type are unsupported: fail the
+	// rule (or backend) closed and surface it on the route status. A rule-scoped
+	// filter takes the whole rule down; a backend-scoped one only the backend's
+	// traffic fraction.
+	sink.add(
+		DiagnosticAccepted,
+		string(gatewayv1.RouteReasonUnsupportedValue),
+		unsupportedFilterMessage(scope, string(filter.Type)),
+		scope == filterScopeRule,
+	)
+	slog.Warn("failing closed: unsupported filter type", "type", filter.Type, "scope", scope)
 
-	return nil
+	return nil, true
+}
+
+// unsupportedFilterMessage builds the actionable status message for a filter
+// type the proxy cannot serve. It names the offending type, the consequence
+// (HTTP 500 for matched requests), and the supported alternatives.
+func unsupportedFilterMessage(scope, filterType string) string {
+	return fmt.Sprintf(
+		"%s filter type %q is not supported; matching requests receive HTTP 500. "+
+			"Remove the filter or replace it with a supported type "+
+			"(RequestHeaderModifier, ResponseHeaderModifier, RequestRedirect, URLRewrite, RequestMirror, CORS).",
+		scope, filterType,
+	)
 }
 
 func convertRequestHeaderFilter(modifier *gatewayv1.HTTPHeaderFilter) *RouteFilter {
@@ -830,6 +882,7 @@ func convertBackendRef(
 	resolver BackendProtocolResolver,
 	tlsResolver BackendTLSResolver,
 	clientCert *ClientCertConfig,
+	sink *diagSink,
 ) (BackendRef, bool) {
 	result, ok := initBackendRefBaseline(backend)
 	if !ok {
@@ -872,7 +925,15 @@ func convertBackendRef(
 	result.TLS = attachGatewayClientCert(result.TLS, clientCert)
 	result.Protocol, result.URL, result.WebSocket = resolveBackendProtocol(ctx, resolver, svcNamespace, serviceName, port, result.URL, result.TLS != nil)
 
-	result.Filters = convertBackendFilters(ctx, backend.Filters, namespace, clusterDomain, validator, tlsResolver, clientCert)
+	var backendFiltersFailClosed bool
+
+	result.Filters, backendFiltersFailClosed = convertBackendFilters(ctx, backend.Filters, namespace, clusterDomain, validator, tlsResolver, clientCert, sink)
+	if backendFiltersFailClosed {
+		// An unsupported per-backend filter must fail closed for this backend's
+		// traffic fraction, exactly like an invalid backendRef: requests routed
+		// to it receive HTTP 500 rather than being served without the filter.
+		result.UnavailableStatus = http.StatusInternalServerError
+	}
 
 	return result, true
 }
@@ -1137,21 +1198,30 @@ func convertBackendFilters(
 	validator BackendRefValidator,
 	tlsResolver BackendTLSResolver,
 	clientCert *ClientCertConfig,
-) []RouteFilter {
+	sink *diagSink,
+) ([]RouteFilter, bool) {
 	if len(filters) == 0 {
-		return nil
+		return nil, false
 	}
 
 	result := make([]RouteFilter, 0, len(filters))
 
+	var failClosed bool
+
 	for filterIdx := range filters {
-		converted := convertFilter(ctx, &filters[filterIdx], namespace, clusterDomain, validator, tlsResolver, clientCert)
+		converted, filterFailClosed := convertFilter(
+			ctx, &filters[filterIdx], namespace, clusterDomain, validator, tlsResolver, clientCert, sink, filterScopeBackend,
+		)
+		if filterFailClosed {
+			failClosed = true
+		}
+
 		if converted != nil {
 			result = append(result, *converted)
 		}
 	}
 
-	return result
+	return result, failClosed
 }
 
 func resolveBackendNamespace(backend *gatewayv1.HTTPBackendRef, fallback string) string {

--- a/internal/proxy/converter_test.go
+++ b/internal/proxy/converter_test.go
@@ -260,9 +260,9 @@ func TestConvertHTTPRoutes_AppProtocolWS_NoWarn(t *testing.T) {
 
 // TestConvertHTTPRoutes_AppProtocolWSS_WithoutPolicy_Warns pins that declaring
 // `appProtocol: kubernetes.io/wss` without a matching BackendTLSPolicy logs a
-// WARN — operators hinted TLS but provided no trust anchor, so the proxy will
-// dial plaintext and the backend (expecting TLS) will refuse the upgrade.
-// Identical fail-closed semantics to the existing `appProtocol: https` path.
+// Fail-closed: operators hinted TLS but provided no trust anchor, so the proxy
+// cannot verify the backend. Rather than dial plaintext to a TLS backend, it
+// fails the backend closed (502) and records a ResolvedRefs diagnostic.
 func TestConvertHTTPRoutes_AppProtocolWSS_WithoutPolicy_Warns(t *testing.T) {
 	pathPrefix := gatewayv1.PathMatchPathPrefix
 	routes := []*gatewayv1.HTTPRoute{httpAppProtocolTestRoute(pathPrefix)}
@@ -278,10 +278,10 @@ func TestConvertHTTPRoutes_AppProtocolWSS_WithoutPolicy_Warns(t *testing.T) {
 	require.Len(t, cfg.Rules[0].Backends, 1)
 	assert.Equal(t, proxy.BackendProtocolHTTP, cfg.Rules[0].Backends[0].Protocol)
 	assert.Nil(t, cfg.Rules[0].Backends[0].TLS, "no policy attached → no TLS config")
-	assert.Contains(t, logs.String(), "appProtocol wss but no BackendTLSPolicy",
-		"appProtocol wss without a policy MUST log a warning so the misconfiguration is visible")
+	assert.Contains(t, logs.String(), "failing backend closed: TLS appProtocol without a BackendTLSPolicy",
+		"appProtocol wss without a policy MUST log so the fail-closed is visible")
 	assert.NotContains(t, logs.String(), "unsupported backend appProtocol",
-		"wss is a known appProtocol — must not be classified as 'unsupported'")
+		"wss is a known appProtocol — must not be classified as the generic 'unsupported' fallback")
 }
 
 // TestConvertHTTPRoutes_AppProtocolWS_WithPolicy_Warns surfaces the same
@@ -534,9 +534,9 @@ func TestConvertHTTPRoutes_AppProtocolPlaintextPassThrough(t *testing.T) {
 }
 
 // TestConvertHTTPRoutes_AppProtocolHTTPSWithoutPolicy_Warns confirms that
-// declaring `appProtocol: https` without a matching BackendTLSPolicy logs a
-// WARN — the proxy would otherwise dial in plaintext, silently violating the
-// operator's TLS intent.
+// declaring `appProtocol: https` without a matching BackendTLSPolicy fails the
+// backend closed and logs it — the proxy would otherwise dial plaintext,
+// silently violating the operator's TLS intent.
 func TestConvertHTTPRoutes_AppProtocolHTTPSWithoutPolicy_Warns(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -562,8 +562,8 @@ func TestConvertHTTPRoutes_AppProtocolHTTPSWithoutPolicy_Warns(t *testing.T) {
 			require.Len(t, cfg.Rules[0].Backends, 1)
 			assert.Equal(t, proxy.BackendProtocolHTTP, cfg.Rules[0].Backends[0].Protocol)
 			assert.Nil(t, cfg.Rules[0].Backends[0].TLS, "no policy attached → no TLS config")
-			assert.Contains(t, logs.String(), "appProtocol https but no BackendTLSPolicy",
-				"appProtocol https without a policy MUST log a warning so the misconfiguration is visible")
+			assert.Contains(t, logs.String(), "failing backend closed: TLS appProtocol without a BackendTLSPolicy",
+				"appProtocol https without a policy MUST log so the fail-closed is visible")
 		})
 	}
 }

--- a/internal/proxy/diagnostics.go
+++ b/internal/proxy/diagnostics.go
@@ -16,6 +16,22 @@ const (
 	// resolved or declares an app protocol this implementation does not support.
 	// The controller sets ResolvedRefs=False.
 	DiagnosticResolvedRefs DiagnosticTarget = "ResolvedRefs"
+	// DiagnosticEvent means the config was applied successfully but a redundant
+	// or conflicting hint was overridden (a benign override, e.g. an appProtocol
+	// cleartext hint superseded by a BackendTLSPolicy, or a ResponseHeaderModifier
+	// that strips a WebSocket handshake header). No standard Gateway API condition
+	// fits, so the controller emits a Kubernetes Event instead of a condition.
+	DiagnosticEvent DiagnosticTarget = "Event"
+)
+
+// Kubernetes Event types for a RouteDiagnostic whose Target is DiagnosticEvent.
+const (
+	// EventTypeNormal marks a benign override the proxy handled correctly (e.g.
+	// "TLS wins" over a cleartext appProtocol hint).
+	EventTypeNormal = "Normal"
+	// EventTypeWarning marks an operator-authored conflict honored as written but
+	// with a consequence worth flagging (e.g. stripping a WS handshake header).
+	EventTypeWarning = "Warning"
 )
 
 // RouteDiagnostic records a piece of a route's spec the controller will not
@@ -39,6 +55,9 @@ type RouteDiagnostic struct {
 	// (every rule wholly unservable) versus PartiallyInvalid=True (some rules or
 	// backends degraded while the route still serves).
 	WholeRule bool
+	// EventType is "Normal" or "Warning"; only meaningful when Target is
+	// DiagnosticEvent. The controller passes it to EventRecorder.Event.
+	EventType string
 }
 
 // diagSink accumulates RouteDiagnostics during a single conversion pass. It is
@@ -90,5 +109,22 @@ func (s *diagSink) add(target DiagnosticTarget, reason, message string, wholeRul
 		Reason:    reason,
 		Message:   message,
 		WholeRule: wholeRule,
+	})
+}
+
+// event records a benign-override diagnostic surfaced as a Kubernetes Event.
+// eventType is EventTypeNormal or EventTypeWarning.
+func (s *diagSink) event(eventType, message string) {
+	if s == nil {
+		return
+	}
+
+	s.items = append(s.items, RouteDiagnostic{
+		Namespace: s.namespace,
+		Name:      s.name,
+		RuleIndex: s.rule,
+		Target:    DiagnosticEvent,
+		Message:   message,
+		EventType: eventType,
 	})
 }

--- a/internal/proxy/diagnostics.go
+++ b/internal/proxy/diagnostics.go
@@ -1,0 +1,94 @@
+package proxy
+
+// DiagnosticTarget identifies which status surface a RouteDiagnostic maps to.
+// The proxy converter classifies each silently-unsupported/dropped config path
+// per the Gateway API spec; the controller turns the classification into the
+// matching condition (or a Kubernetes Event for benign overrides).
+type DiagnosticTarget string
+
+const (
+	// DiagnosticAccepted means a rule cannot be served as written (e.g. it
+	// carries an unsupported filter). The controller aggregates these per route:
+	// when every rule of the route is affected it sets Accepted=False, otherwise
+	// it sets PartiallyInvalid=True with a "Dropped Rule" message.
+	DiagnosticAccepted DiagnosticTarget = "Accepted"
+	// DiagnosticResolvedRefs means a backend/object reference could not be
+	// resolved or declares an app protocol this implementation does not support.
+	// The controller sets ResolvedRefs=False.
+	DiagnosticResolvedRefs DiagnosticTarget = "ResolvedRefs"
+)
+
+// RouteDiagnostic records a piece of a route's spec the controller will not
+// serve exactly as written. It is produced by the proxy converter and consumed
+// by the controller's status writer. It never crosses the proxy wire (Config
+// carries the slice with a json:"-" tag), so it stays a controller-side concern.
+//
+// Message must be explicit and actionable: it names the problem AND the fix in
+// plain words the operator can act on without reading the controller source.
+type RouteDiagnostic struct {
+	Namespace string
+	Name      string
+	RuleIndex int
+	Target    DiagnosticTarget
+	Reason    string // gateway-api RouteConditionReason, e.g. "UnsupportedValue"
+	Message   string
+	// WholeRule is true when the entire rule is unservable (e.g. a rule-level
+	// unsupported filter makes every matched request fail closed), false when
+	// only a backend traffic fraction is affected (e.g. a backend-level
+	// unsupported filter). The status writer uses it to decide Accepted=False
+	// (every rule wholly unservable) versus PartiallyInvalid=True (some rules or
+	// backends degraded while the route still serves).
+	WholeRule bool
+}
+
+// diagSink accumulates RouteDiagnostics during a single conversion pass. It is
+// stamped with the current route identity and rule index so the deep tree of
+// leaf converter functions can emit diagnostics without threading identity and
+// rule index through every signature.
+//
+// It is nil-safe: every method is a no-op on a nil receiver, so converter
+// helpers can be reached from call paths that do not collect diagnostics.
+type diagSink struct {
+	namespace string
+	name      string
+	rule      int
+	items     []RouteDiagnostic
+}
+
+// route sets the identity stamped onto subsequently-added diagnostics.
+func (s *diagSink) route(namespace, name string) {
+	if s == nil {
+		return
+	}
+
+	s.namespace = namespace
+	s.name = name
+}
+
+// at sets the rule index stamped onto subsequently-added diagnostics.
+func (s *diagSink) at(rule int) {
+	if s == nil {
+		return
+	}
+
+	s.rule = rule
+}
+
+// add records a condition-bound diagnostic. wholeRule is true when the entire
+// rule is unservable (rule-level cause), false when only a backend fraction is
+// affected (backend-level cause).
+func (s *diagSink) add(target DiagnosticTarget, reason, message string, wholeRule bool) {
+	if s == nil {
+		return
+	}
+
+	s.items = append(s.items, RouteDiagnostic{
+		Namespace: s.namespace,
+		Name:      s.name,
+		RuleIndex: s.rule,
+		Target:    target,
+		Reason:    reason,
+		Message:   message,
+		WholeRule: wholeRule,
+	})
+}

--- a/internal/proxy/diagnostics_test.go
+++ b/internal/proxy/diagnostics_test.go
@@ -1,0 +1,192 @@
+package proxy_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// TestConvertHTTPRoutes_UnsupportedRuleFilter_FailsClosedWithDiagnostic pins
+// the spec-mandated behaviour for an unsupported rule-level filter
+// (ExtensionRef / ExternalAuth / unknown): the rule fails closed (HTTP 500 for
+// matched requests) and the converter records an Accepted-target diagnostic
+// carrying UnsupportedValue with an actionable message. Per the Gateway API
+// spec such a filter MUST NOT be silently dropped.
+func TestConvertHTTPRoutes_UnsupportedRuleFilter_FailsClosedWithDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	extName := gatewayv1.ObjectName("myfilter")
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Filters: []gatewayv1.HTTPRouteFilter{
+							{
+								Type: gatewayv1.HTTPRouteFilterExtensionRef,
+								ExtensionRef: &gatewayv1.LocalObjectReference{
+									Group: "networking.example.net",
+									Kind:  "MyFilter",
+									Name:  extName,
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("web-svc", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	assert.Equal(t, http.StatusInternalServerError, cfg.Rules[0].UnavailableStatus,
+		"rule with an unsupported filter must fail closed")
+
+	require.Len(t, cfg.Diagnostics, 1)
+	diag := cfg.Diagnostics[0]
+	assert.Equal(t, "default", diag.Namespace)
+	assert.Equal(t, "web", diag.Name)
+	assert.Equal(t, 0, diag.RuleIndex)
+	assert.Equal(t, proxy.DiagnosticAccepted, diag.Target)
+	assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), diag.Reason)
+	assert.True(t, diag.WholeRule, "a rule-level unsupported filter takes the whole rule down")
+	assert.Contains(t, diag.Message, "ExtensionRef", "message must name the offending filter type")
+	assert.Contains(t, diag.Message, "500", "message must name the consequence")
+}
+
+// TestConvertHTTPRoutes_SupportedFilter_NoDiagnostic confirms the happy path:
+// a supported filter produces no diagnostic and leaves the rule servable.
+func TestConvertHTTPRoutes_SupportedFilter_NoDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Filters: []gatewayv1.HTTPRouteFilter{
+							{
+								Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+									Set: []gatewayv1.HTTPHeader{{Name: "X-Test", Value: "1"}},
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("web-svc", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	assert.Zero(t, cfg.Rules[0].UnavailableStatus)
+	assert.Empty(t, cfg.Diagnostics)
+}
+
+// TestConvertHTTPRoutes_UnsupportedBackendFilter_FailsBackendClosed pins that
+// an unsupported per-backend filter fails that backend closed (its traffic
+// fraction returns HTTP 500) and records a diagnostic, while the rule itself
+// stays servable for any sibling backends.
+func TestConvertHTTPRoutes_UnsupportedBackendFilter_FailsBackendClosed(t *testing.T) {
+	t.Parallel()
+
+	extName := gatewayv1.ObjectName("myfilter")
+	backend := backendRef("web-svc", 80, 1)
+	backend.Filters = []gatewayv1.HTTPRouteFilter{
+		{
+			Type: gatewayv1.HTTPRouteFilterExtensionRef,
+			ExtensionRef: &gatewayv1.LocalObjectReference{
+				Group: "networking.example.net",
+				Kind:  "MyFilter",
+				Name:  extName,
+			},
+		},
+	}
+
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules:     []gatewayv1.HTTPRouteRule{{BackendRefs: []gatewayv1.HTTPBackendRef{backend}}},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Equal(t, http.StatusInternalServerError, cfg.Rules[0].Backends[0].UnavailableStatus,
+		"backend with an unsupported filter must fail that backend closed")
+
+	require.Len(t, cfg.Diagnostics, 1)
+	assert.Equal(t, proxy.DiagnosticAccepted, cfg.Diagnostics[0].Target)
+	assert.False(t, cfg.Diagnostics[0].WholeRule,
+		"a backend-level filter affects only the backend fraction, not the whole rule")
+	assert.Zero(t, cfg.Rules[0].UnavailableStatus,
+		"the rule itself stays servable — only the backend fraction fails closed")
+}
+
+// TestConvertGRPCRoutes_FiltersFailClosedWithDiagnostic pins that a GRPCRoute
+// rule carrying any filter (none are supported yet) fails closed and records an
+// Accepted-target diagnostic, rather than the rule serving silently without the
+// declared filter.
+func TestConvertGRPCRoutes_FiltersFailClosedWithDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	svc := gatewayv1.ObjectName("grpc-svc")
+	port := gatewayv1.PortNumber(9000)
+	routes := []*gatewayv1.GRPCRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "grpc", Namespace: "default"},
+			Spec: gatewayv1.GRPCRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"grpc.example.com"},
+				Rules: []gatewayv1.GRPCRouteRule{
+					{
+						Filters: []gatewayv1.GRPCRouteFilter{
+							{Type: gatewayv1.GRPCRouteFilterRequestHeaderModifier},
+						},
+						BackendRefs: []gatewayv1.GRPCBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{Name: svc, Port: &port},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertGRPCRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	assert.Equal(t, http.StatusInternalServerError, cfg.Rules[0].UnavailableStatus)
+
+	require.Len(t, cfg.Diagnostics, 1)
+	diag := cfg.Diagnostics[0]
+	assert.Equal(t, "grpc", diag.Name)
+	assert.Equal(t, proxy.DiagnosticAccepted, diag.Target)
+	assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), diag.Reason)
+	assert.True(t, diag.WholeRule, "gRPC filters fail the whole rule closed")
+	assert.True(t, strings.Contains(diag.Message, "filter"), "message must mention filters")
+}

--- a/internal/proxy/diagnostics_test.go
+++ b/internal/proxy/diagnostics_test.go
@@ -190,3 +190,52 @@ func TestConvertGRPCRoutes_FiltersFailClosedWithDiagnostic(t *testing.T) {
 	assert.True(t, diag.WholeRule, "gRPC filters fail the whole rule closed")
 	assert.True(t, strings.Contains(diag.Message, "filter"), "message must mention filters")
 }
+
+// TestConvertGRPCRoutes_BackendFiltersFailClosedWithDiagnostic pins that a
+// GRPCRoute *backend*-scoped filter (none are supported yet) fails that backend
+// closed — its traffic fraction returns HTTP 500 — and records a backend-scope
+// diagnostic, rather than being silently dropped while the rule serves on. This
+// is the gRPC analogue of the HTTP per-backend filter fail-closed.
+func TestConvertGRPCRoutes_BackendFiltersFailClosedWithDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	svc := gatewayv1.ObjectName("grpc-svc")
+	port := gatewayv1.PortNumber(9000)
+	routes := []*gatewayv1.GRPCRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "grpc", Namespace: "default"},
+			Spec: gatewayv1.GRPCRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"grpc.example.com"},
+				Rules: []gatewayv1.GRPCRouteRule{
+					{
+						BackendRefs: []gatewayv1.GRPCBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{Name: svc, Port: &port},
+								},
+								Filters: []gatewayv1.GRPCRouteFilter{
+									{Type: gatewayv1.GRPCRouteFilterRequestHeaderModifier},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertGRPCRoutes(context.Background(), routes, "cluster.local", nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	assert.Zero(t, cfg.Rules[0].UnavailableStatus, "a backend-scoped filter must not fail the whole rule closed")
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Equal(t, http.StatusInternalServerError, cfg.Rules[0].Backends[0].UnavailableStatus,
+		"the backend carrying an unsupported filter must fail that backend closed")
+
+	require.Len(t, cfg.Diagnostics, 1)
+	diag := cfg.Diagnostics[0]
+	assert.Equal(t, proxy.DiagnosticAccepted, diag.Target)
+	assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), diag.Reason)
+	assert.False(t, diag.WholeRule, "a backend-scoped filter affects only the backend fraction")
+	assert.Contains(t, diag.Message, "filter", "message must mention filters")
+}

--- a/internal/proxy/event_diag_test.go
+++ b/internal/proxy/event_diag_test.go
@@ -1,0 +1,105 @@
+package proxy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// findEventDiag returns the first Event-target diagnostic, or a zero value and
+// false when none is present.
+func findEventDiag(diags []proxy.RouteDiagnostic) (proxy.RouteDiagnostic, bool) {
+	for _, d := range diags {
+		if d.Target == proxy.DiagnosticEvent {
+			return d, true
+		}
+	}
+
+	return proxy.RouteDiagnostic{}, false
+}
+
+// TestConvertHTTPRoutes_H2CSuppressedByTLS_NormalEvent pins that a backend
+// declaring appProtocol kubernetes.io/h2c while also targeted by a
+// BackendTLSPolicy records a benign-override Event diagnostic (Normal): TLS
+// wins, the proxy does the right thing, and the operator is told the cleartext
+// hint was superseded. No condition is raised — config applied successfully.
+func TestConvertHTTPRoutes_H2CSuppressedByTLS_NormalEvent(t *testing.T) {
+	t.Parallel()
+
+	resolver := func(_ context.Context, _, _ string, _ int32) string { return "kubernetes.io/h2c" }
+	tlsResolver := func(_ context.Context, _, _ string, _ int32) *proxy.BackendTLSConfig {
+		return &proxy.BackendTLSConfig{CABundlePEM: "ca", ServerName: "web-svc"}
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{appProtoTestRoute()},
+		"cluster.local", nil, resolver, tlsResolver, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Zero(t, cfg.Rules[0].Backends[0].UnavailableStatus, "TLS-wins is a benign override, not a fail-closed")
+	assert.NotNil(t, cfg.Rules[0].Backends[0].TLS, "the policy still applies — TLS wins")
+
+	diag, ok := findEventDiag(cfg.Diagnostics)
+	require.True(t, ok, "h2c suppressed by a BackendTLSPolicy must record an Event diagnostic")
+	assert.Equal(t, "web", diag.Name)
+	assert.Equal(t, proxy.EventTypeNormal, diag.EventType, "a TLS-wins override is a Normal event")
+	assert.Contains(t, diag.Message, "h2c", "message must name the suppressed hint")
+}
+
+// TestConvertHTTPRoutes_WSHandshakeStrip_WarningEvent pins that a
+// ResponseHeaderModifier removing a WebSocket handshake header on a WS-marked
+// backend records a Warning Event diagnostic — the filter is honored as written
+// (per spec the pipeline runs unconditionally) but the operator is warned that
+// it breaks the upgrade.
+func TestConvertHTTPRoutes_WSHandshakeStrip_WarningEvent(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	port := gatewayv1.PortNumber(80)
+	wsBackend := gatewayv1.HTTPBackendRef{
+		BackendRef: gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{Name: "ws-svc", Port: &port},
+		},
+	}
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}}},
+						Filters: []gatewayv1.HTTPRouteFilter{
+							{
+								Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+								ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+									Remove: []string{"Sec-WebSocket-Accept"},
+								},
+							},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{wsBackend},
+					},
+				},
+			},
+		},
+	}
+
+	// Resolver marks the backend as WebSocket-capable.
+	resolver := func(_ context.Context, _, _ string, _ int32) string { return "kubernetes.io/ws" }
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, resolver, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Filters, 1, "the filter is still applied as written")
+
+	diag, ok := findEventDiag(cfg.Diagnostics)
+	require.True(t, ok, "stripping a WS handshake header must record an Event diagnostic")
+	assert.Equal(t, proxy.EventTypeWarning, diag.EventType, "breaking the WS upgrade is a Warning event")
+	assert.Contains(t, diag.Message, "Sec-WebSocket-Accept", "message must name the stripped header")
+}

--- a/internal/proxy/failclosed_test.go
+++ b/internal/proxy/failclosed_test.go
@@ -1,0 +1,70 @@
+package proxy_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// failClosedConfig builds a single-rule config whose rule is marked
+// fail-closed (UnavailableStatus) while still carrying a real backend, so a
+// passing assertion proves the rule-level short-circuit wins over backend
+// selection rather than coincidentally erroring on a dead backend.
+func failClosedConfig() *proxy.Config {
+	return &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames:         []string{"app.example.com"},
+				Matches:           []proxy.RouteMatch{{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}}},
+				UnavailableStatus: http.StatusInternalServerError,
+				Backends:          []proxy.BackendRef{{URL: "http://backend.default.svc.cluster.local:8080", Weight: 1}},
+			},
+		},
+	}
+}
+
+// TestRuleUnavailableStatusFailsClosed verifies the rule-level fail-closed
+// primitive: a matched rule carrying UnavailableStatus returns that status for
+// every matched request instead of selecting a backend. The proxy converter
+// sets this when a rule cannot be served as written (e.g. it carries an
+// unsupported filter type), per the Gateway API requirement that such requests
+// MUST receive an HTTP error response rather than be served silently.
+func TestRuleUnavailableStatusFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(failClosedConfig()))
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// TestRuleUnavailableStatusFailsClosed_TunnelWriter exercises the same
+// fail-closed path through the cloudflared HTTP/2 response-writer fake (the
+// production tunnel path), not just httptest's HTTP/1.1 writer, per the project
+// design principle that any response-flow feature is validated on the real
+// transport contract.
+func TestRuleUnavailableStatusFailsClosed_TunnelWriter(t *testing.T) {
+	t.Parallel()
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(failClosedConfig()))
+	handler := proxy.NewHandler(router)
+
+	fake := newFakeCloudflaredRespWriter()
+	t.Cleanup(func() { _ = fake.serverSide.Close(); _ = fake.clientSide.Close() })
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	handler.ServeHTTP(fake, req)
+
+	assert.Equal(t, http.StatusInternalServerError, fake.Status())
+}

--- a/internal/proxy/grpc_converter.go
+++ b/internal/proxy/grpc_converter.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"regexp"
 	"strings"
 
@@ -50,17 +52,23 @@ func ConvertGRPCRoutes(
 		Version: configVersionCounter.Add(1),
 	}
 
+	sink := &diagSink{}
+
 	for _, route := range routes {
+		sink.route(route.Namespace, route.Name)
 		hostnames := convertHostnames(route.Spec.Hostnames)
 		clientCert := resolveFirstParentClientCertForGRPCRoute(ctx, route, gatewayCertResolver)
 
 		for ruleIdx := range route.Spec.Rules {
+			sink.at(ruleIdx)
 			cfg.Rules = append(cfg.Rules, convertGRPCRouteRule(
 				ctx, &route.Spec.Rules[ruleIdx], hostnames, route.Namespace, clusterDomain,
-				validator, tlsResolver, clientCert,
+				validator, tlsResolver, clientCert, sink,
 			))
 		}
 	}
+
+	cfg.Diagnostics = sink.items
 
 	return cfg
 }
@@ -84,6 +92,7 @@ func convertGRPCRouteRule(
 	validator BackendRefValidator,
 	tlsResolver BackendTLSResolver,
 	clientCert *ClientCertConfig,
+	sink *diagSink,
 ) RouteRule {
 	proxyRule := RouteRule{Hostnames: hostnames}
 
@@ -94,7 +103,20 @@ func convertGRPCRouteRule(
 	}
 
 	if len(rule.Filters) > 0 {
-		slog.Warn("skipping GRPCRoute filters — not supported by the proxy yet",
+		// The proxy serves no GRPCRoute filters yet. Per the Gateway API spec an
+		// unsupported filter MUST NOT be silently dropped — the rule fails closed
+		// (matched gRPC requests receive HTTP 500) and the route status carries
+		// the UnsupportedValue so the operator is not left guessing.
+		sink.add(
+			DiagnosticAccepted,
+			string(gatewayv1.RouteReasonUnsupportedValue),
+			grpcFiltersUnsupportedMessage(len(rule.Filters)),
+			true,
+		)
+
+		proxyRule.UnavailableStatus = http.StatusInternalServerError
+
+		slog.Warn("failing GRPCRoute rule closed: filters not supported by the proxy",
 			"namespace", namespace, "filters", len(rule.Filters))
 	}
 
@@ -109,6 +131,18 @@ func convertGRPCRouteRule(
 	}
 
 	return proxyRule
+}
+
+// grpcFiltersUnsupportedMessage builds the actionable status message for a
+// GRPCRoute rule whose filters the proxy cannot serve. It names the count, the
+// consequence (HTTP 500 for matching requests), and the remediation.
+func grpcFiltersUnsupportedMessage(count int) string {
+	return fmt.Sprintf(
+		"%d GRPCRoute filter(s) on this rule are not supported by the proxy; "+
+			"matching requests receive HTTP 500. Remove the filters from the rule "+
+			"to restore routing.",
+		count,
+	)
 }
 
 // convertGRPCMatch maps a GRPCRouteMatch to a proxy RouteMatch. Returns

--- a/internal/proxy/grpc_converter.go
+++ b/internal/proxy/grpc_converter.go
@@ -123,7 +123,7 @@ func convertGRPCRouteRule(
 	for backendIdx := range rule.BackendRefs {
 		backend, ok := convertGRPCBackendRef(
 			ctx, &rule.BackendRefs[backendIdx], namespace, clusterDomain,
-			validator, tlsResolver, clientCert,
+			validator, tlsResolver, clientCert, sink,
 		)
 		if ok {
 			proxyRule.Backends = append(proxyRule.Backends, backend)
@@ -143,6 +143,41 @@ func grpcFiltersUnsupportedMessage(count int) string {
 			"to restore routing.",
 		count,
 	)
+}
+
+// grpcBackendFiltersUnsupportedMessage builds the actionable status message for
+// a GRPCRoute backendRef whose per-backend filters the proxy cannot serve. Only
+// that backend's traffic fraction fails closed; the rule keeps serving.
+func grpcBackendFiltersUnsupportedMessage(serviceName string, count int) string {
+	return fmt.Sprintf(
+		"%d GRPCRoute filter(s) on the backendRef to Service %q are not supported by the proxy; "+
+			"requests routed to that backend receive HTTP 500. Remove the filters from the backendRef "+
+			"to restore routing to it.",
+		count, serviceName,
+	)
+}
+
+// grpcBackendFiltersUnsupported reports whether a GRPCRoute backendRef carries
+// per-backend filters the proxy cannot serve (none are supported yet). When it
+// does, it records a backend-scope diagnostic and returns true so the caller
+// fails that backend's traffic fraction closed (HTTP 500). The rule itself keeps
+// serving its other backends — the gRPC analogue of the HTTP per-backend
+// filter fail-closed.
+func grpcBackendFiltersUnsupported(filters []gatewayv1.GRPCRouteFilter, namespace, serviceName string, sink *diagSink) bool {
+	if len(filters) == 0 {
+		return false
+	}
+
+	sink.add(
+		DiagnosticAccepted,
+		string(gatewayv1.RouteReasonUnsupportedValue),
+		grpcBackendFiltersUnsupportedMessage(serviceName, len(filters)),
+		false,
+	)
+	slog.Warn("failing GRPCRoute backend closed: per-backend filters not supported by the proxy",
+		"namespace", namespace, "service", serviceName, "filters", len(filters))
+
+	return true
 }
 
 // convertGRPCMatch maps a GRPCRouteMatch to a proxy RouteMatch. Returns
@@ -260,6 +295,7 @@ func convertGRPCBackendRef(
 	validator BackendRefValidator,
 	tlsResolver BackendTLSResolver,
 	clientCert *ClientCertConfig,
+	sink *diagSink,
 ) (BackendRef, bool) {
 	result := BackendRef{Weight: 1}
 	if backend.Weight != nil {
@@ -303,8 +339,27 @@ func convertGRPCBackendRef(
 
 	result.URL = buildServiceURL(serviceName, svcNamespace, port, clusterDomain)
 
-	// Resolve TLS: when a BackendTLSPolicy targets the Service, stamp it on
-	// the backend and let resolveBackendTLS force the https:// scheme.
+	if grpcBackendFiltersUnsupported(backend.Filters, svcNamespace, serviceName, sink) {
+		result.UnavailableStatus = http.StatusInternalServerError
+	}
+
+	applyGRPCBackendTransport(ctx, &result, tlsResolver, clientCert, svcNamespace, serviceName, port)
+
+	return result, true
+}
+
+// applyGRPCBackendTransport resolves the proxy → gRPC-backend transport on
+// result: a BackendTLSPolicy (with optional Gateway client cert) puts TLS on the
+// wire and ALPN negotiates HTTP/2; with no policy the backend is dialed cleartext
+// h2c. Extracted from convertGRPCBackendRef to keep it within the funlen budget.
+func applyGRPCBackendTransport(
+	ctx context.Context,
+	result *BackendRef,
+	tlsResolver BackendTLSResolver,
+	clientCert *ClientCertConfig,
+	svcNamespace, serviceName string,
+	port int32,
+) {
 	result.TLS, result.URL = resolveBackendTLS(ctx, tlsResolver, svcNamespace, serviceName, port, result.URL)
 	result.TLS = attachGatewayClientCert(result.TLS, clientCert)
 
@@ -312,7 +367,7 @@ func convertGRPCBackendRef(
 		// TLS is on — newTLSTransport handles ALPN HTTP/2 negotiation, the
 		// h2c marker would be ignored on that path (and is misleading), so
 		// leave Protocol at the default and keep the https:// URL.
-		return result, true
+		return
 	}
 
 	// Backward-compat path: no policy, no client cert — force cleartext h2c.
@@ -320,8 +375,6 @@ func convertGRPCBackendRef(
 	// h2c transport dials cleartext.
 	result.URL = strings.Replace(result.URL, "https://", "http://", 1)
 	result.Protocol = BackendProtocolH2C
-
-	return result, true
 }
 
 func derefString(s *string) string {

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -256,6 +256,23 @@ func NewHandler(router *Router, opts ...HandlerOption) *Handler {
 }
 
 // ServeHTTP implements http.Handler.
+// writeRuleUnavailable handles the rule-level fail-closed path: when the
+// controller marked a matched rule unservable as written (e.g. it carries an
+// unsupported filter type whose effect cannot be honoured), the Gateway API
+// spec requires matched requests to receive an HTTP error rather than be served
+// without the dropped config. Returns true when it wrote the error, so the
+// caller short-circuits before backend selection, the WebSocket upgrade, and
+// the filter pipeline — all of which would otherwise reach the backend.
+func writeRuleUnavailable(writer http.ResponseWriter, rule *RouteRule) bool {
+	if rule == nil || rule.UnavailableStatus == 0 {
+		return false
+	}
+
+	http.Error(writer, http.StatusText(rule.UnavailableStatus), rule.UnavailableStatus)
+
+	return true
+}
+
 func (h *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	// Access-log wrapping: zero cost when accessLog is nil -- the
 	// wrapper, defer, and time.Now() ALL sit inside the if branch
@@ -293,6 +310,10 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	if result == nil {
 		http.Error(writer, "no matching route", http.StatusNotFound)
 
+		return
+	}
+
+	if writeRuleUnavailable(writer, result.Rule) {
 		return
 	}
 

--- a/internal/proxy/mirror_diag_test.go
+++ b/internal/proxy/mirror_diag_test.go
@@ -1,0 +1,111 @@
+package proxy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// mirrorRoute builds a one-rule HTTPRoute whose single rule carries a
+// RequestMirror filter pointing at the given backend ref, plus a normal
+// backend so the rule itself still serves.
+func mirrorRoute(mirrorRef gatewayv1.BackendObjectReference) *gatewayv1.HTTPRoute {
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Hostnames: []gatewayv1.Hostname{"example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}}},
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type:          gatewayv1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{BackendRef: mirrorRef},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("web-svc", 80, 1)},
+				},
+			},
+		},
+	}
+}
+
+// TestConvertHTTPRoutes_MirrorNonServiceKind_ResolvedRefsDiagnostic pins that a
+// RequestMirror pointing at a non-Service kind is dropped (the main request
+// still flows) and records a ResolvedRefs-target InvalidKind diagnostic so the
+// dropped mirror is visible on the route status.
+func TestConvertHTTPRoutes_MirrorNonServiceKind_ResolvedRefsDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	group := gatewayv1.Group("example.net")
+	kind := gatewayv1.Kind("Widget")
+	port := gatewayv1.PortNumber(80)
+	ref := gatewayv1.BackendObjectReference{Group: &group, Kind: &kind, Name: "mirror-target", Port: &port}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{mirrorRoute(ref)},
+		"cluster.local", nil, nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	assert.Empty(t, cfg.Rules[0].Filters, "the unservable mirror filter is dropped")
+	require.Len(t, cfg.Rules[0].Backends, 1, "the main backend still serves")
+	assert.Zero(t, cfg.Rules[0].UnavailableStatus, "a dropped mirror does not fail the rule closed")
+
+	require.Len(t, cfg.Diagnostics, 1)
+	diag := cfg.Diagnostics[0]
+	assert.Equal(t, "web", diag.Name)
+	assert.Equal(t, proxy.DiagnosticResolvedRefs, diag.Target)
+	assert.Equal(t, string(gatewayv1.RouteReasonInvalidKind), diag.Reason)
+	assert.False(t, diag.WholeRule)
+	assert.Contains(t, diag.Message, "mirror", "message must name the dropped mirror")
+}
+
+// TestConvertHTTPRoutes_MirrorUnauthorizedCrossNamespace_RefNotPermitted pins
+// that a cross-namespace mirror ref blocked by a missing ReferenceGrant is
+// dropped and recorded as ResolvedRefs / RefNotPermitted.
+func TestConvertHTTPRoutes_MirrorUnauthorizedCrossNamespace_RefNotPermitted(t *testing.T) {
+	t.Parallel()
+
+	otherNS := gatewayv1.Namespace("other")
+	port := gatewayv1.PortNumber(80)
+	ref := gatewayv1.BackendObjectReference{Name: "mirror-target", Namespace: &otherNS, Port: &port}
+
+	// validator returns false → cross-namespace ref not permitted.
+	validator := func(_ context.Context, _ string, _ gatewayv1.BackendObjectReference) bool { return false }
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{mirrorRoute(ref)},
+		"cluster.local", validator, nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	assert.Empty(t, cfg.Rules[0].Filters, "the unauthorized mirror filter is dropped")
+
+	require.Len(t, cfg.Diagnostics, 1)
+	diag := cfg.Diagnostics[0]
+	assert.Equal(t, proxy.DiagnosticResolvedRefs, diag.Target)
+	assert.Equal(t, string(gatewayv1.RouteReasonRefNotPermitted), diag.Reason)
+	assert.False(t, diag.WholeRule)
+}
+
+// TestConvertHTTPRoutes_MirrorValid_NoDiagnostic confirms a valid same-namespace
+// mirror produces the filter and no diagnostic.
+func TestConvertHTTPRoutes_MirrorValid_NoDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	port := gatewayv1.PortNumber(80)
+	ref := gatewayv1.BackendObjectReference{Name: "mirror-target", Port: &port}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), []*gatewayv1.HTTPRoute{mirrorRoute(ref)},
+		"cluster.local", nil, nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Filters, 1, "a valid mirror is preserved")
+	assert.Equal(t, proxy.FilterRequestMirror, cfg.Rules[0].Filters[0].Type)
+	assert.Empty(t, cfg.Diagnostics)
+}

--- a/internal/proxy/timeouts_diag_test.go
+++ b/internal/proxy/timeouts_diag_test.go
@@ -1,0 +1,86 @@
+package proxy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// TestConvertHTTPRoutes_InvalidTimeouts_PartiallyInvalidDiagnostic pins that a
+// rule whose timeouts fail to parse is still served (without the timeout), but
+// records an Accepted-target diagnostic with WholeRule=false so the controller
+// raises PartiallyInvalid rather than Accepted=False — the route still works,
+// only the timeout was dropped.
+func TestConvertHTTPRoutes_InvalidTimeouts_PartiallyInvalidDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	badRequest := gatewayv1.Duration("not-a-duration")
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches:     []gatewayv1.HTTPRouteMatch{{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}}},
+						Timeouts:    &gatewayv1.HTTPRouteTimeouts{Request: &badRequest},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("web-svc", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	assert.Nil(t, cfg.Rules[0].Timeouts, "an unparseable timeout is dropped")
+	assert.Zero(t, cfg.Rules[0].UnavailableStatus, "the rule still serves — a dropped timeout is not fail-closed")
+	require.Len(t, cfg.Rules[0].Backends, 1, "the backend is still routed")
+
+	require.Len(t, cfg.Diagnostics, 1)
+	diag := cfg.Diagnostics[0]
+	assert.Equal(t, "web", diag.Name)
+	assert.Equal(t, 0, diag.RuleIndex)
+	assert.Equal(t, proxy.DiagnosticAccepted, diag.Target)
+	assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), diag.Reason)
+	assert.False(t, diag.WholeRule, "a dropped timeout leaves the rule servable")
+	assert.Contains(t, diag.Message, "timeout", "message must name what was dropped")
+}
+
+// TestConvertHTTPRoutes_ValidTimeouts_NoDiagnostic confirms a parseable timeout
+// is applied with no diagnostic.
+func TestConvertHTTPRoutes_ValidTimeouts_NoDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	good := gatewayv1.Duration("10s")
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches:     []gatewayv1.HTTPRouteMatch{{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}}},
+						Timeouts:    &gatewayv1.HTTPRouteTimeouts{Request: &good},
+						BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("web-svc", 80, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := proxy.ConvertHTTPRoutes(context.Background(), routes, "cluster.local", nil, nil, nil, nil)
+
+	require.Len(t, cfg.Rules, 1)
+	require.NotNil(t, cfg.Rules[0].Timeouts)
+	assert.Empty(t, cfg.Diagnostics)
+}


### PR DESCRIPTION
## Summary

The controller/proxy silently refused, dropped, downgraded, or fail-closed a lot of user config with only a log line — nothing on the resource. An operator running `kubectl describe httproute/grpcroute` saw `Accepted=True` and had no idea their filter was dropped, their `appProtocol` was ignored, or their mirror was discarded. This surfaces every remaining silent path on the resource status (or a Kubernetes Event for benign overrides), with explicit, actionable messages that name the problem and the fix.

The headline gRPC-over-QUIC case already landed in #363; this is the broad audit it scoped.

Closes #359

## Changes

- **Diagnostic plumbing**: the proxy converter records structured `RouteDiagnostic`s for any config it will not serve as written. They ride on `Config` behind a `json:"-"` tag (off the wire) and the controller threads them into the status writer alongside the existing backend-ref failures — no proxy→controller feedback channel needed, since the controller already calls the converter during reconcile.
- **Fail closed where the spec mandates it**: an unsupported HTTPRoute filter (`ExtensionRef`, `ExternalAuth`, unknown) or any GRPCRoute filter now fails the rule (or backend) closed (matched requests get HTTP 500) and sets `Accepted=False/UnsupportedValue` (whole route) or `PartiallyInvalid=True` with the spec-mandated `Dropped Rule` message (partial). A TLS `appProtocol` (`https`/`wss`) without a `BackendTLSPolicy` fails the backend closed (502) and sets `ResolvedRefs=False/UnsupportedProtocol` instead of silently dialing plaintext.
- **Report-only where the feature is best-effort**: an unrecognised `appProtocol`, an unparseable `timeouts` value, and a dropped `RequestMirror` backendRef are surfaced (`ResolvedRefs=False` or `PartiallyInvalid=True`) while the route keeps serving.
- **Kubernetes Events for benign overrides**: a cleartext `appProtocol` superseded by a `BackendTLSPolicy` ("TLS wins") emits a Normal event; a `ResponseHeaderModifier` that strips a WebSocket handshake header emits a Warning event. The route reconcilers now carry an `events.EventRecorder`.
- **Unsupported listener protocols**: Gateway and ListenerSet listeners with `TCP`/`TLS`/`UDP` (no data plane here) are now `Accepted=False/UnsupportedProtocol` instead of a misleading `Accepted=True`.
- Documentation in `docs/gateway-api/limitations.md` updated to describe each surfaced case and the new conditions/events.

The status-writer aggregation, the fail-closed primitive (`Rule.UnavailableStatus`), and the Event path are each covered by tests, including the cloudflared HTTP/2 response-writer fake for the data-plane fail-closed path.

## Testing

- [x] All tests pass locally (`go test -race ./...` — 16/16 packages)
- [x] Linters pass locally (`golangci-lint run`; also checked with `--build-tags e2e,conformance`, where the only findings are pre-existing in `test/e2e`/`test/conformance`, untouched here)
- [x] Markdown linting passes (`markdownlint-cli2`)
- [x] Helm tests pass (`helm unittest` — 228/228, `helm lint`, `helm-docs` no diff)
- [ ] Manual testing completed — maintainer-side conformance + e2e against a live Cloudflare Tunnel pending (this is the draft-PR gate per `CLAUDE.md`)

## Documentation

- [x] README updated (if needed) — N/A; the detailed limitations doc carries the behavior
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed) — N/A

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented — a data-plane behavior change: rules that today serve partially (silently dropping an unsupported filter, or dialing plaintext for a TLS `appProtocol` without a policy) now fail closed with an HTTP error on the affected fraction, per the Gateway API spec. Documented in the limitations doc.
- [x] Related issues referenced

## Additional Notes

The fail-closed paths are the intentional, spec-required behavior change; the report-only paths and Events are additive. Each condition message names both the problem and the remediation so operators can act without reading the source.
