### PR TITLE
feat(proxy): merge ExternalBackend spec.path query string into dialed request

### DIFF
--- a/api/v1alpha1/externalbackend_types.go
+++ b/api/v1alpha1/externalbackend_types.go
@@ -57,7 +57,10 @@ type ExternalBackendSpec struct {
 	Port int32 `json:"port"`
 
 	// Path is an optional base path prepended to the request path when the
-	// proxy dials the backend. Must begin with "/".
+	// proxy dials the backend. Must begin with "/". It may include a query
+	// string (e.g. "/v1?token=abc"); those query parameters are merged into
+	// every dialed request, with the request's own parameters taking
+	// precedence on a key conflict.
 	// +optional
 	// +kubebuilder:validation:Pattern=`^/.*$`
 	Path string `json:"path,omitempty"`

--- a/api/v1alpha1/externalbackend_types_test.go
+++ b/api/v1alpha1/externalbackend_types_test.go
@@ -31,6 +31,11 @@ func TestExternalBackendSpec_URL(t *testing.T) {
 			want: "https://api.example.com:8443/v1",
 		},
 		{
+			name: "base path with query preserved",
+			spec: ExternalBackendSpec{Scheme: ExternalBackendSchemeHTTPS, Host: "api.example.com", Port: 8443, Path: "/v1?token=abc"},
+			want: "https://api.example.com:8443/v1?token=abc",
+		},
+		{
 			name: "bracketed IPv6 literal preserved",
 			spec: ExternalBackendSpec{Scheme: ExternalBackendSchemeHTTP, Host: "[2001:db8::1]", Port: 80},
 			want: "http://[2001:db8::1]:80",
@@ -62,6 +67,10 @@ func TestExternalBackendSpec_Validate(t *testing.T) {
 		{
 			name: "valid https with path",
 			spec: ExternalBackendSpec{Scheme: ExternalBackendSchemeHTTPS, Host: "api.example.com", Port: 443, Path: "/base"},
+		},
+		{
+			name: "valid path with query string",
+			spec: ExternalBackendSpec{Scheme: ExternalBackendSchemeHTTPS, Host: "api.example.com", Port: 443, Path: "/base?token=abc"},
 		},
 		{
 			name:    "invalid scheme",

--- a/charts/cloudflare-tunnel-gateway-controller/crds/cf.k8s.lex.la_externalbackends.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/crds/cf.k8s.lex.la_externalbackends.yaml
@@ -79,7 +79,10 @@ spec:
               path:
                 description: |-
                   Path is an optional base path prepended to the request path when the
-                  proxy dials the backend. Must begin with "/".
+                  proxy dials the backend. Must begin with "/". It may include a query
+                  string (e.g. "/v1?token=abc"); those query parameters are merged into
+                  every dialed request, with the request's own parameters taking
+                  precedence on a key conflict.
                 pattern: ^/.*$
                 type: string
               port:

--- a/docs/gateway-api/external-backend.md
+++ b/docs/gateway-api/external-backend.md
@@ -16,7 +16,7 @@ Use an `ExternalBackend` when the upstream is not a cluster `Service` and you ne
 | `scheme` | Yes | `http` or `https` (enum). |
 | `host` | Yes | Hostname or IP (no scheme, port, or path). Bracket IPv6 literals, e.g. `[2001:db8::1]`. |
 | `port` | Yes | TCP port, `1`–`65535`. |
-| `path` | No | Optional base path prepended when dialing; must begin with `/`. |
+| `path` | No | Optional base path prepended when dialing; must begin with `/`. May include a query string (e.g. `/v1?token=abc`) — see [Base path and query](#base-path-and-query). |
 
 ```yaml
 apiVersion: cf.k8s.lex.la/v1alpha1
@@ -30,6 +30,24 @@ spec:
   port: 8443
   path: /v1
 ```
+
+## Base path and query
+
+`spec.path` is prepended to the incoming request path when the proxy dials the backend, joined with exactly one slash. A request for `/users` against the example above is dialed as `/v1/users`.
+
+The base path may also carry a query string. Those parameters are merged into every dialed request, which is useful for pinning a fixed parameter (for example an API version or a static token) on all traffic to the backend:
+
+```yaml
+spec:
+  scheme: https
+  host: api.example.com
+  port: 8443
+  path: /v1?token=abc
+```
+
+A request for `/users?page=2` is dialed as `/v1/users?page=2&token=abc`.
+
+The request's own parameters take precedence: if a key appears both in the request and in the base query, the request value is kept and the base value is dropped. Base parameters whose keys are absent from the request are appended after the request's parameters, which are preserved verbatim.
 
 ## Referencing it from a route
 

--- a/internal/proxy/external_backend_path_test.go
+++ b/internal/proxy/external_backend_path_test.go
@@ -27,6 +27,20 @@ func pathRecordingBackend(t *testing.T, gotPath *atomic.Pointer[string]) *httpte
 	return srv
 }
 
+// queryRecordingBackend returns an httptest server that records the raw query
+// string of the last request it received and replies 200.
+func queryRecordingBackend(t *testing.T, gotQuery *atomic.Pointer[string]) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		q := r.URL.RawQuery
+		gotQuery.Store(&q)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
 func handlerForBackendURL(t *testing.T, backendURL string) *proxy.Handler {
 	t.Helper()
 
@@ -88,6 +102,99 @@ func TestHandler_ExternalBackendBasePath_OverTunnelWriter(t *testing.T) {
 	require.Eventually(t, func() bool { return gotPath.Load() != nil }, 2*time.Second, 10*time.Millisecond)
 	assert.Equal(t, "/v1/users", *gotPath.Load(),
 		"the backend base path must be prepended on the tunnel write path too")
+	assert.Equal(t, http.StatusOK, fake.Status())
+}
+
+// TestHandler_ExternalBackendBaseQuery_Merged proves a backend URL carrying a
+// query string (an ExternalBackend's spec.path of the form "/v1?x=1", resolved
+// into the backend URL) merges that query into the dialed request. Request
+// parameters take precedence: a key present in the request keeps its request
+// value, and only base keys absent from the request are appended. Without the
+// Director honoring backendURL.RawQuery the base query is silently dropped.
+func TestHandler_ExternalBackendBaseQuery_Merged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		backendPath string // appended to backend.URL (base path + optional query)
+		reqTarget   string // request path + optional query
+		wantQuery   string // raw query the backend must receive
+	}{
+		{
+			name:        "base query, no request query",
+			backendPath: "/v1?token=abc",
+			reqTarget:   "/users",
+			wantQuery:   "token=abc",
+		},
+		{
+			name:        "base query merged with disjoint request query",
+			backendPath: "/v1?token=abc",
+			reqTarget:   "/users?page=2",
+			wantQuery:   "page=2&token=abc",
+		},
+		{
+			name:        "request wins on conflicting key",
+			backendPath: "/v1?token=base",
+			reqTarget:   "/users?token=req",
+			wantQuery:   "token=req",
+		},
+		{
+			name:        "multiple base params sorted on append",
+			backendPath: "/v1?b=2&a=1",
+			reqTarget:   "/users",
+			wantQuery:   "a=1&b=2",
+		},
+		{
+			name:        "root base path carries query only",
+			backendPath: "/?token=abc",
+			reqTarget:   "/users",
+			wantQuery:   "token=abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotQuery atomic.Pointer[string]
+
+			backend := queryRecordingBackend(t, &gotQuery)
+			handler := handlerForBackendURL(t, backend.URL+tt.backendPath)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com"+tt.reqTarget, nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			require.Eventually(t, func() bool { return gotQuery.Load() != nil }, 2*time.Second, 10*time.Millisecond)
+			assert.Equal(t, tt.wantQuery, *gotQuery.Load(),
+				"the backend base path query must be merged into the request query (request wins)")
+		})
+	}
+}
+
+// TestHandler_ExternalBackendBaseQuery_OverTunnelWriter exercises the query
+// merge through the cloudflared HTTP/2 response writer contract (per the
+// project's tunnel-transport testing rule), proving the Director merge holds on
+// the production write path, not only with httptest's recorder.
+func TestHandler_ExternalBackendBaseQuery_OverTunnelWriter(t *testing.T) {
+	t.Parallel()
+
+	var gotQuery atomic.Pointer[string]
+
+	backend := queryRecordingBackend(t, &gotQuery)
+	handler := handlerForBackendURL(t, backend.URL+"/v1?token=abc")
+
+	fake := newFakeCloudflaredRespWriter()
+	t.Cleanup(func() { _ = fake.serverSide.Close(); _ = fake.clientSide.Close() })
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/users?page=2", nil)
+
+	handler.ServeHTTP(fake, req)
+
+	require.Eventually(t, func() bool { return gotQuery.Load() != nil }, 2*time.Second, 10*time.Millisecond)
+	assert.Equal(t, "page=2&token=abc", *gotQuery.Load(),
+		"the backend base path query must be merged on the tunnel write path too")
 	assert.Equal(t, http.StatusOK, fake.Status())
 }
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -597,7 +597,7 @@ func (h *Handler) createReverseProxy(backendURL *url.URL, protocol BackendProtoc
 		Director: func(req *http.Request) {
 			req.URL.Scheme = backendURL.Scheme
 			req.URL.Host = backendURL.Host
-			applyBackendBasePath(req.URL, backendURL.Path)
+			applyBackendBasePath(req.URL, backendURL.Path, backendURL.RawQuery)
 
 			// Preserve the original Host header per Gateway API spec.
 			// Only override it if a URLRewrite filter explicitly set a new host.
@@ -634,20 +634,59 @@ func (h *Handler) createReverseProxy(backendURL *url.URL, protocol BackendProtoc
 }
 
 // applyBackendBasePath prepends a backend base path (e.g. an ExternalBackend's
-// spec.path) to u's path, joining with exactly one slash — the single-host join
-// httputil.NewSingleHostReverseProxy performs that the hand-written Director
-// (and the WebSocket upgrade builder) otherwise skip. A base of "" or "/" — the
-// form every Service / ServiceImport backend URL takes — is a no-op, so only an
-// ExternalBackend with a declared base path is affected.
-func applyBackendBasePath(target *url.URL, base string) {
-	if base == "" || base == "/" {
-		return
+// spec.path) to target's path, joining with exactly one slash — the single-host
+// join httputil.NewSingleHostReverseProxy performs that the hand-written
+// Director (and the WebSocket upgrade builder) otherwise skip. It also merges
+// the base path's query parameters (the "x=1" in a spec.path of "/v1?x=1") into
+// target's query via mergeBackendBaseQuery. A base of "" or "/" with no query —
+// the form every Service / ServiceImport backend URL takes — is a no-op, so only
+// an ExternalBackend with a declared base path or query is affected.
+func applyBackendBasePath(target *url.URL, base, baseRawQuery string) {
+	if base != "" && base != "/" {
+		target.Path = joinBackendBasePath(base, target.Path)
+		if target.RawPath != "" {
+			target.RawPath = joinBackendBasePath(base, target.RawPath)
+		}
 	}
 
-	target.Path = joinBackendBasePath(base, target.Path)
-	if target.RawPath != "" {
-		target.RawPath = joinBackendBasePath(base, target.RawPath)
+	if baseRawQuery != "" {
+		target.RawQuery = mergeBackendBaseQuery(baseRawQuery, target.RawQuery)
 	}
+}
+
+// mergeBackendBaseQuery merges a backend base path's query parameters into the
+// request's query. Request parameters take precedence: a key present in the
+// request keeps its request value(s), and only base keys absent from the request
+// are appended. The request's RawQuery is preserved verbatim (order and
+// encoding) so an order-sensitive backend sees the client's parameters
+// unchanged, with the base defaults appended after, sorted among themselves.
+func mergeBackendBaseQuery(baseRawQuery, reqRawQuery string) string {
+	// A malformed base query yields whatever ParseQuery could decode; an empty
+	// result simply leaves the request query untouched.
+	baseValues, _ := url.ParseQuery(baseRawQuery)
+	if len(baseValues) == 0 {
+		return reqRawQuery
+	}
+
+	reqValues, _ := url.ParseQuery(reqRawQuery)
+
+	extra := url.Values{}
+
+	for key, vals := range baseValues {
+		if _, present := reqValues[key]; !present {
+			extra[key] = vals
+		}
+	}
+
+	if len(extra) == 0 {
+		return reqRawQuery
+	}
+
+	if reqRawQuery == "" {
+		return extra.Encode()
+	}
+
+	return reqRawQuery + "&" + extra.Encode()
 }
 
 // joinBackendBasePath joins a base path and a request path with exactly one

--- a/internal/proxy/handler_websocket.go
+++ b/internal/proxy/handler_websocket.go
@@ -209,9 +209,10 @@ func buildBackendUpgradeRequest(req *http.Request, backendURL *url.URL) *http.Re
 		Path:     req.URL.Path,
 		RawQuery: req.URL.RawQuery,
 	}
-	// Prepend the backend's base path (e.g. an ExternalBackend's spec.path),
-	// matching the non-WebSocket Director; a no-op for Service/ServiceImport URLs.
-	applyBackendBasePath(outReq.URL, backendURL.Path)
+	// Prepend the backend's base path and merge its query (e.g. an
+	// ExternalBackend's spec.path "/v1?x=1"), matching the non-WebSocket
+	// Director; a no-op for Service/ServiceImport URLs.
+	applyBackendBasePath(outReq.URL, backendURL.Path, backendURL.RawQuery)
 	outReq.RequestURI = ""
 	outReq.Host = backendURL.Host
 

--- a/internal/proxy/handler_websocket_basepath_internal_test.go
+++ b/internal/proxy/handler_websocket_basepath_internal_test.go
@@ -58,3 +58,58 @@ func TestBuildBackendUpgradeRequest_BasePath(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildBackendUpgradeRequest_BaseQuery proves a WebSocket upgrade to a
+// backend whose URL carries a query (an ExternalBackend's spec.path of the form
+// "/v1?x=1") merges that query into the upgrade request, matching the
+// non-WebSocket Director. Request parameters take precedence over base ones.
+func TestBuildBackendUpgradeRequest_BaseQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		backendURL string
+		reqTarget  string
+		wantQuery  string
+	}{
+		{
+			name:       "base query, no request query",
+			backendURL: "https://api.example.com:8443/v1?token=abc",
+			reqTarget:  "/ws",
+			wantQuery:  "token=abc",
+		},
+		{
+			name:       "base query merged with disjoint request query",
+			backendURL: "https://api.example.com:8443/v1?token=abc",
+			reqTarget:  "/ws?room=42",
+			wantQuery:  "room=42&token=abc",
+		},
+		{
+			name:       "request wins on conflicting key",
+			backendURL: "https://api.example.com:8443/v1?token=base",
+			reqTarget:  "/ws?token=req",
+			wantQuery:  "token=req",
+		},
+		{
+			name:       "no base query unchanged",
+			backendURL: "http://svc.default.svc.cluster.local:80/v1",
+			reqTarget:  "/ws?room=42",
+			wantQuery:  "room=42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			backendURL, err := url.Parse(tt.backendURL)
+			require.NoError(t, err)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com"+tt.reqTarget, nil)
+
+			out := buildBackendUpgradeRequest(req, backendURL)
+
+			assert.Equal(t, tt.wantQuery, out.URL.RawQuery)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`ExternalBackend.spec.path` may now carry a query string (e.g. `/v1?token=abc`), and those parameters are merged into every request the proxy dials to the backend. Previously only the path component of the base URL was prepended to the request — the query was silently dropped, so an operator who set a base-path query saw it disappear with no error.

## Changes

- Merge a backend base path's query parameters into the dialed request in both the HTTP Director and the WebSocket upgrade builder, keeping the two request-construction paths in sync.
- Request parameters take precedence: a key present in the request keeps its request value(s); only base keys absent from the request are appended, after the request's own (verbatim) parameters.
- Document the behaviour on the `spec.path` API field, in the regenerated CRD, and in the ExternalBackend guide (with a worked example and the precedence rule).

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [ ] Manual testing completed (if applicable)

## Documentation

- [ ] README updated (if needed)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

The merge is covered on the production tunnel write path (`fakeCloudflaredRespWriter`), not only `httptest`, per the proxy testing rule, and at the API layer (`URL()` round-trip + `Validate()` acceptance of a query-bearing path). This is an additive bug fix with no breaking change — nobody relies on the query being silently dropped. README needs no change: the user-facing detail lives in the ExternalBackend guide, which is updated, and no workflow or standards changed, so CLAUDE.md is untouched. Gateway API conformance and the custom e2e suite (the mandatory pre-merge runtime gates) run against a kind cluster before this leaves draft.

Closes #397
