### PR TITLE
perf(controller): cache per-Gateway ListenerSet merge view

### DIFF
--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -109,6 +109,10 @@ type GatewayReconciler struct {
 
 	// ConfigResolver resolves configuration from GatewayClassConfig.
 	ConfigResolver *config.Resolver
+
+	// ViewStore caches the per-Gateway ListenerSet merge view across reconciles.
+	// Shared with the route and ListenerSet reconcilers (issue #332). May be nil.
+	ViewStore *mergeViewStore
 }
 
 func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -118,6 +122,10 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if err := r.Get(ctx, req.NamespacedName, &gateway); err != nil {
 		if apierrors.IsNotFound(err) {
+			// Gateway is gone: drop its cached merge view so the shared store
+			// does not retain entries for deleted Gateways (issue #332).
+			r.ViewStore.forget(req.NamespacedName)
+
 			return ctrl.Result{}, nil
 		}
 
@@ -198,7 +206,9 @@ func (r *GatewayReconciler) updateStatus(
 
 		attachedRoutes := r.countAttachedRoutes(ctx, &freshGateway)
 
-		attachedCount, mergeErr := summariseAttachedListenerSets(ctx, r.Client, &freshGateway)
+		views := newListenerViewCache(r.Client, r.ViewStore)
+
+		attachedCount, mergeErr := summariseAttachedListenerSets(ctx, r.Client, &freshGateway, views)
 		if mergeErr != nil {
 			log.FromContext(ctx).Error(mergeErr, "failed to summarise attached listenersets; reporting 0")
 

--- a/internal/controller/grpcroute_controller.go
+++ b/internal/controller/grpcroute_controller.go
@@ -111,6 +111,10 @@ type GRPCRouteReconciler struct {
 	// bindingValidator validates route binding to Gateway listeners.
 	bindingValidator *routebinding.Validator
 
+	// ViewStore caches the per-Gateway ListenerSet merge view across reconciles
+	// (issue #332). Shared with the other reconcilers. May be nil.
+	ViewStore *mergeViewStore
+
 	// startupComplete indicates whether the startup sync has completed.
 	startupComplete atomic.Bool
 }
@@ -144,7 +148,8 @@ func (r *GRPCRouteReconciler) syncAndUpdateStatus(ctx context.Context) (ctrl.Res
 }
 
 func (r *GRPCRouteReconciler) isRouteForOurGateway(ctx context.Context, route *gatewayv1.GRPCRoute) bool {
-	return IsRouteAcceptedByGateway(ctx, r.Client, r.bindingValidator, r.ControllerName, GRPCRouteWrapper{route})
+	return IsRouteAcceptedByGateway(ctx, r.Client, r.bindingValidator, r.ControllerName, GRPCRouteWrapper{route},
+		newListenerViewCache(r.Client, r.ViewStore))
 }
 
 func (r *GRPCRouteReconciler) updateRouteStatus(
@@ -361,5 +366,6 @@ func (r *GRPCRouteReconciler) getAllRelevantRoutes(ctx context.Context) []reconc
 		routes[i] = GRPCRouteWrapper{&routeList.Items[i]}
 	}
 
-	return FilterAcceptedRoutes(ctx, r.Client, r.bindingValidator, r.ControllerName, routes)
+	return FilterAcceptedRoutes(ctx, r.Client, r.bindingValidator, r.ControllerName, routes,
+		newListenerViewCache(r.Client, r.ViewStore))
 }

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -82,6 +82,10 @@ type HTTPRouteReconciler struct {
 	// bindingValidator validates route binding to Gateway listeners.
 	bindingValidator *routebinding.Validator
 
+	// ViewStore caches the per-Gateway ListenerSet merge view across reconciles
+	// (issue #332). Shared with the other reconcilers. May be nil.
+	ViewStore *mergeViewStore
+
 	// startupComplete indicates whether the startup sync has completed.
 	// This prevents race conditions between startup sync and reconcile loop.
 	startupComplete atomic.Bool
@@ -131,7 +135,8 @@ func httpRoutePtrs(routes []gatewayv1.HTTPRoute) []*gatewayv1.HTTPRoute {
 }
 
 func (r *HTTPRouteReconciler) isRouteForOurGateway(ctx context.Context, route *gatewayv1.HTTPRoute) bool {
-	return IsRouteAcceptedByGateway(ctx, r.Client, r.bindingValidator, r.ControllerName, HTTPRouteWrapper{route})
+	return IsRouteAcceptedByGateway(ctx, r.Client, r.bindingValidator, r.ControllerName, HTTPRouteWrapper{route},
+		newListenerViewCache(r.Client, r.ViewStore))
 }
 
 func (r *HTTPRouteReconciler) updateRouteStatus(
@@ -335,5 +340,6 @@ func (r *HTTPRouteReconciler) getAllRelevantRoutes(ctx context.Context) []reconc
 		routes[i] = HTTPRouteWrapper{&routeList.Items[i]}
 	}
 
-	return FilterAcceptedRoutes(ctx, r.Client, r.bindingValidator, r.ControllerName, routes)
+	return FilterAcceptedRoutes(ctx, r.Client, r.bindingValidator, r.ControllerName, routes,
+		newListenerViewCache(r.Client, r.ViewStore))
 }

--- a/internal/controller/listenerset_collect.go
+++ b/internal/controller/listenerset_collect.go
@@ -16,10 +16,31 @@ import (
 // the given Gateway as its spec.parentRef AND is permitted to attach by the
 // Gateway's spec.allowedListeners filter.
 //
-// Used by GatewayReconciler to compute status.attachedListenerSets and by
-// ListenerSetReconciler to compute the merged view that drives status
-// conditions for the ListenerSet under reconciliation.
+// Production no longer calls this directly — every consumer goes through the
+// per-Gateway merge-view cache (see buildGatewayListenerView / forGateway in
+// listenerset_view.go). It is retained as the independent oracle the merge-view
+// equivalence test composes against, asserting the cache yields the same
+// accepted set + merge a from-scratch computation would.
 func collectAcceptedListenerSetsForGateway(
+	ctx context.Context,
+	cli client.Client,
+	gateway *gatewayv1.Gateway,
+) ([]*gatewayv1.ListenerSet, error) {
+	candidates, err := listTargetingListenerSets(ctx, cli, gateway)
+	if err != nil {
+		return nil, err
+	}
+
+	return acceptedFromCandidates(ctx, routebinding.NewValidator(cli), gateway, candidates)
+}
+
+// listTargetingListenerSets lists every ListenerSet whose spec.parentRef names
+// the given Gateway, without applying the Gateway's allowedListeners filter.
+// This pre-acceptance candidate set is what the merge-view cache fingerprints
+// on: it captures membership and per-ListenerSet generation, which is exactly
+// what the merged view depends on. The List reads the controller-runtime
+// informer cache (no API round-trip).
+func listTargetingListenerSets(
 	ctx context.Context,
 	cli client.Client,
 	gateway *gatewayv1.Gateway,
@@ -29,16 +50,28 @@ func collectAcceptedListenerSetsForGateway(
 		return nil, errors.Wrap(err, "failed to list listenersets")
 	}
 
-	validator := routebinding.NewValidator(cli)
 	out := make([]*gatewayv1.ListenerSet, 0, len(all.Items))
 
 	for i := range all.Items {
-		listenerSet := &all.Items[i]
-
-		if !listenerSetTargetsGateway(listenerSet, gateway) {
-			continue
+		if listenerSetTargetsGateway(&all.Items[i], gateway) {
+			out = append(out, &all.Items[i])
 		}
+	}
 
+	return out, nil
+}
+
+// acceptedFromCandidates filters targeting ListenerSets down to those the
+// Gateway's spec.allowedListeners filter permits to attach.
+func acceptedFromCandidates(
+	ctx context.Context,
+	validator *routebinding.Validator,
+	gateway *gatewayv1.Gateway,
+	candidates []*gatewayv1.ListenerSet,
+) ([]*gatewayv1.ListenerSet, error) {
+	out := make([]*gatewayv1.ListenerSet, 0, len(candidates))
+
+	for _, listenerSet := range candidates {
 		acceptance, err := validator.EvaluateListenerSetAcceptance(ctx, gateway, listenerSet)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to evaluate listenerset acceptance")
@@ -64,17 +97,17 @@ func summariseAttachedListenerSets(
 	ctx context.Context,
 	cli client.Client,
 	gateway *gatewayv1.Gateway,
+	views *listenerViewCache,
 ) (int, error) {
-	listenerSets, err := collectAcceptedListenerSetsForGateway(ctx, cli, gateway)
+	view, err := views.orNew(cli).forGateway(ctx, gateway)
 	if err != nil {
 		return 0, err
 	}
 
-	merged := listenermerge.Merge(gateway, listenerSets)
 	accepted := 0
 
-	for _, listenerSet := range listenerSets {
-		if listenerSetEntriesAccepted(ctx, cli, listenerSet, merged) {
+	for _, listenerSet := range view.acceptedSets {
+		if listenerSetEntriesAccepted(ctx, cli, listenerSet, view.merged) {
 			accepted++
 		}
 	}

--- a/internal/controller/listenerset_collect_test.go
+++ b/internal/controller/listenerset_collect_test.go
@@ -105,7 +105,7 @@ func TestSummariseAttachedListenerSets_BrokenTLSRefNotCounted(t *testing.T) {
 
 	cli := buildTLSFakeClient(t, ls, gw)
 
-	count, err := summariseAttachedListenerSets(context.Background(), cli, gw)
+	count, err := summariseAttachedListenerSets(context.Background(), cli, gw, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count, "a ListenerSet with an unresolved TLS cert ref must not be counted as attached")
 }
@@ -139,7 +139,7 @@ func TestSummariseAttachedListenerSets_HealthyCounted(t *testing.T) {
 
 	cli := buildTLSFakeClient(t, ls, gw)
 
-	count, err := summariseAttachedListenerSets(context.Background(), cli, gw)
+	count, err := summariseAttachedListenerSets(context.Background(), cli, gw, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, count)
 }

--- a/internal/controller/listenerset_controller.go
+++ b/internal/controller/listenerset_controller.go
@@ -40,6 +40,10 @@ type ListenerSetReconciler struct {
 
 	Scheme         *runtime.Scheme
 	ControllerName string
+
+	// ViewStore caches the per-Gateway ListenerSet merge view across reconciles
+	// (issue #332). Shared with the other reconcilers. May be nil.
+	ViewStore *mergeViewStore
 }
 
 // Reconcile is the main entrypoint. It is safe to call against non-existent
@@ -221,7 +225,11 @@ func (r *ListenerSetReconciler) computeAcceptance(
 		}
 	}
 
-	siblings, err := r.collectAcceptedSiblings(ctx, gateway, listenerSet)
+	// The merged view spans the parent Gateway plus every sibling ListenerSet
+	// allowed to attach (including this one — it has just passed the
+	// allowedListeners check above). Shared with the Gateway and route
+	// reconcilers through the cross-reconcile store (issue #332).
+	view, err := newListenerViewCache(r.Client, r.ViewStore).forGateway(ctx, gateway)
 	if err != nil {
 		return listenerSetAcceptanceResult{
 			Accepted: false,
@@ -230,7 +238,7 @@ func (r *ListenerSetReconciler) computeAcceptance(
 		}
 	}
 
-	merged := listenermerge.Merge(gateway, siblings)
+	merged := view.merged
 
 	refChecks, refErr := r.collectListenerEntryRefChecks(ctx, listenerSet)
 	if refErr != nil {
@@ -478,51 +486,6 @@ func summariseListenerSet(
 	}
 
 	return false, gatewayv1.ListenerSetReasonListenersNotValid, listenerSetMsgListenersBad
-}
-
-// collectAcceptedSiblings returns the slice of ListenerSets — including the
-// one being reconciled — that point at the parent Gateway and are themselves
-// allowed by the Gateway's allowedListeners filter. This is the input to the
-// precedence + conflict view so that hostname/protocol conflicts between
-// siblings are visible.
-func (r *ListenerSetReconciler) collectAcceptedSiblings(
-	ctx context.Context,
-	gateway *gatewayv1.Gateway,
-	current *gatewayv1.ListenerSet,
-) ([]*gatewayv1.ListenerSet, error) {
-	var all gatewayv1.ListenerSetList
-	if err := r.List(ctx, &all); err != nil {
-		return nil, errors.Wrap(err, "failed to list listenersets")
-	}
-
-	validator := routebinding.NewValidator(r.Client)
-	siblings := make([]*gatewayv1.ListenerSet, 0, len(all.Items))
-
-	for i := range all.Items {
-		item := &all.Items[i]
-
-		if !listenerSetTargetsGateway(item, gateway) {
-			continue
-		}
-
-		// Always include the current ListenerSet (we've already checked it).
-		if item.Name == current.Name && item.Namespace == current.Namespace {
-			siblings = append(siblings, item)
-
-			continue
-		}
-
-		acceptance, err := validator.EvaluateListenerSetAcceptance(ctx, gateway, item)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to evaluate sibling listenerset")
-		}
-
-		if acceptance.Accepted {
-			siblings = append(siblings, item)
-		}
-	}
-
-	return siblings, nil
 }
 
 // listenerSetTargetsGateway returns true when the ListenerSet's spec.parentRef

--- a/internal/controller/listenerset_view.go
+++ b/internal/controller/listenerset_view.go
@@ -1,0 +1,288 @@
+package controller
+
+import (
+	"context"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/listenermerge"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/routebinding"
+)
+
+// gatewayListenerView is the precedence-ordered, conflict-annotated merged
+// view of a Gateway plus the ListenerSets allowed to attach to it. It bundles
+// the accepted ListenerSets and the single listenermerge.Merge output so the
+// status, count, and route-binding consumers can share one computation instead
+// of each rebuilding it (issue #332).
+//
+// A view is immutable after construction. The cross-reconcile mergeViewStore
+// retains views across goroutines; List returns deep copies from the informer
+// cache, so the *gatewayv1.ListenerSet pointers it holds never alias mutating
+// state.
+type gatewayListenerView struct {
+	acceptedSets []*gatewayv1.ListenerSet
+	merged       *listenermerge.MergeResult
+}
+
+// conflictReason returns the conflict reason annotated on the merged-view entry
+// for (listenerSet, name), or "" when the entry is conflict-free or absent.
+func (v *gatewayListenerView) conflictReason(
+	listenerSet *gatewayv1.ListenerSet,
+	name gatewayv1.SectionName,
+) gatewayv1.ListenerConditionReason {
+	if v == nil {
+		return ""
+	}
+
+	entry := findMergedEntry(v.merged, listenerSet, name)
+	if entry == nil {
+		return ""
+	}
+
+	return entry.ConflictReason
+}
+
+// buildGatewayListenerView computes the view for a Gateway from scratch: list
+// the targeting ListenerSets, keep those the allowedListeners filter accepts,
+// and run listenermerge.Merge once. This is the single construction path; the
+// caches below only memoize its result.
+func buildGatewayListenerView(
+	ctx context.Context,
+	cli client.Client,
+	gateway *gatewayv1.Gateway,
+) (*gatewayListenerView, error) {
+	candidates, err := listTargetingListenerSets(ctx, cli, gateway)
+	if err != nil {
+		return nil, err
+	}
+
+	return viewFromCandidates(ctx, cli, gateway, candidates)
+}
+
+// viewFromCandidates builds the view from an already-listed candidate set,
+// letting the store reuse the List it performed for fingerprinting.
+func viewFromCandidates(
+	ctx context.Context,
+	cli client.Client,
+	gateway *gatewayv1.Gateway,
+	candidates []*gatewayv1.ListenerSet,
+) (*gatewayListenerView, error) {
+	accepted, err := acceptedFromCandidates(ctx, routebinding.NewValidator(cli), gateway, candidates)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gatewayListenerView{
+		acceptedSets: accepted,
+		merged:       listenermerge.Merge(gateway, accepted),
+	}, nil
+}
+
+// listenerViewCache memoizes gatewayListenerView for the duration of a single
+// reconcile/sync pass. Within one pass a Gateway is resolved (and its
+// ListenerSets listed) at most once, even when many routes reference it. On a
+// miss it consults the shared store (when present) for cross-reconcile reuse,
+// otherwise it builds the view directly.
+//
+// A nil *listenerViewCache is valid and computes views directly without
+// memoizing — call sites that have no pass to scope (e.g. tests) may pass nil.
+type listenerViewCache struct {
+	cli   client.Client
+	store *mergeViewStore
+	views map[client.ObjectKey]*gatewayListenerView
+}
+
+// newListenerViewCache creates a per-pass cache. store may be nil (no
+// cross-reconcile reuse).
+func newListenerViewCache(cli client.Client, store *mergeViewStore) *listenerViewCache {
+	return &listenerViewCache{
+		cli:   cli,
+		store: store,
+		views: make(map[client.ObjectKey]*gatewayListenerView),
+	}
+}
+
+// orNew returns the cache when non-nil, otherwise a fresh standalone cache
+// bound to cli (no store, no cross-call memoization). Call sites that thread a
+// pass-scoped cache pass it through; those without one (e.g. tests) pass nil
+// and still get a working, behaviour-identical view.
+func (c *listenerViewCache) orNew(cli client.Client) *listenerViewCache {
+	if c != nil {
+		return c
+	}
+
+	return newListenerViewCache(cli, nil)
+}
+
+// forGateway returns the merged view for gateway, building it once per pass.
+func (c *listenerViewCache) forGateway(
+	ctx context.Context,
+	gateway *gatewayv1.Gateway,
+) (*gatewayListenerView, error) {
+	key := client.ObjectKeyFromObject(gateway)
+	if view, ok := c.views[key]; ok {
+		return view, nil
+	}
+
+	view, err := c.resolve(ctx, gateway)
+	if err != nil {
+		return nil, err
+	}
+
+	c.views[key] = view
+
+	return view, nil
+}
+
+func (c *listenerViewCache) resolve(
+	ctx context.Context,
+	gateway *gatewayv1.Gateway,
+) (*gatewayListenerView, error) {
+	if c.store == nil {
+		return buildGatewayListenerView(ctx, c.cli, gateway)
+	}
+
+	return c.store.resolve(ctx, c.cli, gateway)
+}
+
+// storeEntry pairs a cached view with the fingerprint of the inputs it was
+// built from.
+type storeEntry struct {
+	fingerprint string
+	view        *gatewayListenerView
+}
+
+// mergeViewStore caches gatewayListenerView across reconciles, keyed by
+// Gateway. It is shared by every reconciler/syncer that needs the merged view,
+// so a burst of reconciles triggered by one event reuses a single Merge.
+//
+// Reuse is guarded by a content fingerprint over the Gateway generation and the
+// targeting ListenerSets' (namespace, name, generation) — NOT the Gateway
+// generation alone, because a sibling ListenerSet spec edit changes the view
+// without bumping the Gateway's generation. Any input change flips the
+// fingerprint and forces a rebuild, so the store never serves a stale view.
+//
+// Gateways using allowedListeners From=Selector bypass the store entirely:
+// acceptance then depends on Namespace labels, which are not part of the
+// fingerprint (and not watched), so caching could outlive a label change.
+type mergeViewStore struct {
+	mu      sync.Mutex
+	entries map[client.ObjectKey]storeEntry
+}
+
+// newMergeViewStore creates an empty shared store.
+func newMergeViewStore() *mergeViewStore {
+	return &mergeViewStore{
+		entries: make(map[client.ObjectKey]storeEntry),
+	}
+}
+
+// forget drops the cached entry for a Gateway. The GatewayReconciler calls it
+// when a Gateway is deleted (observed as a NotFound) so the store does not
+// retain merged views — and the deep-copied ListenerSets they reference — for
+// Gateways that no longer exist. Safe to call on a nil store or for a Gateway
+// that was never cached.
+func (s *mergeViewStore) forget(key client.ObjectKey) {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	delete(s.entries, key)
+	s.mu.Unlock()
+}
+
+// resolve returns the merged view for gateway, reusing a cached one when the
+// inputs are unchanged. It always lists the targeting ListenerSets (a cheap
+// informer-cache read) to derive the fingerprint; on a hit it skips the
+// acceptance evaluation and the Merge.
+func (s *mergeViewStore) resolve(
+	ctx context.Context,
+	cli client.Client,
+	gateway *gatewayv1.Gateway,
+) (*gatewayListenerView, error) {
+	candidates, err := listTargetingListenerSets(ctx, cli, gateway)
+	if err != nil {
+		return nil, err
+	}
+
+	// Selector mode depends on Namespace labels outside the fingerprint —
+	// build fresh and do not cache.
+	if gatewayUsesNamespaceSelector(gateway) {
+		return viewFromCandidates(ctx, cli, gateway, candidates)
+	}
+
+	key := client.ObjectKeyFromObject(gateway)
+	fingerprint := mergeViewFingerprint(gateway, candidates)
+
+	s.mu.Lock()
+	if entry, ok := s.entries[key]; ok && entry.fingerprint == fingerprint {
+		s.mu.Unlock()
+
+		return entry.view, nil
+	}
+	s.mu.Unlock()
+
+	// Build outside the lock. Concurrent builders for the same Gateway may
+	// observe different informer-cache snapshots, so last-writer-wins can store
+	// the older view; this self-corrects because the update that produced the
+	// newer state also enqueued a reconcile that recomputes the fingerprint.
+	view, err := viewFromCandidates(ctx, cli, gateway, candidates)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.entries[key] = storeEntry{fingerprint: fingerprint, view: view}
+	s.mu.Unlock()
+
+	return view, nil
+}
+
+// gatewayUsesNamespaceSelector reports whether the Gateway's allowedListeners
+// filter selects ListenerSet namespaces by label selector.
+func gatewayUsesNamespaceSelector(gateway *gatewayv1.Gateway) bool {
+	allowed := gateway.Spec.AllowedListeners
+
+	return allowed != nil &&
+		allowed.Namespaces != nil &&
+		allowed.Namespaces.From != nil &&
+		*allowed.Namespaces.From == gatewayv1.NamespacesFromSelector
+}
+
+// mergeViewFingerprint produces a canonical key over everything the merged view
+// depends on: the Gateway generation (covers spec.listeners and
+// spec.allowedListeners) and, per targeting ListenerSet, its identity +
+// generation + creationTimestamp.
+//
+// Generation covers spec.listeners and spec.parentRef of a live object.
+// creationTimestamp is in the token because Merge orders ListenerSets by it
+// (see listenermerge.sortListenerSets), which decides conflict precedence — and
+// it is NOT redundant with generation across a delete+recreate: a ListenerSet
+// recreated under the same namespace/name resets its generation to 1 but gets a
+// fresh creationTimestamp, so without it the fingerprint would collide and the
+// store could serve a stale precedence ordering.
+func mergeViewFingerprint(gateway *gatewayv1.Gateway, candidates []*gatewayv1.ListenerSet) string {
+	keys := make([]string, 0, len(candidates))
+	for _, ls := range candidates {
+		keys = append(keys, ls.Namespace+"/"+ls.Name+
+			"@"+strconv.FormatInt(ls.Generation, 10)+
+			"#"+strconv.FormatInt(ls.CreationTimestamp.UnixNano(), 10))
+	}
+
+	slices.Sort(keys)
+
+	var builder strings.Builder
+
+	builder.WriteString("g@")
+	builder.WriteString(strconv.FormatInt(gateway.Generation, 10))
+	builder.WriteByte(';')
+	builder.WriteString(strings.Join(keys, ";"))
+
+	return builder.String()
+}

--- a/internal/controller/listenerset_view_test.go
+++ b/internal/controller/listenerset_view_test.go
@@ -1,0 +1,343 @@
+package controller
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/listenermerge"
+)
+
+// listSpyClient counts List(ListenerSetList) calls so tests can assert how
+// often the merge view re-lists.
+type listSpyClient struct {
+	client.Client
+
+	listenerSetLists atomic.Int64
+}
+
+func (c *listSpyClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if _, ok := list.(*gatewayv1.ListenerSetList); ok {
+		c.listenerSetLists.Add(1)
+	}
+
+	return errors.Wrap(c.Client.List(ctx, list, opts...), "list")
+}
+
+func viewTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	return scheme
+}
+
+func viewGateway(from gatewayv1.FromNamespaces) *gatewayv1.Gateway {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "infra", Generation: 1},
+		Spec:       gatewayv1.GatewaySpec{GatewayClassName: "managed-class"},
+	}
+
+	gw.Spec.AllowedListeners = &gatewayv1.AllowedListeners{
+		Namespaces: &gatewayv1.ListenerNamespaces{From: &from},
+	}
+
+	return gw
+}
+
+func viewListenerSet(name string, host gatewayv1.Hostname, port gatewayv1.PortNumber, proto gatewayv1.ProtocolType) *gatewayv1.ListenerSet {
+	return &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "infra", Generation: 1},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{Name: "gw"},
+			Listeners: []gatewayv1.ListenerEntry{
+				{Name: "l1", Port: port, Protocol: proto, Hostname: &host},
+			},
+		},
+	}
+}
+
+// TestListenerViewCache_ForGateway_EquivalentToDirectMerge pins behaviour: the
+// view the cache hands out is byte-for-byte the merge a consumer would have
+// built directly. This is the safety net for the whole refactor — if the cache
+// ever diverges from listenermerge.Merge(gw, collectAccepted(gw)), this fails.
+func TestListenerViewCache_ForGateway_EquivalentToDirectMerge(t *testing.T) {
+	t.Parallel()
+
+	hostA := gatewayv1.Hostname("a.example.com")
+	hostB := gatewayv1.Hostname("b.example.com")
+
+	tests := []struct {
+		name string
+		from gatewayv1.FromNamespaces
+		sets []*gatewayv1.ListenerSet
+	}{
+		{name: "no listenersets", from: gatewayv1.NamespacesFromSame},
+		{
+			name: "conflict-free",
+			from: gatewayv1.NamespacesFromSame,
+			sets: []*gatewayv1.ListenerSet{
+				viewListenerSet("ls-a", hostA, 80, gatewayv1.HTTPProtocolType),
+				viewListenerSet("ls-b", hostB, 80, gatewayv1.HTTPProtocolType),
+			},
+		},
+		{
+			name: "hostname conflict",
+			from: gatewayv1.NamespacesFromAll,
+			sets: []*gatewayv1.ListenerSet{
+				viewListenerSet("ls-a", hostA, 80, gatewayv1.HTTPProtocolType),
+				viewListenerSet("ls-b", hostA, 80, gatewayv1.HTTPProtocolType),
+			},
+		},
+		{
+			name: "protocol conflict",
+			from: gatewayv1.NamespacesFromAll,
+			sets: []*gatewayv1.ListenerSet{
+				viewListenerSet("ls-a", hostA, 80, gatewayv1.HTTPProtocolType),
+				viewListenerSet("ls-b", hostB, 80, gatewayv1.HTTPSProtocolType),
+			},
+		},
+		{name: "from none rejects all", from: gatewayv1.NamespacesFromNone, sets: []*gatewayv1.ListenerSet{
+			viewListenerSet("ls-a", hostA, 80, gatewayv1.HTTPProtocolType),
+		}},
+		{name: "from selector bypasses store", from: gatewayv1.NamespacesFromSelector, sets: []*gatewayv1.ListenerSet{
+			viewListenerSet("ls-a", hostA, 80, gatewayv1.HTTPProtocolType),
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gw := viewGateway(tt.from)
+
+			objs := []client.Object{gw}
+			for _, ls := range tt.sets {
+				objs = append(objs, ls)
+			}
+
+			cli := fake.NewClientBuilder().WithScheme(viewTestScheme(t)).WithObjects(objs...).Build()
+
+			want, err := collectAcceptedListenerSetsForGateway(context.Background(), cli, gw)
+			require.NoError(t, err)
+			wantMerged := listenermerge.Merge(gw, want)
+
+			cache := newListenerViewCache(cli, newMergeViewStore())
+			view, err := cache.forGateway(context.Background(), gw)
+			require.NoError(t, err)
+
+			assert.Equal(t, wantMerged, view.merged)
+			assert.Equal(t, want, view.acceptedSets)
+		})
+	}
+}
+
+// TestMergeViewStore_ReusesUnchanged proves the store skips the Merge on a
+// fingerprint hit: two resolves over unchanged inputs return the SAME view
+// pointer (a recompute would allocate a fresh one).
+func TestMergeViewStore_ReusesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	gw := viewGateway(gatewayv1.NamespacesFromSame)
+	ls := viewListenerSet("ls-a", "a.example.com", 80, gatewayv1.HTTPProtocolType)
+	cli := fake.NewClientBuilder().WithScheme(viewTestScheme(t)).WithObjects(gw, ls).Build()
+
+	store := newMergeViewStore()
+
+	first, err := store.resolve(context.Background(), cli, gw)
+	require.NoError(t, err)
+
+	second, err := store.resolve(context.Background(), cli, gw)
+	require.NoError(t, err)
+
+	assert.Same(t, first, second, "unchanged inputs must reuse the cached view, not rebuild it")
+}
+
+// TestMergeViewStore_RecomputesOnGenerationBump proves a sibling ListenerSet
+// spec change (generation bump) invalidates the entry — the reason the
+// fingerprint must cover ListenerSet generation, not just the Gateway's.
+func TestMergeViewStore_RecomputesOnGenerationBump(t *testing.T) {
+	t.Parallel()
+
+	gw := viewGateway(gatewayv1.NamespacesFromSame)
+	ls := viewListenerSet("ls-a", "a.example.com", 80, gatewayv1.HTTPProtocolType)
+	cli := fake.NewClientBuilder().WithScheme(viewTestScheme(t)).WithObjects(gw, ls).Build()
+
+	store := newMergeViewStore()
+
+	first, err := store.resolve(context.Background(), cli, gw)
+	require.NoError(t, err)
+
+	// Bump the ListenerSet's generation in the backing store (spec edit).
+	var live gatewayv1.ListenerSet
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(ls), &live))
+	live.Generation = 2
+	require.NoError(t, cli.Update(context.Background(), &live))
+
+	second, err := store.resolve(context.Background(), cli, gw)
+	require.NoError(t, err)
+
+	assert.NotSame(t, first, second, "a ListenerSet generation bump must force a rebuild")
+}
+
+// TestMergeViewStore_SelectorBypassesCache proves From=Selector Gateways never
+// populate the store (namespace labels are outside the fingerprint).
+func TestMergeViewStore_SelectorBypassesCache(t *testing.T) {
+	t.Parallel()
+
+	gw := viewGateway(gatewayv1.NamespacesFromSelector)
+	cli := fake.NewClientBuilder().WithScheme(viewTestScheme(t)).WithObjects(gw).Build()
+
+	store := newMergeViewStore()
+
+	_, err := store.resolve(context.Background(), cli, gw)
+	require.NoError(t, err)
+
+	assert.Empty(t, store.entries, "selector-mode Gateways must not be cached")
+}
+
+// TestListenerViewCache_PerPassDedup proves the per-pass cache lists the
+// ListenerSets at most once per Gateway, however many times forGateway is
+// called within the pass.
+func TestListenerViewCache_PerPassDedup(t *testing.T) {
+	t.Parallel()
+
+	gw := viewGateway(gatewayv1.NamespacesFromSame)
+	ls := viewListenerSet("ls-a", "a.example.com", 80, gatewayv1.HTTPProtocolType)
+	base := fake.NewClientBuilder().WithScheme(viewTestScheme(t)).WithObjects(gw, ls).Build()
+	spy := &listSpyClient{Client: base}
+
+	cache := newListenerViewCache(spy, newMergeViewStore())
+
+	for range 5 {
+		_, err := cache.forGateway(context.Background(), gw)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(1), spy.listenerSetLists.Load(), "one pass must list ListenerSets once per Gateway")
+}
+
+// TestMergeViewStore_ConcurrentResolve exercises the lock under -race.
+func TestMergeViewStore_ConcurrentResolve(t *testing.T) {
+	t.Parallel()
+
+	gw := viewGateway(gatewayv1.NamespacesFromSame)
+	ls := viewListenerSet("ls-a", "a.example.com", 80, gatewayv1.HTTPProtocolType)
+	cli := fake.NewClientBuilder().WithScheme(viewTestScheme(t)).WithObjects(gw, ls).Build()
+
+	store := newMergeViewStore()
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			_, err := store.resolve(context.Background(), cli, gw)
+			assert.NoError(t, err)
+		})
+	}
+
+	wg.Wait()
+}
+
+// TestMergeViewStore_RecomputesOnListenerSetRecreate proves the fingerprint
+// covers creationTimestamp, not just generation: recreating a ListenerSet under
+// the same namespace/name (generation resets to 1) with a later
+// creationTimestamp must reorder conflict precedence and force a rebuild — not
+// serve the pre-delete merged view.
+func TestMergeViewStore_RecomputesOnListenerSetRecreate(t *testing.T) {
+	t.Parallel()
+
+	gw := viewGateway(gatewayv1.NamespacesFromAll)
+
+	// Two conflicting entries on the same (port, hostname): the earlier-created
+	// ListenerSet wins, the later one is annotated HostnameConflict.
+	host := gatewayv1.Hostname("clash.example.com")
+	lsA := viewListenerSet("ls-a", host, 80, gatewayv1.HTTPProtocolType)
+	lsA.CreationTimestamp = metav1.NewTime(time.Unix(100, 0))
+	lsB := viewListenerSet("ls-b", host, 80, gatewayv1.HTTPProtocolType)
+	lsB.CreationTimestamp = metav1.NewTime(time.Unix(200, 0))
+
+	cli := fake.NewClientBuilder().WithScheme(viewTestScheme(t)).WithObjects(gw, lsA, lsB).Build()
+	store := newMergeViewStore()
+
+	first, err := store.resolve(context.Background(), cli, gw)
+	require.NoError(t, err)
+	// ls-a (created first) wins; ls-b conflicts.
+	assert.Empty(t, first.conflictReason(lsA, "l1"))
+	assert.NotEmpty(t, first.conflictReason(lsB, "l1"))
+
+	// Recreate ls-a with a creationTimestamp LATER than ls-b, generation reset
+	// to 1 (as the API server would on a fresh create).
+	require.NoError(t, cli.Delete(context.Background(), lsA))
+
+	lsARecreated := viewListenerSet("ls-a", host, 80, gatewayv1.HTTPProtocolType)
+	lsARecreated.CreationTimestamp = metav1.NewTime(time.Unix(300, 0))
+	require.NoError(t, cli.Create(context.Background(), lsARecreated))
+
+	second, err := store.resolve(context.Background(), cli, gw)
+	require.NoError(t, err)
+
+	assert.NotSame(t, first, second, "a same-name recreate with a new creationTimestamp must rebuild the view")
+	// Precedence flipped: ls-b (created first now) wins; the recreated ls-a conflicts.
+	assert.Empty(t, second.conflictReason(lsB, "l1"))
+	assert.NotEmpty(t, second.conflictReason(lsARecreated, "l1"))
+}
+
+// TestMergeViewStore_Forget proves a cached entry is dropped on forget so the
+// store does not retain views for deleted Gateways.
+func TestMergeViewStore_Forget(t *testing.T) {
+	t.Parallel()
+
+	gw := viewGateway(gatewayv1.NamespacesFromSame)
+	ls := viewListenerSet("ls-a", "a.example.com", 80, gatewayv1.HTTPProtocolType)
+	cli := fake.NewClientBuilder().WithScheme(viewTestScheme(t)).WithObjects(gw, ls).Build()
+
+	store := newMergeViewStore()
+
+	_, err := store.resolve(context.Background(), cli, gw)
+	require.NoError(t, err)
+	require.NotEmpty(t, store.entries)
+
+	store.forget(client.ObjectKeyFromObject(gw))
+	assert.Empty(t, store.entries, "forget must drop the cached entry")
+
+	// forget on a nil store and an unknown key must not panic.
+	var nilStore *mergeViewStore
+
+	nilStore.forget(client.ObjectKeyFromObject(gw))
+	store.forget(types.NamespacedName{Name: "never-cached", Namespace: "x"})
+}
+
+// TestGatewayReconciler_ForgetsViewOnDelete proves the reconciler evicts a
+// Gateway's cached merge view when the Gateway is gone (Get → NotFound).
+func TestGatewayReconciler_ForgetsViewOnDelete(t *testing.T) {
+	t.Parallel()
+
+	key := types.NamespacedName{Name: "gone", Namespace: "infra"}
+
+	store := newMergeViewStore()
+	store.entries[key] = storeEntry{fingerprint: "stale", view: &gatewayListenerView{}}
+
+	// Empty client: the Gateway does not exist, so Reconcile takes the
+	// NotFound path.
+	cli := fake.NewClientBuilder().WithScheme(viewTestScheme(t)).Build()
+	r := &GatewayReconciler{Client: cli, ControllerName: "test-controller", ViewStore: store}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	assert.Empty(t, store.entries, "a deleted Gateway must be evicted from the merge-view store")
+}

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -175,11 +175,17 @@ func Run(ctx context.Context, cfg *Config) error {
 	// Uses slog.Default() which can be configured with TraceHandler at startup
 	baseLogger := slog.Default()
 
+	// Shared per-Gateway merge-view cache (issue #332). One instance threaded
+	// through every reconciler/syncer that needs the ListenerSet merge view so
+	// a burst of reconciles from one event reuses a single computation.
+	viewStore := newMergeViewStore()
+
 	gatewayReconciler := &GatewayReconciler{
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
 		ControllerName: cfg.ControllerName,
 		ConfigResolver: configResolver,
+		ViewStore:      viewStore,
 	}
 
 	if err := gatewayReconciler.SetupWithManager(mgr); err != nil {
@@ -196,9 +202,11 @@ func Run(ctx context.Context, cfg *Config) error {
 		metricsCollector,
 		baseLogger,
 	)
+	routeSyncer.ViewStore = viewStore
 
 	// Create proxy syncer for L7 proxy config push (mandatory in v3)
 	proxySyncer := initProxySyncer(cfg, proxyEndpoints, mgr.GetClient(), baseLogger, logger)
+	proxySyncer.ViewStore = viewStore
 
 	httpRouteReconciler := &HTTPRouteReconciler{
 		Client:         mgr.GetClient(),
@@ -208,6 +216,7 @@ func Run(ctx context.Context, cfg *Config) error {
 		ProxySyncer:    proxySyncer,
 		ProxyEndpoints: proxyEndpoints,
 		Recorder:       mgr.GetEventRecorder("httproute-controller"),
+		ViewStore:      viewStore,
 	}
 
 	if err := httpRouteReconciler.SetupWithManager(mgr); err != nil {
@@ -223,13 +232,14 @@ func Run(ctx context.Context, cfg *Config) error {
 		ProxyEndpoints: proxyEndpoints,
 		TunnelProtocol: cfg.TunnelProtocol,
 		Recorder:       mgr.GetEventRecorder("grpcroute-controller"),
+		ViewStore:      viewStore,
 	}
 
 	if err := grpcRouteReconciler.SetupWithManager(mgr); err != nil {
 		return errors.Wrap(err, "failed to setup grpcroute controller")
 	}
 
-	if err := setupListenerSetReconciler(mgr, cfg.ControllerName); err != nil {
+	if err := setupListenerSetReconciler(mgr, cfg.ControllerName, viewStore); err != nil {
 		return err
 	}
 
@@ -276,11 +286,12 @@ func Run(ctx context.Context, cfg *Config) error {
 // setupListenerSetReconciler wires the ListenerSet controller. Extracted
 // from Run so the per-reconciler setup chain in Run stays under the
 // cyclomatic-complexity gate.
-func setupListenerSetReconciler(mgr ctrl.Manager, controllerName string) error {
+func setupListenerSetReconciler(mgr ctrl.Manager, controllerName string, viewStore *mergeViewStore) error {
 	reconciler := &ListenerSetReconciler{
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
 		ControllerName: controllerName,
+		ViewStore:      viewStore,
 	}
 
 	if err := reconciler.SetupWithManager(mgr); err != nil {

--- a/internal/controller/mappers.go
+++ b/internal/controller/mappers.go
@@ -603,11 +603,14 @@ func FilterAcceptedRoutes(
 	validator *routebinding.Validator,
 	controllerName string,
 	routes []Route,
+	views *listenerViewCache,
 ) []reconcile.Request {
+	views = views.orNew(cli)
+
 	var requests []reconcile.Request
 
 	for _, route := range routes {
-		if IsRouteAcceptedByGateway(ctx, cli, validator, controllerName, route) {
+		if IsRouteAcceptedByGateway(ctx, cli, validator, controllerName, route, views) {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: client.ObjectKey{
 					Name:      route.GetName(),
@@ -701,7 +704,10 @@ func IsRouteAcceptedByGateway(
 	validator *routebinding.Validator,
 	controllerName string,
 	route Route,
+	views *listenerViewCache,
 ) bool {
+	views = views.orNew(cli)
+
 	routeInfoTemplate := &routebinding.RouteInfo{
 		Name:      route.GetName(),
 		Namespace: route.GetNamespace(),
@@ -710,7 +716,7 @@ func IsRouteAcceptedByGateway(
 	}
 
 	for _, ref := range route.GetParentRefs() {
-		binding, err := resolveRouteParentBinding(ctx, cli, validator, controllerName, ref, route.GetNamespace(), withRefFilters(routeInfoTemplate, ref))
+		binding, err := resolveRouteParentBinding(ctx, cli, validator, controllerName, ref, route.GetNamespace(), withRefFilters(routeInfoTemplate, ref), views)
 		if err != nil {
 			logging.FromContext(ctx).Error("failed to validate route binding",
 				"route", route.GetNamespace()+"/"+route.GetName(),

--- a/internal/controller/mappers_test.go
+++ b/internal/controller/mappers_test.go
@@ -1294,6 +1294,7 @@ func TestIsRouteAcceptedByGateway(t *testing.T) {
 				validator,
 				tt.controllerName,
 				tt.route,
+				nil,
 			)
 
 			assert.Equal(t, tt.expected, result)
@@ -1631,6 +1632,7 @@ func TestFilterAcceptedRoutes(t *testing.T) {
 				validator,
 				tt.controllerName,
 				tt.routes,
+				nil,
 			)
 
 			assert.Len(t, result, tt.expectedCount)
@@ -1682,7 +1684,7 @@ func TestIsRouteAcceptedByGateway_NonGatewayKind(t *testing.T) {
 		},
 	}}
 
-	result := IsRouteAcceptedByGateway(context.Background(), fakeClient, validator, "test-controller", route)
+	result := IsRouteAcceptedByGateway(context.Background(), fakeClient, validator, "test-controller", route, nil)
 	assert.False(t, result)
 }
 
@@ -1707,7 +1709,7 @@ func TestIsRouteAcceptedByGateway_GatewayNotFound(t *testing.T) {
 		},
 	}}
 
-	result := IsRouteAcceptedByGateway(context.Background(), fakeClient, validator, "test-controller", route)
+	result := IsRouteAcceptedByGateway(context.Background(), fakeClient, validator, "test-controller", route, nil)
 	assert.False(t, result)
 }
 
@@ -1753,7 +1755,7 @@ func TestIsRouteAcceptedByGateway_CrossNamespaceExplicit(t *testing.T) {
 		},
 	}}
 
-	result := IsRouteAcceptedByGateway(context.Background(), fakeClient, validator, "test-controller", route)
+	result := IsRouteAcceptedByGateway(context.Background(), fakeClient, validator, "test-controller", route, nil)
 	assert.True(t, result)
 }
 

--- a/internal/controller/proxy_syncer.go
+++ b/internal/controller/proxy_syncer.go
@@ -58,6 +58,11 @@ type ProxySyncer struct {
 	gatewayCertResolver  proxy.GatewayClientCertResolver
 	syncMu               sync.Mutex
 	lastCfg              *proxy.Config
+
+	// ViewStore caches the per-Gateway ListenerSet merge view across reconciles
+	// (issue #332). Set by the manager after construction and shared with the
+	// other reconcilers. nil disables cross-reconcile reuse.
+	ViewStore *mergeViewStore
 }
 
 // NewProxySyncer creates a ProxySyncer for pushing config to proxy replicas.
@@ -668,11 +673,16 @@ func (s *ProxySyncer) buildProxyConfig(
 	failedRefs []ingress.BackendRefError,
 	grpcFailedRefs []ingress.BackendRefError,
 ) *proxy.Config {
+	// One merge-view cache for this whole proxy-config build: the hostname and
+	// redirect-scheme passes both resolve the same Gateways, so they share a
+	// single merge instead of rebuilding it per route per pass (issue #332).
+	views := newListenerViewCache(s.k8sClient, s.ViewStore)
+
 	// When a route binds to a Gateway listener or ListenerSet entry with a
 	// non-empty hostname and itself declares spec.hostnames empty, the proxy
 	// rule MUST serve only the parent listener's hostname. Augment in-memory
 	// before handing to the converter; the input routes are left untouched.
-	routes = withEffectiveHostnames(ctx, s.k8sClient, routes)
+	routes = withEffectiveHostnames(ctx, s.k8sClient, routes, views)
 
 	// A RequestRedirect filter that leaves scheme empty must default to the
 	// scheme of the request, which behind the tunnel means the parent
@@ -680,7 +690,7 @@ func (s *ProxySyncer) buildProxyConfig(
 	// origin request carries no usable scheme). Resolve it here so the
 	// converter sees an explicit scheme instead of the proxy's hardcoded
 	// https fallback. Input routes are left untouched.
-	routes = withDefaultRedirectScheme(ctx, s.k8sClient, routes)
+	routes = withDefaultRedirectScheme(ctx, s.k8sClient, routes, views)
 
 	// Convert to proxy config with cross-namespace validation, backend
 	// protocol resolution (e.g. h2c from Service appProtocol), and
@@ -702,7 +712,7 @@ func (s *ProxySyncer) buildProxyConfig(
 		// none, exactly like HTTPRoutes — otherwise an empty-hostname gRPC rule
 		// becomes a catch-all answering every Host (including hostnames owned by
 		// other routes).
-		grpcRoutes = withEffectiveHostnamesGRPC(ctx, s.k8sClient, grpcRoutes)
+		grpcRoutes = withEffectiveHostnamesGRPC(ctx, s.k8sClient, grpcRoutes, views)
 
 		grpcCfg := proxy.ConvertGRPCRoutes(ctx, grpcRoutes, s.clusterDomain, s.grpcBackendValidator, s.tlsResolver, s.gatewayCertResolver)
 		cfg.Rules = append(cfg.Rules, grpcCfg.Rules...)

--- a/internal/controller/referencegrant_integration_test.go
+++ b/internal/controller/referencegrant_integration_test.go
@@ -95,7 +95,7 @@ func TestRouteSyncer_CrossNamespaceRef_WithoutGrant(t *testing.T) {
 	ctx := context.Background()
 
 	// Get relevant routes (should include our route)
-	httpResult, err := syncer.getRelevantHTTPRoutes(ctx)
+	httpResult, err := syncer.getRelevantHTTPRoutes(ctx, nil)
 	require.NoError(t, err)
 	require.Len(t, httpResult.accepted, 1)
 	assert.Equal(t, "cross-ns-route", httpResult.accepted[0].Name)
@@ -379,7 +379,7 @@ func TestRouteSyncer_GRPCRoute_CrossNamespaceRef_WithGrant(t *testing.T) {
 	ctx := context.Background()
 
 	// Get relevant routes
-	grpcResult, err := syncer.getRelevantGRPCRoutes(ctx)
+	grpcResult, err := syncer.getRelevantGRPCRoutes(ctx, nil)
 	require.NoError(t, err)
 	require.Len(t, grpcResult.accepted, 1)
 
@@ -541,7 +541,7 @@ func TestRouteSyncer_ReferenceGrant_SpecificName(t *testing.T) {
 	ctx := context.Background()
 
 	// Get relevant routes
-	httpResult2, err := syncer.getRelevantHTTPRoutes(ctx)
+	httpResult2, err := syncer.getRelevantHTTPRoutes(ctx, nil)
 	require.NoError(t, err)
 	require.Len(t, httpResult2.accepted, 2)
 

--- a/internal/controller/route_effective_hostnames.go
+++ b/internal/controller/route_effective_hostnames.go
@@ -38,11 +38,13 @@ func withEffectiveHostnames(
 	ctx context.Context,
 	cli client.Client,
 	routes []*gatewayv1.HTTPRoute,
+	views *listenerViewCache,
 ) []*gatewayv1.HTTPRoute {
 	if len(routes) == 0 {
 		return routes
 	}
 
+	views = views.orNew(cli)
 	validator := routebinding.NewValidator(cli)
 	out := make([]*gatewayv1.HTTPRoute, len(routes))
 
@@ -53,7 +55,7 @@ func withEffectiveHostnames(
 			continue
 		}
 
-		parentHostnames := collectAcceptedListenerHostnames(ctx, cli, validator, HTTPRouteWrapper{route})
+		parentHostnames := collectAcceptedListenerHostnames(ctx, cli, validator, HTTPRouteWrapper{route}, views)
 		if len(parentHostnames) == 0 {
 			out[i] = route
 
@@ -81,11 +83,13 @@ func withEffectiveHostnamesGRPC(
 	ctx context.Context,
 	cli client.Client,
 	routes []*gatewayv1.GRPCRoute,
+	views *listenerViewCache,
 ) []*gatewayv1.GRPCRoute {
 	if len(routes) == 0 {
 		return routes
 	}
 
+	views = views.orNew(cli)
 	validator := routebinding.NewValidator(cli)
 	out := make([]*gatewayv1.GRPCRoute, len(routes))
 
@@ -96,7 +100,7 @@ func withEffectiveHostnamesGRPC(
 			continue
 		}
 
-		parentHostnames := collectAcceptedListenerHostnames(ctx, cli, validator, GRPCRouteWrapper{route})
+		parentHostnames := collectAcceptedListenerHostnames(ctx, cli, validator, GRPCRouteWrapper{route}, views)
 		if len(parentHostnames) == 0 {
 			out[i] = route
 
@@ -121,6 +125,7 @@ func collectAcceptedListenerHostnames(
 	cli client.Client,
 	validator *routebinding.Validator,
 	route Route,
+	views *listenerViewCache,
 ) []gatewayv1.Hostname {
 	seen := make(map[gatewayv1.Hostname]struct{})
 
@@ -140,7 +145,7 @@ func collectAcceptedListenerHostnames(
 	}
 
 	for _, ref := range route.GetParentRefs() {
-		for _, hostname := range acceptedHostnamesForParentRef(ctx, cli, validator, route, ref) {
+		for _, hostname := range acceptedHostnamesForParentRef(ctx, cli, validator, route, ref, views) {
 			add(hostname)
 		}
 	}
@@ -154,6 +159,7 @@ func acceptedHostnamesForParentRef(
 	validator *routebinding.Validator,
 	route Route,
 	ref gatewayv1.ParentReference,
+	views *listenerViewCache,
 ) []gatewayv1.Hostname {
 	if ref.Group != nil && string(*ref.Group) != "" && string(*ref.Group) != gatewayv1.GroupName {
 		return nil
@@ -182,7 +188,7 @@ func acceptedHostnamesForParentRef(
 	case kindGateway:
 		return gatewayAcceptedHostnames(ctx, cli, validator, namespace, string(ref.Name), routeInfo)
 	case kindListenerSet:
-		return listenerSetAcceptedHostnames(ctx, cli, validator, namespace, string(ref.Name), routeInfo)
+		return listenerSetAcceptedHostnames(ctx, cli, validator, namespace, string(ref.Name), routeInfo, views)
 	}
 
 	return nil
@@ -219,6 +225,7 @@ func listenerSetAcceptedHostnames(
 	validator *routebinding.Validator,
 	namespace, name string,
 	routeInfo *routebinding.RouteInfo,
+	views *listenerViewCache,
 ) []gatewayv1.Hostname {
 	var listenerSet gatewayv1.ListenerSet
 	if err := cli.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &listenerSet); err != nil {
@@ -230,7 +237,7 @@ func listenerSetAcceptedHostnames(
 		return nil
 	}
 
-	matched := nonConflictedSections(ctx, cli, &listenerSet, result.MatchedListeners)
+	matched := nonConflictedSections(ctx, cli, &listenerSet, result.MatchedListeners, views)
 
 	hostByName := make(map[gatewayv1.SectionName]*gatewayv1.Hostname, len(listenerSet.Spec.Listeners))
 	for i := range listenerSet.Spec.Listeners {
@@ -252,20 +259,19 @@ func nonConflictedSections(
 	cli client.Client,
 	listenerSet *gatewayv1.ListenerSet,
 	sections []gatewayv1.SectionName,
+	views *listenerViewCache,
 ) []gatewayv1.SectionName {
 	parent, found := listenerSetParentGateway(ctx, cli, listenerSet)
 	if !found {
 		return sections
 	}
 
-	siblings, err := collectAcceptedListenerSetsForGateway(ctx, cli, parent)
+	view, err := views.orNew(cli).forGateway(ctx, parent)
 	if err != nil {
 		return sections
 	}
 
-	merged := listenermerge.Merge(parent, siblings)
-
-	return dropConflictedSections(merged, listenerSet, sections)
+	return dropConflictedSections(view.merged, listenerSet, sections)
 }
 
 func dropConflictedSections(

--- a/internal/controller/route_effective_hostnames_test.go
+++ b/internal/controller/route_effective_hostnames_test.go
@@ -46,7 +46,7 @@ func TestWithEffectiveHostnames_InheritsFromGatewayListener(t *testing.T) {
 
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Equal(t, []gatewayv1.Hostname{gatewayHost}, out[0].Spec.Hostnames)
 }
@@ -89,7 +89,7 @@ func TestWithEffectiveHostnamesGRPC_InheritsFromGatewayListener(t *testing.T) {
 
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withEffectiveHostnamesGRPC(context.Background(), cli, []*gatewayv1.GRPCRoute{route})
+	out := withEffectiveHostnamesGRPC(context.Background(), cli, []*gatewayv1.GRPCRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Equal(t, []gatewayv1.Hostname{gatewayHost}, out[0].Spec.Hostnames)
 }
@@ -128,7 +128,7 @@ func TestWithEffectiveHostnames_InheritsFromListenerSetEntry(t *testing.T) {
 
 	cli := buildGatewayFakeClient(t, ls)
 
-	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Equal(t, []gatewayv1.Hostname{entryHost}, out[0].Spec.Hostnames)
 }
@@ -175,7 +175,7 @@ func TestWithEffectiveHostnames_SectionNameNarrowsListenerSetEntries(t *testing.
 
 	cli := buildGatewayFakeClient(t, ls)
 
-	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Equal(t, []gatewayv1.Hostname{b}, out[0].Spec.Hostnames, "only the sectionName-matched entry's hostname should be inherited")
 }
@@ -211,7 +211,7 @@ func TestWithEffectiveHostnames_NoOpWhenRouteAlreadyDeclaresHostnames(t *testing
 
 	cli := buildGatewayFakeClient(t, ls)
 
-	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Equal(t, []gatewayv1.Hostname{declared}, out[0].Spec.Hostnames, "explicit route hostnames must not be overwritten")
 }
@@ -268,7 +268,7 @@ func TestWithEffectiveHostnames_OnlyInheritsFromAcceptingListeners(t *testing.T)
 
 	cli := buildGatewayFakeClient(t, ls)
 
-	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Equal(t, []gatewayv1.Hostname{allHost}, out[0].Spec.Hostnames,
 		"route must inherit only the accepting listener's hostname, not the same-namespace-only listener's")
@@ -292,7 +292,7 @@ func TestWithEffectiveHostnames_StableWhenParentMissing(t *testing.T) {
 
 	cli := buildGatewayFakeClient(t)
 
-	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Empty(t, out[0].Spec.Hostnames, "missing parent must not synthesise hostnames")
 }
@@ -372,7 +372,7 @@ func TestWithEffectiveHostnames_ListenerSetConflictedEntryNotInherited(t *testin
 
 	cli := buildGatewayFakeClient(t, gw, ls)
 
-	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withEffectiveHostnames(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Empty(t, out[0].Spec.Hostnames,
 		"a conflicted ListenerSet entry is not programmed → its hostname must not be inherited")

--- a/internal/controller/route_parent_binding.go
+++ b/internal/controller/route_parent_binding.go
@@ -7,7 +7,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/listenermerge"
 	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/routebinding"
 )
 
@@ -42,6 +41,7 @@ func resolveRouteParentBinding(
 	ref gatewayv1.ParentReference,
 	routeNamespace string,
 	routeInfo *routebinding.RouteInfo,
+	views *listenerViewCache,
 ) (parentRefBinding, error) {
 	kind := kindGateway
 	if ref.Kind != nil {
@@ -52,7 +52,7 @@ func resolveRouteParentBinding(
 	case kindGateway:
 		return resolveGatewayParentBinding(ctx, cli, validator, controllerName, ref, routeNamespace, routeInfo)
 	case kindListenerSet:
-		return resolveListenerSetParentBinding(ctx, cli, validator, controllerName, ref, routeNamespace, routeInfo)
+		return resolveListenerSetParentBinding(ctx, cli, validator, controllerName, ref, routeNamespace, routeInfo, views)
 	}
 
 	return parentRefBinding{}, nil
@@ -100,6 +100,7 @@ func resolveListenerSetParentBinding(
 	ref gatewayv1.ParentReference,
 	routeNamespace string,
 	routeInfo *routebinding.RouteInfo,
+	views *listenerViewCache,
 ) (parentRefBinding, error) {
 	namespace := routeNamespace
 	if ref.Namespace != nil {
@@ -150,7 +151,7 @@ func resolveListenerSetParentBinding(
 	// says should not exist. Filter the matched sections through the merge
 	// view; if every match is conflicted, surface NoMatchingParent.
 	if bindResult.Accepted {
-		bindResult = filterMatchedListenersByConflict(ctx, cli, &listenerSet, parent, bindResult)
+		bindResult = filterMatchedListenersByConflict(ctx, cli, &listenerSet, parent, bindResult, views)
 	}
 
 	return parentRefBinding{ManagedByThisController: true, Result: bindResult}, nil
@@ -165,21 +166,19 @@ func filterMatchedListenersByConflict(
 	listenerSet *gatewayv1.ListenerSet,
 	parent *gatewayv1.Gateway,
 	result routebinding.BindingResult,
+	views *listenerViewCache,
 ) routebinding.BindingResult {
-	siblings, err := collectAcceptedListenerSetsForGateway(ctx, cli, parent)
+	view, err := views.orNew(cli).forGateway(ctx, parent)
 	if err != nil {
 		// Best-effort: if we can't compute the merge view, leave the binding
 		// as-is. A later reconcile will retry.
 		return result
 	}
 
-	merged := listenermerge.Merge(parent, siblings)
-
 	kept := make([]gatewayv1.SectionName, 0, len(result.MatchedListeners))
 
 	for _, section := range result.MatchedListeners {
-		entry := findMergedEntry(merged, listenerSet, section)
-		if entry != nil && entry.ConflictReason != "" {
+		if view.conflictReason(listenerSet, section) != "" {
 			continue
 		}
 

--- a/internal/controller/route_parent_binding_test.go
+++ b/internal/controller/route_parent_binding_test.go
@@ -42,7 +42,7 @@ func TestResolveRouteParentBinding_GatewayParentManaged(t *testing.T) {
 		Hostnames: nil, Kind: routebinding.KindHTTPRoute,
 	}
 
-	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo)
+	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo, nil)
 	require.NoError(t, err)
 	assert.True(t, binding.ManagedByThisController)
 	assert.True(t, binding.Result.Accepted)
@@ -68,7 +68,7 @@ func TestResolveRouteParentBinding_GatewayManagedByForeignController(t *testing.
 	ref := gatewayv1.ParentReference{Kind: &gwKind, Name: "gw", Namespace: &gwNS}
 	routeInfo := &routebinding.RouteInfo{Name: "r", Namespace: "team-a", Kind: routebinding.KindHTTPRoute}
 
-	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo)
+	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo, nil)
 	require.NoError(t, err)
 	assert.False(t, binding.ManagedByThisController, "ref to a Gateway whose class is owned by a foreign controller must not register as ours")
 }
@@ -104,7 +104,7 @@ func TestResolveRouteParentBinding_ListenerSetNotAllowedByGateway(t *testing.T) 
 	ref := gatewayv1.ParentReference{Kind: &lsKind, Name: "ls", Namespace: &lsNS}
 	routeInfo := &routebinding.RouteInfo{Name: "r", Namespace: "team-a", Kind: routebinding.KindHTTPRoute}
 
-	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo)
+	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo, nil)
 	require.NoError(t, err)
 	assert.True(t, binding.ManagedByThisController, "Gateway IS managed, even though it rejects the ListenerSet — so the route still belongs to us")
 	assert.False(t, binding.Result.Accepted)
@@ -129,7 +129,7 @@ func TestResolveRouteParentBinding_ListenerSetParentGatewayMissing(t *testing.T)
 	ref := gatewayv1.ParentReference{Kind: &lsKind, Name: "ls", Namespace: &lsNS}
 	routeInfo := &routebinding.RouteInfo{Name: "r", Namespace: "team-a", Kind: routebinding.KindHTTPRoute}
 
-	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo)
+	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo, nil)
 	require.NoError(t, err)
 	assert.False(t, binding.ManagedByThisController, "missing parent Gateway leaves the ref unresolvable")
 }
@@ -181,7 +181,7 @@ func TestResolveRouteParentBinding_CrossNamespaceListenerSet(t *testing.T) {
 	ref := gatewayv1.ParentReference{Kind: &lsKind, Name: "ls", Namespace: &lsNS}
 	routeInfo := &routebinding.RouteInfo{Name: "r", Namespace: "team-a", Kind: routebinding.KindHTTPRoute}
 
-	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo)
+	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo, nil)
 	require.NoError(t, err)
 	assert.True(t, binding.ManagedByThisController)
 	assert.True(t, binding.Result.Accepted, "route attaches via the cross-namespace ListenerSet's entry")
@@ -234,7 +234,7 @@ func TestResolveRouteParentBinding_ConflictedListenerSetEntryRejected(t *testing
 	ref := gatewayv1.ParentReference{Kind: &lsKind, Name: "ls", Namespace: &lsNS}
 	routeInfo := &routebinding.RouteInfo{Name: "r", Namespace: "team-a", Kind: routebinding.KindHTTPRoute}
 
-	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo)
+	binding, err := resolveRouteParentBinding(context.Background(), cli, validator, testListenerSetController, ref, "team-a", routeInfo, nil)
 	require.NoError(t, err)
 	assert.True(t, binding.ManagedByThisController)
 	assert.False(t, binding.Result.Accepted, "binding to a conflicted LS entry must be rejected")

--- a/internal/controller/route_redirect_scheme.go
+++ b/internal/controller/route_redirect_scheme.go
@@ -42,16 +42,18 @@ func withDefaultRedirectScheme(
 	ctx context.Context,
 	cli client.Client,
 	routes []*gatewayv1.HTTPRoute,
+	views *listenerViewCache,
 ) []*gatewayv1.HTTPRoute {
 	if len(routes) == 0 {
 		return routes
 	}
 
+	views = views.orNew(cli)
 	validator := routebinding.NewValidator(cli)
 	out := make([]*gatewayv1.HTTPRoute, len(routes))
 
 	for i, route := range routes {
-		out[i] = defaultRedirectSchemeForRoute(ctx, cli, validator, route)
+		out[i] = defaultRedirectSchemeForRoute(ctx, cli, validator, route, views)
 	}
 
 	return out
@@ -65,12 +67,13 @@ func defaultRedirectSchemeForRoute(
 	cli client.Client,
 	validator *routebinding.Validator,
 	route *gatewayv1.HTTPRoute,
+	views *listenerViewCache,
 ) *gatewayv1.HTTPRoute {
 	if !routeHasEmptyRedirectScheme(route) {
 		return route
 	}
 
-	scheme := acceptedListenerScheme(ctx, cli, validator, HTTPRouteWrapper{route})
+	scheme := acceptedListenerScheme(ctx, cli, validator, HTTPRouteWrapper{route}, views)
 	if scheme == "" {
 		return route
 	}
@@ -151,11 +154,12 @@ func acceptedListenerScheme(
 	cli client.Client,
 	validator *routebinding.Validator,
 	route Route,
+	views *listenerViewCache,
 ) string {
 	sawHTTP := false
 
 	for _, ref := range route.GetParentRefs() {
-		for _, protocol := range acceptedProtocolsForParentRef(ctx, cli, validator, route, ref) {
+		for _, protocol := range acceptedProtocolsForParentRef(ctx, cli, validator, route, ref, views) {
 			switch protocol {
 			case gatewayv1.HTTPSProtocolType:
 				return redirectSchemeHTTPS
@@ -186,6 +190,7 @@ func acceptedProtocolsForParentRef(
 	validator *routebinding.Validator,
 	route Route,
 	ref gatewayv1.ParentReference,
+	views *listenerViewCache,
 ) []gatewayv1.ProtocolType {
 	if ref.Group != nil && string(*ref.Group) != "" && string(*ref.Group) != gatewayv1.GroupName {
 		return nil
@@ -218,7 +223,7 @@ func acceptedProtocolsForParentRef(
 	case kindGateway:
 		return gatewayAcceptedProtocols(ctx, cli, validator, namespace, string(ref.Name), routeInfo)
 	case kindListenerSet:
-		return listenerSetAcceptedProtocols(ctx, cli, validator, namespace, string(ref.Name), routeInfo)
+		return listenerSetAcceptedProtocols(ctx, cli, validator, namespace, string(ref.Name), routeInfo, views)
 	}
 
 	return nil
@@ -255,6 +260,7 @@ func listenerSetAcceptedProtocols(
 	validator *routebinding.Validator,
 	namespace, name string,
 	routeInfo *routebinding.RouteInfo,
+	views *listenerViewCache,
 ) []gatewayv1.ProtocolType {
 	var listenerSet gatewayv1.ListenerSet
 	if err := cli.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &listenerSet); err != nil {
@@ -269,7 +275,7 @@ func listenerSetAcceptedProtocols(
 	// Drop sections whose merged-view entry is conflicted — a conflicted
 	// listener is not programmed, so a route must not infer its scheme from
 	// that listener's protocol. Same step the hostname-inheritance path takes.
-	matched := nonConflictedSections(ctx, cli, &listenerSet, result.MatchedListeners)
+	matched := nonConflictedSections(ctx, cli, &listenerSet, result.MatchedListeners, views)
 
 	protoByName := make(map[gatewayv1.SectionName]gatewayv1.ProtocolType, len(listenerSet.Spec.Listeners))
 	for i := range listenerSet.Spec.Listeners {

--- a/internal/controller/route_redirect_scheme_test.go
+++ b/internal/controller/route_redirect_scheme_test.go
@@ -75,7 +75,7 @@ func TestWithDefaultRedirectScheme_HTTPListenerDefaultsToHTTP(t *testing.T) {
 	route := redirectRoute(nil)
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	got := redirectFilterScheme(out[0])
 	require.NotNil(t, got, "redirect scheme must be defaulted from the HTTP listener")
@@ -93,7 +93,7 @@ func TestWithDefaultRedirectScheme_HTTPSListenerDefaultsToHTTPS(t *testing.T) {
 	route := redirectRoute(nil)
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	got := redirectFilterScheme(out[0])
 	require.NotNil(t, got)
@@ -112,7 +112,7 @@ func TestWithDefaultRedirectScheme_TLSListenerLeavesSchemeNil(t *testing.T) {
 	route := redirectRoute(nil)
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Nil(t, redirectFilterScheme(out[0]), "a TLS listener does not accept an HTTPRoute → no inferred scheme")
 }
@@ -128,7 +128,7 @@ func TestWithDefaultRedirectScheme_TCPListenerLeavesSchemeNil(t *testing.T) {
 	route := redirectRoute(nil)
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Nil(t, redirectFilterScheme(out[0]), "a TCP listener implies no L7 redirect scheme")
 }
@@ -142,7 +142,7 @@ func TestWithDefaultRedirectScheme_ExplicitSchemePreserved(t *testing.T) {
 	route := redirectRoute(new("http"))
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	got := redirectFilterScheme(out[0])
 	require.NotNil(t, got)
@@ -163,7 +163,7 @@ func TestWithDefaultRedirectScheme_NoRedirectFilterPassthrough(t *testing.T) {
 	}
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Same(t, route, out[0], "routes without a redirect filter must pass through untouched")
 }
@@ -177,7 +177,7 @@ func TestWithDefaultRedirectScheme_NoParentLeavesSchemeNil(t *testing.T) {
 	route := redirectRoute(nil)
 	cli := buildGatewayFakeClient(t) // no Gateway seeded
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	assert.Nil(t, redirectFilterScheme(out[0]), "no resolvable parent → no inferred scheme")
 }
@@ -220,7 +220,7 @@ func TestWithDefaultRedirectScheme_ListenerSetHTTPDefaultsToHTTP(t *testing.T) {
 
 	cli := buildGatewayFakeClient(t, ls)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{listenerSetRedirectRoute()})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{listenerSetRedirectRoute()}, nil)
 	require.Len(t, out, 1)
 	got := redirectFilterScheme(out[0])
 	require.NotNil(t, got, "scheme must be inferred from the accepted ListenerSet entry")
@@ -279,7 +279,7 @@ func TestWithDefaultRedirectScheme_ListenerSetConflictedEntryLeavesSchemeNil(t *
 
 	cli := buildGatewayFakeClient(t, gw, ls)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{listenerSetRedirectRoute()})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{listenerSetRedirectRoute()}, nil)
 	require.Len(t, out, 1)
 	assert.Nil(t, redirectFilterScheme(out[0]),
 		"a conflicted ListenerSet entry is not programmed → its protocol must not seed the scheme")
@@ -341,7 +341,7 @@ func TestWithDefaultRedirectScheme_BackendRefHTTPListenerDefaultsToHTTP(t *testi
 	route := backendRefRedirectRoute()
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	got := backendRefRedirectFilterScheme(out[0])
 	require.NotNil(t, got, "backendRef redirect scheme must be defaulted from the HTTP listener")
@@ -359,7 +359,7 @@ func TestWithDefaultRedirectScheme_BackendRefHTTPSListenerDefaultsToHTTPS(t *tes
 	route := backendRefRedirectRoute()
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	got := backendRefRedirectFilterScheme(out[0])
 	require.NotNil(t, got)
@@ -394,7 +394,7 @@ func TestWithDefaultRedirectScheme_HTTPSWinsTie(t *testing.T) {
 	route := redirectRoute(nil)
 	cli := buildGatewayFakeClient(t, gw)
 
-	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route})
+	out := withDefaultRedirectScheme(context.Background(), cli, []*gatewayv1.HTTPRoute{route}, nil)
 	require.Len(t, out, 1)
 	got := redirectFilterScheme(out[0])
 	require.NotNil(t, got)

--- a/internal/controller/route_syncer.go
+++ b/internal/controller/route_syncer.go
@@ -45,6 +45,12 @@ type RouteSyncer struct {
 	grpcBuilder      *ingress.GRPCBuilder
 	bindingValidator *routebinding.Validator
 
+	// ViewStore caches the per-Gateway ListenerSet merge view across reconciles
+	// (issue #332). Set by the manager after construction and shared with the
+	// other reconcilers. nil disables cross-reconcile reuse (per-pass dedup
+	// still applies).
+	ViewStore *mergeViewStore
+
 	// syncMu protects concurrent calls to SyncAllRoutes.
 	// Both HTTPRouteReconciler and GRPCRouteReconciler may call SyncAllRoutes
 	// concurrently, and this mutex ensures serialized access to Cloudflare API.
@@ -354,8 +360,9 @@ func parametersRefEqual(left, right *gatewayv1.ParametersReference) bool {
 // Used when early errors occur (before routes are collected) to ensure
 // route statuses are updated to reflect the error.
 func (s *RouteSyncer) buildResultForError(ctx context.Context) *SyncResult {
-	httpResult, _ := s.getRelevantHTTPRoutes(ctx)
-	grpcResult, _ := s.getRelevantGRPCRoutes(ctx)
+	views := newListenerViewCache(s.Client, s.ViewStore)
+	httpResult, _ := s.getRelevantHTTPRoutes(ctx, views)
+	grpcResult, _ := s.getRelevantGRPCRoutes(ctx, views)
 
 	result := &SyncResult{}
 
@@ -431,14 +438,19 @@ func (s *RouteSyncer) SyncAllRoutes(ctx context.Context) (ctrl.Result, *SyncResu
 
 	s.Metrics.RecordAPICall(ctx, "get", "tunnel_config", "success", time.Since(getStart))
 
+	// One merge-view cache for the whole sync: every route's ListenerSet
+	// parentRefs that resolve to the same Gateway reuse a single merge instead
+	// of rebuilding it per route (issue #332).
+	views := newListenerViewCache(s.Client, s.ViewStore)
+
 	// Collect all relevant HTTPRoutes with binding validation
-	httpResult, err := s.getRelevantHTTPRoutes(ctx)
+	httpResult, err := s.getRelevantHTTPRoutes(ctx, views)
 	if err != nil {
 		return ctrl.Result{}, nil, errors.Wrap(err, "failed to list httproutes")
 	}
 
 	// Collect all relevant GRPCRoutes with binding validation
-	grpcResult, err := s.getRelevantGRPCRoutes(ctx)
+	grpcResult, err := s.getRelevantGRPCRoutes(ctx, views)
 	if err != nil {
 		return ctrl.Result{}, nil, errors.Wrap(err, "failed to list grpcroutes")
 	}
@@ -569,6 +581,7 @@ type grpcRouteResult struct {
 //nolint:dupl // mirrored on purpose against getRelevantGRPCRoutes — different list/result types prevent a clean generic
 func (s *RouteSyncer) getRelevantHTTPRoutes(
 	ctx context.Context,
+	views *listenerViewCache,
 ) (*httpRouteResult, error) {
 	logger := logging.FromContext(ctx)
 	if logger == slog.Default() {
@@ -588,7 +601,7 @@ func (s *RouteSyncer) getRelevantHTTPRoutes(
 		route := &routeList.Items[i]
 		bindingInfo, accepted, referencesUs := s.bindRouteParents(
 			ctx, logger, route.Namespace, route.Name, route.Spec.Hostnames,
-			routebinding.KindHTTPRoute, route.Spec.ParentRefs,
+			routebinding.KindHTTPRoute, route.Spec.ParentRefs, views,
 		)
 		result.bindings[route.Namespace+"/"+route.Name] = bindingInfo
 
@@ -606,6 +619,7 @@ func (s *RouteSyncer) getRelevantHTTPRoutes(
 //nolint:dupl // mirrored on purpose against getRelevantHTTPRoutes — different list/result types prevent a clean generic
 func (s *RouteSyncer) getRelevantGRPCRoutes(
 	ctx context.Context,
+	views *listenerViewCache,
 ) (*grpcRouteResult, error) {
 	logger := logging.FromContext(ctx)
 	if logger == slog.Default() {
@@ -625,7 +639,7 @@ func (s *RouteSyncer) getRelevantGRPCRoutes(
 		route := &routeList.Items[i]
 		bindingInfo, accepted, referencesUs := s.bindRouteParents(
 			ctx, logger, route.Namespace, route.Name, route.Spec.Hostnames,
-			routebinding.KindGRPCRoute, route.Spec.ParentRefs,
+			routebinding.KindGRPCRoute, route.Spec.ParentRefs, views,
 		)
 		result.bindings[route.Namespace+"/"+route.Name] = bindingInfo
 
@@ -651,6 +665,7 @@ func (s *RouteSyncer) bindRouteParents(
 	hostnames []gatewayv1.Hostname,
 	kind gatewayv1.Kind,
 	parentRefs []gatewayv1.ParentReference,
+	views *listenerViewCache,
 ) (routeBindingInfo, bool, bool) {
 	bindingInfo := routeBindingInfo{
 		bindingResults: make(map[int]routebinding.BindingResult),
@@ -669,7 +684,7 @@ func (s *RouteSyncer) bindRouteParents(
 			Port:        ref.Port,
 		}
 
-		binding, err := resolveRouteParentBinding(ctx, s.Client, s.bindingValidator, s.ControllerName, ref, routeNamespace, routeInfo)
+		binding, err := resolveRouteParentBinding(ctx, s.Client, s.bindingValidator, s.ControllerName, ref, routeNamespace, routeInfo, views)
 		if err != nil {
 			logger.Error("failed to resolve route parentRef",
 				"route", routeNamespace+"/"+routeName, "refIdx", refIdx, "error", err)

--- a/internal/controller/route_syncer_test.go
+++ b/internal/controller/route_syncer_test.go
@@ -265,7 +265,7 @@ func TestRouteSyncer_GetRelevantHTTPRoutes(t *testing.T) {
 				nil,
 			)
 
-			result, err := syncer.getRelevantHTTPRoutes(context.Background())
+			result, err := syncer.getRelevantHTTPRoutes(context.Background(), nil)
 
 			require.NoError(t, err)
 			assert.Len(t, result.accepted, tt.expectedCount)
@@ -389,7 +389,7 @@ func TestRouteSyncer_GetRelevantGRPCRoutes(t *testing.T) {
 				nil,
 			)
 
-			result, err := syncer.getRelevantGRPCRoutes(context.Background())
+			result, err := syncer.getRelevantGRPCRoutes(context.Background(), nil)
 
 			require.NoError(t, err)
 			assert.Len(t, result.accepted, tt.expectedCount)
@@ -857,7 +857,7 @@ func TestRouteSyncer_GetRelevantGRPCRoutes_WithExplicitNamespace(t *testing.T) {
 				nil,
 			)
 
-			result, err := syncer.getRelevantGRPCRoutes(context.Background())
+			result, err := syncer.getRelevantGRPCRoutes(context.Background(), nil)
 
 			require.NoError(t, err)
 			assert.Len(t, result.accepted, tt.expectedCount)


### PR DESCRIPTION
# Pull Request

## Summary

The ListenerSet status, the Gateway `attachedListenerSets` count, route binding, and per-entry `AttachedRoutes` each independently listed all ListenerSets and recomputed the precedence/conflict merge from scratch on every reconcile. In the route sync path this rebuilt the same per-Gateway view for every route × ListenerSet-ref, and a single Gateway event fanned out to N ListenerSet reconciles each doing O(N) work. This PR computes the per-Gateway merge view once and threads it through every consumer, backed by a shared cross-reconcile cache.

Closes #332.

## Changes

- Introduce a single `gatewayListenerView` (accepted ListenerSets + `listenermerge.Merge` output) built once per reconcile/sync pass via a `listenerViewCache`, and thread it through the status, count, and route-binding consumers instead of each rebuilding it.
- Back the per-pass cache with a shared `mergeViewStore` so a burst of reconciles triggered by one event reuses a single merge. Reuse is guarded by a content fingerprint over the Gateway generation and each targeting ListenerSet's `(namespace, name, generation, creationTimestamp)` — the Gateway generation alone is insufficient, because a sibling ListenerSet spec edit changes the view without bumping the Gateway's generation, and `creationTimestamp` decides conflict precedence and survives a same-name delete+recreate that resets generation to 1.
- Bypass the cross-reconcile store for Gateways using `allowedListeners` `From=Selector` (acceptance then depends on Namespace labels, which are outside the fingerprint and not watched); per-pass dedup still applies.
- Evict a Gateway's cached view when the Gateway is deleted, so the store stays bounded by live Gateway count.
- Collapse the duplicated `collectAcceptedSiblings` enumeration into the shared view builder.

Behaviour is unchanged — this is purely a reconcile-cost reduction. An equivalence test pins the cache output byte-for-byte against a from-scratch `listenermerge.Merge`.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [ ] Markdown linting passes (`markdownlint **/*.md`) — no markdown changed in this PR
- [ ] Manual testing completed (if applicable) — Gateway API conformance + custom e2e against a live tunnel still to run (see Additional Notes)

## Documentation

- [ ] README updated (if needed) — not needed; no user-facing behaviour change
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed) — not applicable

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none; behaviour-preserving
- [x] Related issues referenced (if any)

## Additional Notes

Reviewed by Opus across two passes; the first surfaced two correctness gaps (unbounded store growth, and a stale merged view after a same-name ListenerSet delete+recreate) that are fixed and covered by dedicated tests.

Pending before merge: the official Gateway API conformance suite and the custom e2e suite against a real Cloudflare Tunnel. These require a registered tunnel and a reachable cluster and are run maintainer-side; this PR stays in draft until they are green.
