### PR TITLE
fix(testing): require tunnel hostname for conformance/e2e, thread it through conformance-setup.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Local credentials for hack/conformance-setup.sh (kind conformance + e2e).
+# Copy this file to .env and fill in the values. .env is gitignored — never
+# commit real tokens or hostnames. Values shown are placeholders.
+
+# Cloudflare API token. Needs account "Cloudflare Tunnel: Write" +
+# "Account Settings: Read", and (for DNS-managed test hostnames) zone
+# "DNS: Write" + "Zone: Read".
+CF_API_TOKEN=
+
+# Cloudflare account ID that owns the test tunnel.
+CF_ACCOUNT_ID=
+
+# UUID of the Cloudflare Tunnel the in-process test proxy connects to.
+V2_TUNNEL_ID=
+
+# Connector token for the tunnel above (GET cfd_tunnel/{id}/token).
+V2_TUNNEL_TOKEN=
+
+# Edge hostname whose DNS routes to the tunnel above. The conformance and e2e
+# suites send TLS SNI + Host to this name. There is no default — it must match
+# the deployed tunnel. e.g. your-tunnel-hostname.example.com
+V2_TUNNEL_HOSTNAME=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,11 +569,11 @@ Official Gateway API conformance suite (`sigs.k8s.io/gateway-api/conformance` v1
 # to also run the suite. ttl.sh artifacts expire 24h after the PR's CI ran.
 ./hack/conformance-setup.sh --use-ci-images <PR-number>
 
-# Run all conformance tests on existing cluster
-go test -v -tags conformance -count=1 -timeout=60m -parallel 10 ./test/conformance/...
+# Run all conformance tests on existing cluster (CONFORMANCE_TUNNEL_HOSTNAME is required)
+CONFORMANCE_TUNNEL_HOSTNAME=<your-tunnel-hostname> go test -v -tags conformance -count=1 -timeout=60m -parallel 10 ./test/conformance/...
 
 # Run specific failing test
-go test -v -tags conformance -count=1 -timeout=10m ./test/conformance/... -run "HTTPRouteMatchingAcrossRoutes"
+CONFORMANCE_TUNNEL_HOSTNAME=<your-tunnel-hostname> go test -v -tags conformance -count=1 -timeout=10m ./test/conformance/... -run "HTTPRouteMatchingAcrossRoutes"
 
 # Rebuild and redeploy images without recreating cluster
 docker build --tag controller:dev --file Containerfile .
@@ -593,6 +593,6 @@ kubectl --context kind-<cluster-name> rollout restart deployment --namespace clo
 
 ### Environment Variables
 
-- `CONFORMANCE_TUNNEL_HOSTNAME` — Edge hostname (default: `v2-test.lex.la`)
+- `CONFORMANCE_TUNNEL_HOSTNAME` — Edge hostname routing to the test tunnel (required; no default — see `.env.example`)
 - `CONFORMANCE_GATEWAY_CLASS` — GatewayClass name (default: `cloudflare-tunnel`)
 - `CONFORMANCE_REPORT_OUTPUT` — Path for YAML conformance report

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -282,14 +282,16 @@ Conformance tests validate that the controller implements the Gateway API specif
 
 ### Running E2E Tests
 
-E2E tests run against a live kind cluster with Cloudflare Tunnel and L7 proxy deployed.
+E2E tests run against a live kind cluster with Cloudflare Tunnel and L7 proxy deployed. `E2E_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` (`V2_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.
 
 ```bash
 # Run all E2E tests
-go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/...
+E2E_TUNNEL_HOSTNAME=<your-tunnel-hostname> \
+  go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/...
 
 # Run a single test
-go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/... \
+E2E_TUNNEL_HOSTNAME=<your-tunnel-hostname> \
+  go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/... \
   -run TestHTTPRouteSimpleSameNamespace
 ```
 
@@ -297,7 +299,7 @@ go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/... \
 
 | Variable | Fallback | Default | Description |
 | --- | --- | --- | --- |
-| `E2E_TUNNEL_HOSTNAME` | `CONFORMANCE_TUNNEL_HOSTNAME` | `v2-test.lex.la` | Tunnel hostname for requests |
+| `E2E_TUNNEL_HOSTNAME` | `CONFORMANCE_TUNNEL_HOSTNAME` | none (required) | Edge hostname routing to the test tunnel; see `.env.example` |
 | `E2E_KUBE_CONTEXT` | `CONFORMANCE_KUBE_CONTEXT` | `kind-v2-test` | kubectl context |
 | `E2E_NAMESPACE` | `CONFORMANCE_NAMESPACE` | `cloudflare-tunnel-system` | Controller namespace |
 | `E2E_TEST_NAMESPACE` | `CONFORMANCE_TEST_NAMESPACE` | `e2e-test` | Test resources namespace |
@@ -316,17 +318,22 @@ Tests cover both Cloudflare Tunnel and L7 proxy features:
 
 The project integrates the official `sigs.k8s.io/gateway-api/conformance` suite with a custom `TunnelRoundTripper` that routes requests through Cloudflare edge.
 
+`CONFORMANCE_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` (`V2_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.
+
 ```bash
 # Run conformance tests (requires deployed controller + tunnel)
-go test -v -tags conformance -count=1 -timeout=30m ./test/conformance/...
+CONFORMANCE_TUNNEL_HOSTNAME=<your-tunnel-hostname> \
+  go test -v -tags conformance -count=1 -timeout=30m ./test/conformance/...
 
 # Generate conformance report
+CONFORMANCE_TUNNEL_HOSTNAME=<your-tunnel-hostname> \
 CONFORMANCE_REPORT_OUTPUT=./conformance-report.yaml \
   go test -v -tags conformance -count=1 -timeout=30m ./test/conformance/...
 ```
 
 | Variable | Default | Description |
 | --- | --- | --- |
+| `CONFORMANCE_TUNNEL_HOSTNAME` | none (required) | Edge hostname routing to the test tunnel; see `.env.example` |
 | `CONFORMANCE_GATEWAY_CLASS` | `cloudflare-tunnel` | GatewayClass name |
 | `CONFORMANCE_REPORT_OUTPUT` | (none) | Path for YAML conformance report |
 | `CONTROLLER_VERSION` | `dev` | Version for report metadata |

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -21,7 +21,8 @@
 #                                                  # chart+images (no local build)
 #
 # Prerequisites:
-#   - .env file in repo root with: CF_API_TOKEN, CF_ACCOUNT_ID, V2_TUNNEL_ID, V2_TUNNEL_TOKEN
+#   - .env file in repo root with: CF_API_TOKEN, CF_ACCOUNT_ID, V2_TUNNEL_ID,
+#     V2_TUNNEL_TOKEN, V2_TUNNEL_HOSTNAME (the edge hostname routing to the tunnel)
 #   - colima, docker, kind, helm, kubectl, go installed
 
 set -euo pipefail
@@ -89,9 +90,9 @@ fi
 # shellcheck source=/dev/null
 source "${ENV_FILE}"
 
-for var in CF_API_TOKEN CF_ACCOUNT_ID V2_TUNNEL_ID V2_TUNNEL_TOKEN; do
+for var in CF_API_TOKEN CF_ACCOUNT_ID V2_TUNNEL_ID V2_TUNNEL_TOKEN V2_TUNNEL_HOSTNAME; do
   if [[ -z "${!var:-}" ]]; then
-    die "Required variable ${var} is not set in .env"
+    die "Required variable ${var} is not set in .env (see .env.example)"
   fi
 done
 
@@ -265,16 +266,17 @@ echo ""
 
 # --- Step 11: Run tests (optional) ---
 if [[ "${RUN_TESTS}" == "true" ]]; then
-  info "Running conformance tests..."
+  info "Running conformance tests against ${V2_TUNNEL_HOSTNAME}..."
   CONFORMANCE_KUBE_CONTEXT="${KUBE_CONTEXT}" \
+  CONFORMANCE_TUNNEL_HOSTNAME="${V2_TUNNEL_HOSTNAME}" \
     go test -v -race -tags conformance -count=1 -timeout=60m -parallel 10 ./test/conformance/...
 else
   echo ""
   info "Setup complete! To run conformance tests:"
-  echo "  CONFORMANCE_KUBE_CONTEXT=${KUBE_CONTEXT} go test -v -race -tags conformance -count=1 -timeout=30m ./test/conformance/..."
+  echo "  CONFORMANCE_KUBE_CONTEXT=${KUBE_CONTEXT} CONFORMANCE_TUNNEL_HOSTNAME=${V2_TUNNEL_HOSTNAME} go test -v -race -tags conformance -count=1 -timeout=30m ./test/conformance/..."
   echo ""
   info "To run E2E tests:"
-  echo "  CONFORMANCE_KUBE_CONTEXT=${KUBE_CONTEXT} go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/..."
+  echo "  CONFORMANCE_KUBE_CONTEXT=${KUBE_CONTEXT} E2E_TUNNEL_HOSTNAME=${V2_TUNNEL_HOSTNAME} go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/..."
   echo ""
   info "To tear down:"
   echo "  kind delete cluster --name ${CLUSTER_NAME}"

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/test/internal/tunnelhost"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/gateway-api/conformance"
@@ -19,6 +20,15 @@ import (
 )
 
 func TestGatewayAPIConformance(t *testing.T) {
+	// Fail fast when the edge hostname is unset: without it every request would
+	// route at an empty host and the suite would only fail deep inside its poll
+	// timeouts. There is no default — the deployed tunnel's hostname must be
+	// supplied (hack/conformance-setup.sh threads it from .env).
+	_, err := tunnelhost.Resolve(envTunnelHostname)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	opts := conformance.DefaultOptions(t)
 
 	opts.GatewayClassName = envOrDefault("CONFORMANCE_GATEWAY_CLASS", "cloudflare-tunnel")

--- a/test/conformance/roundtripper.go
+++ b/test/conformance/roundtripper.go
@@ -25,8 +25,8 @@ import (
 //
 // The *.cfargotunnel.com CNAME used as Gateway address only has AAAA records
 // pointing to Cloudflare ULA (fd10::/8) which are not publicly routable.
-// Instead, we connect to the real tunnel hostname (e.g. v2-test.lex.la) which
-// has proper DNS pointing to Cloudflare edge. TLS SNI uses the tunnel hostname
+// Instead, we connect to the real tunnel hostname (from CONFORMANCE_TUNNEL_HOSTNAME)
+// which has proper DNS pointing to Cloudflare edge. TLS SNI uses the tunnel hostname
 // so Cloudflare routes traffic to our tunnel. The HTTP Host header carries the
 // test-specific hostname for our proxy to route on.
 type TunnelRoundTripper struct {
@@ -41,13 +41,17 @@ type TunnelRoundTripper struct {
 // Shared by TunnelRoundTripper (HTTP) and TunnelGRPCClient (gRPC).
 const originalHostHeader = "X-Original-Host"
 
-// tunnelHostname returns the hostname used to reach the tunnel via Cloudflare edge.
-func tunnelHostname() string {
-	if h := os.Getenv("CONFORMANCE_TUNNEL_HOSTNAME"); h != "" {
-		return h
-	}
+// envTunnelHostname names the env var that carries the edge hostname the
+// conformance suite routes through (TLS SNI + the wire Host; the test's intended
+// host rides X-Original-Host). TestGatewayAPIConformance enforces it is set via
+// tunnelhost.Resolve before any request runs.
+const envTunnelHostname = "CONFORMANCE_TUNNEL_HOSTNAME"
 
-	return "v2-test.lex.la"
+// tunnelHostname returns the configured edge hostname. The conformance entry
+// point validates it is set (tunnelhost.Resolve) before any request runs, so the
+// roundtripper and gRPC client read it directly here.
+func tunnelHostname() string {
+	return os.Getenv(envTunnelHostname)
 }
 
 // CaptureRoundTrip implements roundtripper.RoundTripper.

--- a/test/e2e/e2e_backend_protocol_websocket_test.go
+++ b/test/e2e/e2e_backend_protocol_websocket_test.go
@@ -49,7 +49,7 @@ import (
 // BEFORE writing the 101 status, which the cloudflared HTTP/2 response
 // writer rejects -- the failure mode the production deployment hits.
 func TestHTTPRouteBackendProtocolWebSocket(t *testing.T) {
-	cfg := loadTestConfig()
+	cfg := loadTestConfig(t)
 	k8sClient := newK8sClient(t, cfg.KubeContext)
 
 	setupTestNamespace(t, k8sClient, cfg)
@@ -185,7 +185,7 @@ var errProxySyncNotConverged = errors.New("proxy sync not converged yet")
 // backend's original headers (no X-CF-Tunnel-E2E-Added) and the
 // assertion fails loudly.
 func TestHTTPRouteBackendProtocolWebSocket_AppliesResponseFilters(t *testing.T) {
-	cfg := loadTestConfig()
+	cfg := loadTestConfig(t)
 	k8sClient := newK8sClient(t, cfg.KubeContext)
 
 	setupTestNamespace(t, k8sClient, cfg)

--- a/test/e2e/e2e_grpc_test.go
+++ b/test/e2e/e2e_grpc_test.go
@@ -40,7 +40,7 @@ const (
 //
 //nolint:funlen // one end-to-end scenario with deploy + wait + gRPC dial steps
 func TestGRPCRouteEndToEnd(t *testing.T) {
-	cfg := loadTestConfig()
+	cfg := loadTestConfig(t)
 
 	// gRPC only works over the http2 tunnel transport; skip fast (with an
 	// actionable message) rather than poll for ~90s against a transport that

--- a/test/e2e/e2e_listenerset_test.go
+++ b/test/e2e/e2e_listenerset_test.go
@@ -33,7 +33,7 @@ import (
 //
 //nolint:funlen // single end-to-end scenario with several wait/assert steps
 func TestListenerSetEndToEnd(t *testing.T) {
-	cfg := loadTestConfig()
+	cfg := loadTestConfig(t)
 	httpClient := tunnelClient()
 	k8sClient := newK8sClient(t, cfg.KubeContext)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/test/internal/tunnelhost"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -50,9 +51,16 @@ type testConfig struct {
 	TunnelProtocol string
 }
 
-func loadTestConfig() testConfig {
+func loadTestConfig(tb testing.TB) testConfig {
+	tb.Helper()
+
+	hostname, err := tunnelhost.Resolve("E2E_TUNNEL_HOSTNAME", "CONFORMANCE_TUNNEL_HOSTNAME")
+	if err != nil {
+		tb.Fatal(err)
+	}
+
 	return testConfig{
-		TunnelHostname: envWithFallback("E2E_TUNNEL_HOSTNAME", "CONFORMANCE_TUNNEL_HOSTNAME", "v2-test.lex.la"),
+		TunnelHostname: hostname,
 		KubeContext:    envWithFallback("E2E_KUBE_CONTEXT", "CONFORMANCE_KUBE_CONTEXT", "kind-v2-test"),
 		Namespace:      envWithFallback("E2E_NAMESPACE", "CONFORMANCE_NAMESPACE", "cloudflare-tunnel-system"),
 		TestNamespace:  envWithFallback("E2E_TEST_NAMESPACE", "CONFORMANCE_TEST_NAMESPACE", "e2e-test"),
@@ -245,7 +253,7 @@ func wipeAllRoutesInNamespace(t *testing.T, k8sClient client.Client, cfg testCon
 //
 // Run with: go test -v -tags e2e -timeout 10m ./test/e2e/
 func TestHTTPRouteConformance(t *testing.T) {
-	cfg := loadTestConfig()
+	cfg := loadTestConfig(t)
 	httpClient := tunnelClient()
 	k8sClient := newK8sClient(t, cfg.KubeContext)
 

--- a/test/internal/tunnelhost/tunnelhost.go
+++ b/test/internal/tunnelhost/tunnelhost.go
@@ -1,0 +1,40 @@
+// Package tunnelhost resolves the Cloudflare edge hostname the conformance and
+// e2e suites route requests through. Both suites need the same fail-fast
+// contract — there is deliberately no built-in default, because a hardcoded
+// test hostname silently routed the suites at a stale tunnel — and differ only
+// in which env keys they accept. One shared resolver keeps that contract in a
+// single place instead of two copies that drift.
+package tunnelhost
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// errUnset is the base error returned when none of the candidate env keys is
+// set. Resolve wraps it with the specific keys it tried so the message names
+// what to export.
+var errUnset = errors.New(
+	"tunnel hostname not set; see .env.example (hack/conformance-setup.sh sources it from .env via V2_TUNNEL_HOSTNAME)")
+
+// Resolve returns the first non-empty value among the given env keys, checked
+// in order. It errors when none is set so callers can fail fast with a clear
+// message instead of routing every request at an empty host. There is no
+// default by design.
+func Resolve(keys ...string) (string, error) {
+	return resolveFrom(os.Getenv, keys...)
+}
+
+// resolveFrom is Resolve with an injected getenv so the resolution logic is
+// unit-testable without mutating process env.
+func resolveFrom(getenv func(string) string, keys ...string) (string, error) {
+	for _, key := range keys {
+		if value := getenv(key); value != "" {
+			return value, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: set one of %s", errUnset, strings.Join(keys, ", "))
+}

--- a/test/internal/tunnelhost/tunnelhost_test.go
+++ b/test/internal/tunnelhost/tunnelhost_test.go
@@ -1,0 +1,86 @@
+package tunnelhost
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveFrom pins the shared resolver's precedence and fail-fast contract:
+// first non-empty key wins, later keys are fallbacks, and an all-empty (or
+// no-key) lookup errors. There is deliberately no default — a hardcoded test
+// hostname silently routed the suites at a stale tunnel. Driven by a fake
+// getenv so the subtests stay parallel without mutating process env.
+func TestResolveFrom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		keys    []string
+		env     map[string]string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "no keys errors",
+			keys:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "single key unset errors",
+			keys:    []string{"CONFORMANCE_TUNNEL_HOSTNAME"},
+			env:     map[string]string{},
+			wantErr: true,
+		},
+		{
+			name: "single key set returns value",
+			keys: []string{"CONFORMANCE_TUNNEL_HOSTNAME"},
+			env:  map[string]string{"CONFORMANCE_TUNNEL_HOSTNAME": "edge.example.com"},
+			want: "edge.example.com",
+		},
+		{
+			name: "first key wins over later",
+			keys: []string{"E2E_TUNNEL_HOSTNAME", "CONFORMANCE_TUNNEL_HOSTNAME"},
+			env: map[string]string{
+				"E2E_TUNNEL_HOSTNAME":         "primary.example.com",
+				"CONFORMANCE_TUNNEL_HOSTNAME": "fallback.example.com",
+			},
+			want: "primary.example.com",
+		},
+		{
+			name: "later key used when first empty",
+			keys: []string{"E2E_TUNNEL_HOSTNAME", "CONFORMANCE_TUNNEL_HOSTNAME"},
+			env:  map[string]string{"CONFORMANCE_TUNNEL_HOSTNAME": "fallback.example.com"},
+			want: "fallback.example.com",
+		},
+		{
+			name: "all keys empty errors",
+			keys: []string{"E2E_TUNNEL_HOSTNAME", "CONFORMANCE_TUNNEL_HOSTNAME"},
+			env: map[string]string{
+				"E2E_TUNNEL_HOSTNAME":         "",
+				"CONFORMANCE_TUNNEL_HOSTNAME": "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			getenv := func(key string) string { return tt.env[key] }
+
+			got, err := resolveFrom(getenv, tt.keys...)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`hack/conformance-setup.sh --test` ran the conformance suite without exporting the tunnel hostname, so the suite fell back to a hardcoded in-code default and targeted a stale/foreign tunnel regardless of which tunnel was deployed — every edge-routed assertion failed (or hit a defunct host) unless the variable was exported by hand. This makes the tunnel edge hostname a required, fail-fast input across the conformance and e2e harnesses and threads it through the setup script, so `--test` targets the deployed tunnel with no manual export.

## Changes

- Add a shared `test/internal/tunnelhost` resolver: `Resolve(keys...)` returns the first non-empty env var and errors (no default) when none is set — one implementation shared by both suites instead of two copies that drift.
- The conformance and e2e suites now fail fast with an actionable message when the hostname env var is unset, instead of routing every request at an empty host and failing deep inside poll timeouts.
- Remove the hardcoded test-hostname default from the harnesses; the edge hostname must now be supplied.
- `hack/conformance-setup.sh`: require `V2_TUNNEL_HOSTNAME` in `.env` and thread it into the `--test` invocation and the printed manual-run commands.
- Add `.env.example` (referenced by the script's missing-file error but absent until now), documenting every required variable with placeholders only.
- Update `CLAUDE.md` and `docs/development/testing.md`: the hostname is required (no default) and the example commands set it.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [ ] Manual testing completed (if applicable)

## Documentation

- [ ] README updated (if needed)
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

The new `test/internal/tunnelhost` package carries no build tag, so unlike the tagged `test/e2e` / `test/conformance` packages it is covered by CI's `golangci-lint` run.

Behavior change for test runners: a bare `go test -tags conformance|e2e` now requires `CONFORMANCE_TUNNEL_HOSTNAME` / `E2E_TUNNEL_HOSTNAME` (or run via `hack/conformance-setup.sh`, which sources it from `.env`). This is intentional — the old silent default routed runs at a stale tunnel. CI does not run these suites, so the new required var does not affect CI.

Pre-existing golangci-lint findings in the tagged `test/e2e` package are unrelated to this change (they predate it and sit outside this diff) and are tracked separately in #402.

Full kind conformance + custom e2e against a live tunnel is the remaining maintainer-owned pre-ready gate.

Closes #394
