### PR TITLE
cleanup(proxy): drop no-op BackendTLSPolicy resolver on gRPC ExternalBackend path

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -340,6 +340,15 @@ CONFORMANCE_REPORT_OUTPUT=./conformance-report.yaml \
 
 Profiles: `GATEWAY-HTTP`, `GATEWAY-GRPC`.
 
+### Known conformance flakes
+
+A few conformance subtests are statistical by nature and occasionally need the suite's built-in retry budget to pass over the real Cloudflare Tunnel. These are sampling-variance non-regressions, not implementation failures — a retry of the named subtest passes. They are listed here so a failed *individual* attempt in the logs is not mistaken for a regression.
+
+- **`HTTPRouteRequestPercentageMirror`** — the subtest distributes traffic and asserts the observed mirror rate lands in an 85–115% band over a 500-request sample. Over the tunnel the sampled rate occasionally lands just outside (78% and 116% observed on individual attempts) before passing within the suite's retry budget. The tolerance, sample size, and retry count are hardcoded in the upstream suite (`vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-percentage-mirror.go`), so they cannot be widened locally without forking official conformance — the flake is documented rather than tuned. Reported upstream as [kubernetes-sigs/gateway-api#4933](https://github.com/kubernetes-sigs/gateway-api/issues/4933): the relative ±15% band is only ~1.7σ on the 20% subcase, so even a perfectly conforming implementation flakes ~8–9% per distribution-check by binomial sampling alone.
+- **`HTTPRouteRequestMirror`** — the `RequestMirror` filter dispatches a fire-and-forget mirror asynchronously, so the mirrored request occasionally arrives shortly after the test's poll window closes. The subtest passes on retry.
+
+The same sampling-variance reasoning is applied inline for weighted backend selection in the custom e2e suite (`test/e2e/e2e_test.go`), where a deliberately wide proportion bound avoids reintroducing the flake from the opposite tail.
+
 ## Best Practices
 
 1. **Fast tests**: Unit tests should run in milliseconds

--- a/internal/proxy/grpc_converter.go
+++ b/internal/proxy/grpc_converter.go
@@ -332,7 +332,7 @@ func convertGRPCBackendRef(
 	// sentinel); the backendRef port is ignored in favour of spec.port.
 	if IsExternalBackendRef(backend.BackendObjectReference) {
 		return convertGRPCExternalBackendRef(ctx, result.Weight, backend, namespace, svcNamespace, serviceName,
-			clusterDomain, validator, tlsResolver, clientCert, sink)
+			clusterDomain, validator, sink)
 	}
 
 	if !validatePort(port) {
@@ -356,18 +356,20 @@ func convertGRPCBackendRef(
 }
 
 // convertGRPCExternalBackendRef builds a gRPC BackendRef for an ExternalBackend
-// ref. Like the HTTP path it emits a sentinel URL the controller rewrites; the
-// backend is left h2c (gRPC default), and when the resolved ExternalBackend uses
-// the https scheme the controller clears h2c so the TLS transport negotiates
-// HTTP/2 over ALPN instead.
+// ref. Like the HTTP convertExternalBackendRef path it emits a sentinel URL the
+// controller rewrites from the ExternalBackend spec and runs NO BackendTLSPolicy
+// resolver: a BackendTLSPolicy targetRef is Service-shaped and cannot
+// legitimately target an ExternalBackend, so resolving here would only risk
+// cross-wiring a like-named Service's TLS config (same namespace/name/port) onto
+// it. The TLS decision is scheme-driven instead — the backend is left h2c (gRPC
+// default), and when the resolved ExternalBackend uses the https scheme the
+// controller clears h2c so the default transport negotiates HTTP/2 over ALPN.
 func convertGRPCExternalBackendRef(
 	ctx context.Context,
 	weight int32,
 	backend *gatewayv1.GRPCBackendRef,
 	namespace, svcNamespace, serviceName, clusterDomain string,
 	validator BackendRefValidator,
-	tlsResolver BackendTLSResolver,
-	clientCert *ClientCertConfig,
 	sink *diagSink,
 ) (BackendRef, bool) {
 	if !validateCrossNamespace(ctx, svcNamespace, namespace, serviceName, backend.BackendObjectReference, validator) {
@@ -375,13 +377,15 @@ func convertGRPCExternalBackendRef(
 			"cross-namespace reference not permitted by ReferenceGrant")
 	}
 
-	result := BackendRef{Weight: weight, URL: ExternalBackendSentinelURL(svcNamespace, serviceName)}
+	result := BackendRef{
+		Weight:   weight,
+		URL:      ExternalBackendSentinelURL(svcNamespace, serviceName),
+		Protocol: BackendProtocolH2C,
+	}
 
 	if grpcBackendFiltersUnsupported(backend.Filters, svcNamespace, serviceName, sink) {
 		result.UnavailableStatus = http.StatusInternalServerError
 	}
-
-	applyGRPCBackendTransport(ctx, &result, tlsResolver, clientCert, svcNamespace, serviceName, defaultServicePort)
 
 	return result, true
 }

--- a/internal/proxy/grpc_converter_test.go
+++ b/internal/proxy/grpc_converter_test.go
@@ -557,6 +557,88 @@ func TestConvertGRPCRoutes_ExternalBackendSentinel(t *testing.T) {
 		"gRPC ExternalBackend stays h2c until the controller resolves an https scheme")
 }
 
+// TestConvertGRPCRoutes_ExternalBackendSkipsBackendTLSResolver pins #395: the
+// gRPC ExternalBackend path must mirror the HTTP convertExternalBackendRef path
+// and run NO BackendTLSPolicy resolver. A BackendTLSPolicy targetRef is
+// Service-shaped, so resolving an ExternalBackend by namespace/name/port can
+// only ever cross-wire a like-named Service's TLS config onto it. The TLS
+// decision is scheme-driven instead: the backend stays h2c here and the
+// controller flips it to plain HTTP for an https-scheme ExternalBackend so ALPN
+// negotiates HTTP/2 over TLS. A parent-Gateway client cert is likewise not
+// stamped — cert over plaintext is meaningless, same contract as the HTTP path.
+func TestConvertGRPCRoutes_ExternalBackendSkipsBackendTLSResolver(t *testing.T) {
+	t.Parallel()
+
+	svc := "grpc.examples.echo.Echo"
+	group := gatewayv1.Group("cf.k8s.lex.la")
+	kind := gatewayv1.Kind("ExternalBackend")
+	weight := int32(1)
+	routes := []*gatewayv1.GRPCRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "echo", Namespace: "default"},
+			Spec: gatewayv1.GRPCRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName("gw")}},
+				},
+				Rules: []gatewayv1.GRPCRouteRule{
+					{
+						Matches: []gatewayv1.GRPCRouteMatch{
+							{Method: &gatewayv1.GRPCMethodMatch{Type: grpcExact(), Service: &svc}},
+						},
+						BackendRefs: []gatewayv1.GRPCBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Group: &group, Kind: &kind, Name: "ext-grpc",
+									},
+									Weight: &weight,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// A BackendTLSPolicy resolver that, if consulted, would cross-wire TLS onto
+	// the ExternalBackend (modelling a like-named Service collision).
+	resolverCalled := false
+	tlsResolver := func(_ context.Context, _, _ string, _ int32) *proxy.BackendTLSConfig {
+		resolverCalled = true
+
+		return &proxy.BackendTLSConfig{
+			CABundlePEM: "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n",
+			ServerName:  "ext-grpc.default.svc.cluster.local",
+		}
+	}
+
+	certResolver := func(_ context.Context, gw types.NamespacedName) *proxy.ClientCertConfig {
+		if gw.Namespace == "default" && gw.Name == "gw" {
+			return &proxy.ClientCertConfig{
+				CertPEM: []byte("-----BEGIN CERTIFICATE-----\nCLIENT-CERT\n-----END CERTIFICATE-----\n"),
+				KeyPEM:  []byte("-----BEGIN PRIVATE KEY-----\nCLIENT-KEY\n-----END PRIVATE KEY-----\n"),
+			}
+		}
+
+		return nil
+	}
+
+	cfg := proxy.ConvertGRPCRoutes(context.Background(), routes, "cluster.local", nil, tlsResolver, certResolver)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	backend := cfg.Rules[0].Backends[0]
+
+	assert.False(t, resolverCalled,
+		"gRPC ExternalBackend path MUST NOT invoke the BackendTLSPolicy resolver (mirrors the HTTP path)")
+	assert.Nil(t, backend.TLS,
+		"gRPC ExternalBackend must carry no TLS config — no cross-wired policy, no client cert")
+	assert.Equal(t, proxy.BackendProtocolH2C, backend.Protocol,
+		"gRPC ExternalBackend stays h2c until the controller resolves an https scheme")
+	assert.Equal(t, proxy.ExternalBackendSentinelURL("default", "ext-grpc"), backend.URL)
+}
+
 // TestConvertGRPCRoutes_RegexMethod maps a RegularExpression method match to a
 // regex path rule.
 func TestConvertGRPCRoutes_RegexMethod(t *testing.T) {

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -81,6 +81,14 @@ func TestGatewayAPIConformance(t *testing.T) {
 		features.SupportHTTPRouteBackendProtocolH2C,
 		features.SupportHTTPRouteBackendProtocolWebSocket,
 		features.SupportHTTPRouteRequestMultipleMirrors,
+		// SupportHTTPRouteRequestPercentageMirror can flake on sampling variance
+		// over the real tunnel: the subtest asserts the observed mirror rate
+		// lands in an 85-115% band over a 500-request sample, and an individual
+		// attempt occasionally lands just outside (78%/116% observed) before
+		// passing within the suite's retry budget. The tolerance and sample size
+		// are hardcoded upstream, so this is documented as a known statistical
+		// non-regression rather than tuned — see docs/development/testing.md
+		// "Known conformance flakes" and kubernetes-sigs/gateway-api#4933.
 		features.SupportHTTPRouteRequestPercentageMirror,
 		features.SupportBackendTLSPolicy,
 		features.SupportBackendTLSPolicySANValidation,


### PR DESCRIPTION
## Summary

Two small `v3.0.0` backlog items: a gRPC ExternalBackend TLS-path cleanup (#395) and documenting two mirror conformance subtests as known statistical flakes (#398).

## Changes

- **`cleanup(proxy)` (#395):** The gRPC `ExternalBackend` backendRef path no longer runs the `BackendTLSPolicy` resolver. The resolver is keyed on namespace/name/port and matches by name only, so for an ExternalBackend it could cross-wire a like-named Service's TLS config onto it. The path now mirrors the HTTP `convertExternalBackendRef` path: emit the sentinel URL, mark the backend h2c, and let the controller flip h2c → plain HTTP for an https-scheme ExternalBackend so ALPN negotiates HTTP/2 over TLS. Scheme-driven, no resolver.
- **`docs(testing)` (#398):** Record `HTTPRouteRequestPercentageMirror` and the async `RequestMirror` sibling as known statistical non-regressions that pass within the conformance suite's retry budget. The percentage-mirror flake is reported upstream as kubernetes-sigs/gateway-api#4933 — the relative ±15% tolerance is only ~1.7σ on the 20% subcase, so a conforming implementation flakes ~8–9% per distribution-check by binomial sampling alone.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [ ] Manual testing completed (if applicable)

## Documentation

- [ ] README updated (if needed)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

Closes #395

Closes #398

## Additional Notes

The #395 behavior change only manifests under a name collision (an ExternalBackend whose name matches a TLS-policied Service in the same namespace on port 80) — today that wrongly stamps the Service's TLS onto the ExternalBackend; after this change it does not. No production behavior change otherwise. The gRPC ExternalBackend path is not exercised by the conformance suite (its gRPC subtests dial the tunnel CNAME directly and are skipped) nor by the custom e2e suite, so the new `TestConvertGRPCRoutes_ExternalBackendSkipsBackendTLSResolver` unit test is the authoritative coverage; it is red without the fix and green with it.
