### PR TITLE
docs: remove pre-v3 historical content from docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ All matching and filter behavior is performed by the in-process L7 proxy that th
 
 ### Known Limitations
 
-The in-process L7 proxy handles routing for every tunnel request, so the v1/v2 Cloudflare-Tunnel-API path-matching quirks (no true exact match, prefix bleed across `/foo` siblings) no longer apply. Edge-side caveats (Cloudflare hostname registration, edge HTTPS termination, etc.) are documented in the [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/) page.
+The in-process L7 proxy handles routing for every tunnel request. Edge-side caveats (Cloudflare hostname registration, edge HTTPS termination, etc.) are documented in the [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/) page.
 
 `BackendTLSPolicy` (proxy → backend TLS) is supported at minimum-viable scope:
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,10 +1,10 @@
 # Architecture
 
-This document describes the internal architecture of the Cloudflare Tunnel Gateway Controller.
+This document describes the internal architecture of the Cloudflare Tunnel Gateway Controller and its in-process L7 proxy data plane.
 
 ## High-Level Overview
 
-The controller implements the Kubernetes Gateway API to configure Cloudflare Tunnel ingress rules. It watches Gateway and HTTPRoute resources and translates them into Cloudflare Tunnel configuration via the Cloudflare API.
+The controller implements the Kubernetes Gateway API to configure Cloudflare Tunnel ingress rules. It watches Gateway and HTTPRoute resources, translates them into Cloudflare Tunnel configuration via the Cloudflare API, and pushes route state to the in-process L7 proxy that carries tunnel traffic.
 
 ```mermaid
 flowchart TB
@@ -13,7 +13,7 @@ flowchart TB
         HR[HTTPRoute]
         SVC[Services]
         CTRL[Controller]
-        CFD[cloudflared]
+        PROXY[Proxy Pod<br/>embedded cloudflared transport]
     end
 
     subgraph Cloudflare["Cloudflare Edge"]
@@ -25,10 +25,11 @@ flowchart TB
     HR -->|watch| CTRL
     SVC -->|resolve| CTRL
     CTRL -->|configure| API
-    API -->|push config| CFD
-    CFD -->|tunnel| EDGE
-    EDGE -->|traffic| CFD
-    CFD -->|route| SVC
+    CTRL -->|sync routes| PROXY
+    API -->|tunnel config| PROXY
+    PROXY -->|tunnel| EDGE
+    EDGE -->|traffic| PROXY
+    PROXY -->|route| SVC
 ```
 
 ## Package Structure

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -2,26 +2,6 @@
 
 This document describes the known limitations of the Cloudflare Tunnel Gateway Controller and provides workarounds where applicable.
 
-## Historical context (pre-v3 only)
-
-In the v1/v2 chart line, several HTTPRoute features required opting into the L7 proxy because the alternative path (Cloudflare Tunnel's native ingress) cannot express exact-path / header / query / method matching, weighted splitting, or filters. **v3 collapses this to a single data plane** — the proxy is always rendered, so all of those features work unconditionally. The bullets below are kept as historical context; if you are running v3 you can skip to the [Controller Limitations](#controller-limitations) section.
-
-??? note "v1/v2 feature matrix (kept for upgrade context)"
-
-    | Feature | v1/v2 without proxy | v1/v2 with proxy / v3 |
-    | --- | --- | --- |
-    | Exact path matching | No | Yes |
-    | Header matching | No | Yes |
-    | Query parameter matching | No | Yes |
-    | Method matching | No | Yes |
-    | Request header modification | No | Yes |
-    | Response header modification | No | Yes |
-    | Request redirect | No | Yes |
-    | URL rewrite | No | Yes |
-    | Request mirroring | No | Yes |
-    | Traffic splitting (weighted) | No | Yes |
-    | Regex path matching | No | Yes |
-
 ## Controller Limitations
 
 | Limitation | Description |
@@ -55,9 +35,7 @@ A cross-namespace `ServiceImport` or `ExternalBackend` `backendRef` requires a `
 
 ## Traffic Splitting and Load Balancing
 
-The in-process L7 proxy performs weighted traffic splitting across the `backendRefs` of a rule, for both HTTPRoute and GRPCRoute. Each backend's `weight` is honoured by a weighted-random selection at request time: traffic is distributed in proportion to the weights, and a backend with `weight: 0` receives no traffic (a rule whose backends all have weight 0 serves nothing).
-
-This is the v3 behaviour. In the v1/v2 native-tunnel path, Cloudflare Tunnel ingress rules accepted only a single service URL per rule, so the controller forwarded 100% of traffic to the highest-weight backend and weighted splitting required an external load balancer. v3 renders the proxy unconditionally, so splitting works without one.
+The in-process L7 proxy performs weighted traffic splitting across the `backendRefs` of a rule, for both HTTPRoute and GRPCRoute. Each backend's `weight` is honoured by a weighted-random selection at request time: traffic is distributed in proportion to the weights, and a backend with `weight: 0` receives no traffic (a rule whose backends all have weight 0 serves nothing). Weighted splitting works directly in the proxy and does not require an external load balancer.
 
 For plain round-robin between pods of one Deployment, a standard Kubernetes `Service` is still the simplest option — point the route at the Service and let kube-proxy balance:
 


### PR DESCRIPTION
Fixes #355

Here for the contribution — aiming for a clean, quick merge.

## Summary
- remove the pre-v3 historical section from `docs/gateway-api/limitations.md`
- describe weighted traffic splitting only in terms of the current proxy-backed v3 behavior
- update the architecture overview and diagram to show the proxy pod with embedded cloudflared transport
- drop the README aside that referenced old v1/v2 path-matching quirks

## Validation
- `mkdocs build --strict`
- `npx --yes markdownlint-cli2 '**/*.md'`
