### PR TITLE
cleanup(proxy): reject the ExternalBackend sentinel scheme at dial time

### DIFF
--- a/internal/proxy/external_backend.go
+++ b/internal/proxy/external_backend.go
@@ -19,8 +19,11 @@ const (
 	// encodes the ref's namespace/name into this sentinel, which the controller
 	// rewrites to the real scheme://host:port/path before the config is pushed
 	// (see resolveExternalBackends). A sentinel that somehow survives to the
-	// proxy is never dialed because the same step marks an unresolvable backend
-	// 500.
+	// proxy is never dialed: resolveExternalBackends marks an unresolvable
+	// backend 500, and proxyToBackend defensively rejects any backend URL still
+	// carrying this scheme with a 500 before dialing, so the guarantee holds even
+	// if a future ordering regression leaves a sentinel with UnavailableStatus
+	// == 0.
 	externalBackendScheme = "externalbackend"
 )
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -550,6 +550,18 @@ func (h *Handler) proxyToBackend(writer http.ResponseWriter, req *http.Request, 
 		return
 	}
 
+	// A backend URL still carrying the ExternalBackend sentinel scheme means it
+	// escaped resolveExternalBackends with UnavailableStatus == 0 (only reachable
+	// via a future ordering regression in buildProxyConfig). Return a clean 500
+	// here rather than letting the unknown scheme reach a dial and surface an
+	// opaque 502 — this is what makes the "never dialed" guarantee on
+	// externalBackendScheme literally true.
+	if backendURL.Scheme == externalBackendScheme {
+		http.Error(writer, "backend unavailable", http.StatusInternalServerError)
+
+		return
+	}
+
 	// Merge rule-level and backend-specific filters for response processing.
 	// slices.Concat allocates a fresh slice; using append on result.Filters
 	// would alias its backing array if cap > len and races against concurrent

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -752,6 +752,50 @@ func TestHandler_MarkedBackendReturnsStatusWithoutDialing(t *testing.T) {
 	}
 }
 
+// TestHandler_ExternalBackendSentinelSchemeReturns500WithoutDialing pins the
+// defensive guard for an ExternalBackend sentinel URL that reached the proxy
+// unresolved with UnavailableStatus == 0 (only reachable via a future ordering
+// regression in buildProxyConfig, since resolveExternalBackends normally either
+// rewrites the sentinel to a real URL or marks it 500). The handler must return
+// a clean 500 instead of dialing the unknown scheme — a dial would fail the
+// transport's RoundTrip with "unsupported protocol scheme" and surface an
+// opaque 502. Asserting 500-not-502 is the no-dial proof: 502 is exactly what a
+// dial attempt on the sentinel scheme produces.
+func TestHandler_ExternalBackendSentinelSchemeReturns500WithoutDialing(t *testing.T) {
+	t.Parallel()
+
+	router := proxy.NewRouter()
+
+	cfg := &proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches: []proxy.RouteMatch{
+					{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}},
+				},
+				Backends: []proxy.BackendRef{
+					{URL: proxy.ExternalBackendSentinelURL("default", "ext-api"), Weight: 1},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, router.UpdateConfig(cfg))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/test", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code,
+		"a stray ExternalBackend sentinel must return a clean 500")
+	assert.NotEqual(t, http.StatusBadGateway, recorder.Code,
+		"a 502 would mean the sentinel scheme was dialed; the guard must fire before any dial")
+}
+
 // TestHandler_MarkedBackendPreservesValidSiblingFraction pins that marking one
 // backend in a weighted pool does not affect a valid sibling: a request that
 // selects the valid backend still reaches it and gets 200, while the marked

--- a/internal/proxy/handler_tunnelfake_test.go
+++ b/internal/proxy/handler_tunnelfake_test.go
@@ -819,3 +819,44 @@ func TestHandler_AccessLog_TunnelMode_SkipsStatus101OnHijackPath(t *testing.T) {
 	assert.Empty(t, strings.TrimSpace(buf.String()),
 		"WS upgrade through the cloudflared writer must NOT produce an access log line -- duration_ms / bytes_written would mislead")
 }
+
+// TestHandler_ExternalBackendSentinelScheme_TunnelMode_Returns500 mirrors the
+// httptest sentinel-guard test against the production cloudflared HTTP/2 writer
+// (per the project's "validate the tunnel transport, not just httptest"
+// principle). The guard returns the 500 before any hijack, so ServeHTTP runs
+// synchronously; the assertion confirms the status is written cleanly through
+// the cloudflared writer (plain WriteHeader(500), no hijack, no 101→200
+// translation involved).
+func TestHandler_ExternalBackendSentinelScheme_TunnelMode_Returns500(t *testing.T) {
+	t.Parallel()
+
+	router := proxy.NewRouter()
+	require.NoError(t, router.UpdateConfig(&proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{
+			{
+				Hostnames: []string{"app.example.com"},
+				Matches: []proxy.RouteMatch{
+					{Path: &proxy.PathMatch{Type: proxy.PathMatchPathPrefix, Value: "/"}},
+				},
+				Backends: []proxy.BackendRef{
+					{URL: proxy.ExternalBackendSentinelURL("default", "ext-api"), Weight: 1},
+				},
+			},
+		},
+	}))
+
+	handler := proxy.NewHandler(router)
+
+	fake := newFakeCloudflaredRespWriter()
+	t.Cleanup(func() { _ = fake.serverSide.Close(); _ = fake.clientSide.Close() })
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/test", nil)
+
+	handler.ServeHTTP(fake, req)
+
+	assert.Equal(t, http.StatusInternalServerError, fake.Status(),
+		"a stray ExternalBackend sentinel must return a clean 500 through the cloudflared HTTP/2 writer")
+	assert.False(t, fake.Hijacked(),
+		"the sentinel guard must return before any hijack")
+}


### PR DESCRIPTION
# Pull Request

## Summary

The proxy handler dialed any backend URL whose scheme it did not recognise. An ExternalBackend sentinel URL (`externalbackend://<name>?ns=<namespace>`) that reached the proxy unresolved with `UnavailableStatus == 0` would therefore be dialed and surface an opaque 502 instead of a clean 500. The doc comment on the sentinel scheme claims it "is never dialed" — a guarantee the code did not actually enforce. This adds a defensive guard so the guarantee holds even if a future ordering regression in `buildProxyConfig` leaves a sentinel unmarked.

## Changes

- Guard `proxyToBackend` against the ExternalBackend sentinel scheme: return a clean 500 before any dial, covering both the reverse-proxy and WebSocket-upgrade paths.
- Update the `externalBackendScheme` doc comment so the "never dialed" guarantee names both enforcement points (the controller's 500-marking and the new handler guard).
- Add a red/green pin via two tests — one through `httptest`, one through the production cloudflared HTTP/2 writer.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [ ] Markdown linting passes (`markdownlint **/*.md`) — N/A, no markdown files changed
- [ ] Manual testing completed (if applicable) — Gateway API conformance + custom e2e against a real tunnel are run before the PR moves out of draft

## Documentation

- [ ] README updated (if needed) — not needed, the user-facing contract is unchanged
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed) — not needed

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none, this is internal defensive hardening
- [x] Related issues referenced (if any)

## Additional Notes

The tests assert 500-not-502: a dial of the sentinel scheme fails the transport's RoundTrip with "unsupported protocol scheme" and falls through to 502, so 500-not-502 is the proof that the guard fires before any dial. Confirmed red without the guard, green with it.

Closes #396
