### PR TITLE
ci: fix chart-testing Rekor flake and add Cloudflare token pre-flight

### DIFF
--- a/.github/actions/setup-chart-testing/action.yml
+++ b/.github/actions/setup-chart-testing/action.yml
@@ -1,0 +1,75 @@
+name: Set up chart-testing
+description: >-
+  Install helm chart-testing (ct) plus yamllint and yamale, reproducing
+  helm/chart-testing-action but wrapping the cosign-verified download in a retry
+  so a transient sigstore/Rekor HTTP/2 stream reset does not fail the job.
+  Requires actions/setup-python to have run first (yamllint/yamale go into a
+  dedicated venv built from that Python).
+runs:
+  using: composite
+  steps:
+    - name: Install cosign
+      uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+    # The upstream helm/chart-testing-action runs a bare `cosign verify-blob`
+    # whose Rekor transparency-log query is the one un-retried network call; a
+    # transient HTTP/2 stream reset there fails the whole Lint Chart job. Wrap
+    # the download + verify + install in a retry so the blip is recoverable.
+    - name: Download, verify and install chart-testing
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        shell: bash
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 10
+        command: |
+          set -euo pipefail
+
+          # renovate: datasource=github-releases depName=helm/chart-testing
+          CT_VERSION="v3.14.0"
+          # renovate: datasource=pypi depName=yamllint
+          YAMLLINT_VERSION="1.33.0"
+          # renovate: datasource=pypi depName=yamale
+          YAMALE_VERSION="6.0.0"
+
+          if [[ "$(uname -m)" == "aarch64" ]]; then arch=arm64; else arch=amd64; fi
+          ver="${CT_VERSION#v}"
+          dir="${RUNNER_TEMP}/ct"
+          base="https://github.com/helm/chart-testing/releases/download/${CT_VERSION}"
+          tarball="chart-testing_${ver}_linux_${arch}.tar.gz"
+          mkdir -p "${dir}"
+
+          curl --retry 5 --retry-delay 1 -sSLo "${dir}/ct.tar.gz"     "${base}/${tarball}"
+          curl --retry 5 --retry-delay 1 -sSLo "${dir}/ct.tar.gz.pem" "${base}/${tarball}.pem"
+          curl --retry 5 --retry-delay 1 -sSLo "${dir}/ct.tar.gz.sig" "${base}/${tarball}.sig"
+
+          # Keyless verification against the chart-testing release workflow's
+          # identity. The identity/issuer are stable across ct versions (they
+          # reference the workflow ref, not the version), so only CT_VERSION
+          # changes on a bump.
+          cosign verify-blob \
+            --certificate "${dir}/ct.tar.gz.pem" \
+            --signature "${dir}/ct.tar.gz.sig" \
+            --certificate-identity "https://github.com/helm/chart-testing/.github/workflows/release.yaml@refs/heads/main" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${dir}/ct.tar.gz"
+
+          tar -xzf "${dir}/ct.tar.gz" -C "${dir}"
+          rm -f "${dir}/ct.tar.gz" "${dir}/ct.tar.gz.pem" "${dir}/ct.tar.gz.sig"
+
+          # Install yamllint + yamale into a dedicated venv and put its bin dir
+          # on PATH explicitly, mirroring upstream ct.sh. ct lint shells out to
+          # both tools by name, so relying on the ambient pip console-script dir
+          # being on PATH would be fragile — the venv makes resolution explicit.
+          python3 -m venv "${dir}/venv"
+          "${dir}/venv/bin/pip" install "yamllint==${YAMLLINT_VERSION}" "yamale==${YAMALE_VERSION}"
+
+          # $GITHUB_PATH / $GITHUB_ENV are job-scoped files, so these appends
+          # persist to subsequent job steps even though they run inside the
+          # retry wrapper. CT_CONFIG_DIR points at the tarball's etc/ dir
+          # (chart_schema.yaml + lintconf.yaml), matching upstream ct.sh.
+          echo "${dir}" >> "${GITHUB_PATH}"
+          echo "${dir}/venv/bin" >> "${GITHUB_PATH}"
+          echo "CT_CONFIG_DIR=${dir}/etc" >> "${GITHUB_ENV}"
+
+          "${dir}/ct" version

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -292,7 +292,7 @@ jobs:
           python-version: '3.14.5'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+        uses: ./.github/actions/setup-chart-testing
 
       - name: Install tools
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.14.5'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+        uses: ./.github/actions/setup-chart-testing
 
       - name: Install tools
         run: |

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -95,6 +95,24 @@ for var in CF_API_TOKEN CF_ACCOUNT_ID V2_TUNNEL_ID V2_TUNNEL_TOKEN; do
   fi
 done
 
+# --- Pre-flight: validate the Cloudflare token against the real tunnel endpoint ---
+# A non-empty token is not enough: an expired/invalid token deploys fine but then
+# 401s on every cfd_tunnel/.../configurations call, Gateways never reach
+# Accepted=True, and the conformance suite silently polls until timeout. Hit the
+# exact endpoint the controller uses and fail fast instead.
+# NB: do NOT use /user/tokens/verify — a minimum-privilege account token
+# (Account -> Cloudflare Tunnel -> Edit) lacks user-level token introspection, so
+# verify returns success:false / code 1000 for a working token. The
+# configurations endpoint is the authoritative signal.
+info "Validating Cloudflare API token against tunnel ${V2_TUNNEL_ID}..."
+token_http_code="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+  --retry 3 --retry-delay 1 --max-time 15 \
+  --header "Authorization: Bearer ${CF_API_TOKEN}" \
+  "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${V2_TUNNEL_ID}/configurations" || true)"
+if [[ "${token_http_code}" != "200" ]]; then
+  die "CF_API_TOKEN cannot read tunnel ${V2_TUNNEL_ID} (HTTP ${token_http_code:-no-response}). Refresh the token (Cloudflare dashboard -> account -> Cloudflare Tunnel -> Edit) before re-running."
+fi
+
 # --- CI-images mode: fail fast if the PR chart is gone before building a cluster ---
 if [[ -n "${CI_PR_NUMBER}" ]]; then
   CI_CHART_VERSION="0.0.0-pr.${CI_PR_NUMBER}-1d"

--- a/renovate.json
+++ b/renovate.json
@@ -77,7 +77,8 @@
       "customType": "regex",
       "description": "Update versioned binaries in GitHub Actions workflows",
       "fileMatch": [
-        "^\\.github/workflows/.*\\.ya?ml$"
+        "^\\.github/workflows/.*\\.ya?ml$",
+        "^\\.github/actions/.*\\.ya?ml$"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s+[A-Z_]+VERSION=\"(?<currentValue>.*?)\""


### PR DESCRIPTION
## Summary

Two CI/test-infra hardening fixes:

- **#378** — the `Lint Chart` job intermittently failed while setting up chart-testing. The upstream `helm/chart-testing-action` retries the tarball download but runs a bare `cosign verify-blob` whose Rekor transparency-log query is un-retried; a transient HTTP/2 stream reset there failed the whole job, and a plain re-run on the same commit passed. Replace the action with a local composite action that reproduces its behaviour (cosign keyless verification, yamllint, yamale) but wraps the download-and-verify in a retry.
- **#379** — `conformance-setup.sh` only checked that `CF_API_TOKEN` was non-empty. An expired token deployed cleanly, then the controller got 401 on every tunnel-configuration call, Gateways never reached `Accepted=True`, and the conformance suite polled until timeout. Add a pre-flight that hits the exact endpoint the controller uses and fails fast on a non-200.

## Changes

- New local composite action `.github/actions/setup-chart-testing`, used by both the PR and release `Lint Chart` jobs. The cosign-verified `ct` install runs under a retry, so a transient sigstore/Rekor blip is recoverable instead of fatal. yamllint and yamale install into a dedicated venv whose `bin` dir is added to `PATH` explicitly, matching the upstream install.
- `conformance-setup.sh` gains a token pre-flight against the `cfd_tunnel/.../configurations` endpoint, aborting with an actionable message on non-200. It deliberately avoids `/user/tokens/verify`, which false-negatives on minimum-privilege account tokens.
- Renovate: widen the versioned-binary custom manager to also scan `.github/actions/**` so the pinned `ct` / yamllint / yamale versions stay current.

## Testing

- [ ] All tests pass locally (`go test ./...`) — N/A, no Go changes
- [ ] Linters pass locally (`golangci-lint run`) — N/A, no Go changes
- [ ] Markdown linting passes (`markdownlint **/*.md`) — N/A, no markdown changes
- [x] Manual testing completed

Manual verification:

- `actionlint` clean on both workflows; the new composite action parses as a valid composite action.
- `shellcheck` and `bash -n` clean on `conformance-setup.sh`.
- Token pre-flight exercised against the live API: a valid token returns `200` (setup proceeds); an invalid token returns non-200 and aborts immediately.
- The composite action itself is exercised end-to-end by this PR's own `Lint Chart` job.

## Documentation

- [x] Code comments added for complex logic
- [ ] README updated (if needed) — not needed
- [ ] CLAUDE.md updated (if workflow/standards changed) — not needed

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [ ] Breaking changes documented (if any) — none
- [x] Related issues referenced (if any)

## Additional Notes

A CI lint job for shell/workflow YAML (`shellcheck` + `actionlint`) would have caught this class of issue earlier; the repo has none today. Left as a follow-up to keep this PR scoped.

Closes #378
Closes #379
