### PR TITLE
feat: fail fast with a clear signal when Cloudflare zone gRPC proxying is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ All matching and filter behavior is performed by the in-process L7 proxy that th
 
 ### Known Limitations
 
-The in-process L7 proxy handles routing for every tunnel request. Edge-side caveats (Cloudflare hostname registration, edge HTTPS termination, etc.) are documented in the [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/) page.
+The in-process L7 proxy handles routing for every tunnel request. Edge-side caveats (Cloudflare hostname registration, edge HTTPS termination, etc.) are documented in the [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/) page. In particular, a GRPCRoute also needs Cloudflare zone gRPC proxying enabled (dashboard → Network → gRPC); if disabled, the edge returns `403` zone-wide for `application/grpc` and gRPC fails before reaching the proxy ([details](https://cf.k8s.lex.la/gateway-api/limitations/#grpc-requires-cloudflare-zone-grpc-proxying)).
 
 `BackendTLSPolicy` (proxy → backend TLS) is supported at minimum-viable scope:
 

--- a/docs/gateway-api/grpcroute.md
+++ b/docs/gateway-api/grpcroute.md
@@ -6,7 +6,11 @@ GRPCRoute enables routing gRPC traffic through Cloudflare Tunnel with service an
 
     cloudflared does **not** forward HTTP trailers over QUIC (its default transport), and gRPC carries the mandatory `grpc-status` in a trailer. Over a QUIC tunnel the trailer is dropped at the edge and every gRPC call fails with `server closed the stream without sending trailers`. This is a cloudflared/Cloudflare limitation, not a controller bug.
 
-    With the default `proxy.tunnel.protocol: auto` (or unset) you do not need to change anything: the proxy dials `http2` at startup when a GRPCRoute is present. A GRPCRoute added after the proxy has already dialed a non-`http2` transport needs a proxy restart (the proxy logs a restart-needed error). An explicit `proxy.tunnel.protocol: quic` is never upgraded and cannot serve gRPC — the controller logs an error and sets the GRPCRoute's `Accepted` condition to `False` / `UnsupportedProtocol` with an actionable message. Also enable gRPC on the Cloudflare zone (Network → gRPC), or the edge returns 403 for `application/grpc` requests.
+    With the default `proxy.tunnel.protocol: auto` (or unset) you do not need to change anything: the proxy dials `http2` at startup when a GRPCRoute is present. A GRPCRoute added after the proxy has already dialed a non-`http2` transport needs a proxy restart (the proxy logs a restart-needed error). An explicit `proxy.tunnel.protocol: quic` is never upgraded and cannot serve gRPC — the controller logs an error and sets the GRPCRoute's `Accepted` condition to `False` / `UnsupportedProtocol` with an actionable message.
+
+!!! note "Prerequisite: enable gRPC on the Cloudflare zone"
+
+    Separate from the tunnel transport, the Cloudflare **zone** must have gRPC proxying enabled (dashboard → **Network → gRPC**). If it is disabled, the Cloudflare edge returns `403` with `content-type: text/html` zone-wide for every `application/grpc` request — upstream of the tunnel, so the request never reaches the proxy. The GRPCRoute still reports `Accepted=True` while every gRPC call fails with the opaque client error `rpc error: code = PermissionDenied ... received unexpected content-type "text/html"`. As a breadcrumb the controller emits a Normal Event (`reason: GRPCEdgeProxyingRequired`) on accepted GRPCRoutes naming this prerequisite. See [Limitations](limitations.md#grpc-requires-cloudflare-zone-grpc-proxying).
 
 ## Basic Example
 

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -180,7 +180,19 @@ With the default `proxy.tunnel.protocol: auto` (or unset) you do not need to do 
 
 Startup-latency tradeoff of `auto`: because the `auto` choice must learn whether a GRPCRoute is present before dialing, an `auto`/unset proxy waits for the controller's first config push — bounded by a cap (~30s) — before establishing the tunnel. On a cluster that has routes, the first push arrives within seconds, so the delay is negligible. But a route-less cluster (no HTTPRoutes or GRPCRoutes yet) has nothing to push, so every `auto` proxy pod waits the full cap on each start before the tunnel comes up. There is no traffic to serve in that state, so it is harmless in practice — but if you see an `auto` proxy slow to establish its tunnel on a route-less cluster, that wait is the cause; pin `proxy.tunnel.protocol: http2` or `quic` to dial immediately (an explicit transport skips the wait).
 
-Separately, gRPC must be enabled on the Cloudflare zone (dashboard Network → gRPC); without it the edge returns 403 zone-wide for `content-type: application/grpc`.
+### gRPC requires Cloudflare zone gRPC proxying
+
+Separate from the tunnel transport above, the Cloudflare _zone_ must have gRPC proxying enabled (dashboard → Network → gRPC). When it is disabled, the Cloudflare edge returns `403` with `content-type: text/html` zone-wide for any request whose `content-type` is `application/grpc` — the request never reaches the in-cluster proxy.
+
+Because the 403 happens at the edge, upstream of the tunnel, the controller never sees it: the GRPCRoute reports `Accepted=True` / `ResolvedRefs=True` while every gRPC call fails. The client-side symptom is opaque:
+
+```text
+rpc error: code = PermissionDenied desc = unexpected HTTP status code received from server: 403 (Forbidden); transport: received unexpected content-type "text/html"
+```
+
+The toggle is dashboard-only: there is no zone-settings API for it (`PATCH /settings/grpc` returns `400` / code `1006` "Unrecognized zone setting name" even with a full-scope token) and the Terraform provider has no resource, so the controller cannot read the setting to validate it. As a breadcrumb, the controller emits a Normal Kubernetes Event (`reason: GRPCEdgeProxyingRequired`) on every accepted GRPCRoute naming this prerequisite, so `kubectl describe grpcroute <name>` points at the fix without edge packet inspection.
+
+**Fix:** enable Network → gRPC for the zone in the Cloudflare dashboard.
 
 ### Gateway client cert rotation is hot-reloaded
 

--- a/internal/controller/diagnostic_events_test.go
+++ b/internal/controller/diagnostic_events_test.go
@@ -175,7 +175,17 @@ func TestGRPCRouteReconciler_updateRouteStatus_EmitsEvent(t *testing.T) {
 
 	require.NoError(t, r.updateRouteStatus(context.Background(), route, routeBindingInfo{}, nil, diagnostics, nil))
 
-	got := drainEvents(rec)
-	require.Len(t, got, 1, "the GRPCRoute reconciler must emit the Event-target diagnostic")
-	assert.Contains(t, got[0], "h2c suppressed")
+	// updateRouteStatus also emits the unconditional gRPC edge-toggle breadcrumb
+	// on this gRPC-capable transport, so filter to the diagnostic Event under test
+	// rather than asserting a single total.
+	var diagEvents []string
+
+	for _, e := range drainEvents(rec) {
+		if strings.Contains(e, "h2c suppressed") {
+			diagEvents = append(diagEvents, e)
+		}
+	}
+
+	require.Len(t, diagEvents, 1, "the GRPCRoute reconciler must emit the Event-target diagnostic")
+	assert.Contains(t, diagEvents[0], "h2c suppressed")
 }

--- a/internal/controller/grpcroute_controller.go
+++ b/internal/controller/grpcroute_controller.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync/atomic"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -27,6 +29,15 @@ import (
 const grpcQUICUnsupportedStatusMessage = "gRPC is not compatible with the \"quic\" tunnel transport " +
 	"(cloudflared drops HTTP trailers over QUIC, so grpc-status is lost). Set proxy.tunnel.protocol " +
 	"to \"http2\" (or \"auto\"/unset, which the controller will upgrade to http2 for gRPC) to enable this route."
+
+// grpcEdgeHintMessage is the breadcrumb surfaced as a Normal Event on every
+// accepted GRPCRoute (see emitGRPCEdgeHint). It names the Cloudflare zone
+// prerequisite and the exact failure mode so an operator who sees gRPC failing
+// on a route that reports Accepted=True has something actionable to find.
+const grpcEdgeHintMessage = "gRPC traffic requires Cloudflare zone gRPC proxying enabled (dashboard Network → gRPC). " +
+	"If it is disabled the Cloudflare edge returns 403 (content-type text/html) for application/grpc requests " +
+	"zone-wide, so gRPC calls fail before reaching the proxy. This is a Cloudflare edge prerequisite, not a " +
+	"controller error."
 
 // isExplicitQUIC reports whether the operator deliberately pinned the tunnel
 // transport to quic (case-insensitive, trimmed). Only an explicit quic is a
@@ -65,6 +76,48 @@ func grpcProtocolWarning(protocol string, grpcRouteCount int) (string, bool) {
 			"This is a cloudflared/Cloudflare limitation, not on our side.",
 		grpcRouteCount, protocol,
 	), true
+}
+
+// emitGRPCEdgeHint emits a non-fatal Normal Event reminding the operator that a
+// GRPCRoute only works if the Cloudflare zone has gRPC proxying enabled
+// (dashboard Network → gRPC). The toggle is dashboard-only with no API to read,
+// so the controller cannot validate it; this breadcrumb gives the operator
+// something to find via `kubectl describe grpcroute` instead of an opaque edge
+// 403. A nil recorder is a no-op (matches emitDiagnosticEvents, e.g. in unit
+// tests). k8s deduplicates repeats by reason+message, so emitting once per
+// reconcile is not spammy.
+func emitGRPCEdgeHint(recorder events.EventRecorder, route runtime.Object) {
+	if recorder == nil {
+		return
+	}
+
+	recorder.Eventf(route, nil, corev1.EventTypeNormal,
+		eventReasonGRPCEdgeProxyingRequired, eventActionVerifyEdgeConfig, "%s", grpcEdgeHintMessage)
+}
+
+// grpcRouteWillBeAccepted reports whether the route's Accepted condition will be
+// True for at least one managed parent. It folds the same inputs buildParentStatus
+// passes to buildAcceptedCondition: no sync error (else Pending), at least one
+// bound parent (else a binding rejection), no caller override (the explicit-quic
+// UnsupportedProtocol case), and no diagnostic-derived whole-route override (every
+// rule unservable → UnsupportedValue). diagnosticConditions is the single source
+// of truth for that last input, so the gate cannot drift from the condition the
+// operator sees. The zero generation/time are unused — only the override (first
+// return) is read, and its presence does not depend on them.
+func grpcRouteWillBeAccepted(
+	bindingInfo routeBindingInfo,
+	diagnostics []proxy.RouteDiagnostic,
+	ruleCount int,
+	syncErr error,
+	override *acceptedConditionOverride,
+) bool {
+	if syncErr != nil || override != nil || !bindingInfo.hasAcceptedParent() {
+		return false
+	}
+
+	diagOverride, _ := diagnosticConditions(diagnostics, ruleCount, 0, metav1.Time{})
+
+	return diagOverride == nil
 }
 
 // GRPCRouteReconciler reconciles GRPCRoute resources, synchronizing them to
@@ -177,6 +230,17 @@ func (r *GRPCRouteReconciler) updateRouteStatus(
 			reason:  string(gatewayv1.RouteReasonUnsupportedProtocol),
 			message: grpcQUICUnsupportedStatusMessage,
 		}
+	}
+
+	// Edge breadcrumb: emit only when the route's Accepted condition will be True,
+	// so the reminder never lands on a route this same update reports Accepted=False
+	// for an already-surfaced reason (explicit-quic UnsupportedProtocol, a sync
+	// Pending, a binding rejection — updateRouteStatus also runs over
+	// RejectedGRPCRoutes — or a diagnostic that marks every rule unservable). The
+	// gate mirrors buildParentStatus' inputs so it cannot diverge from the
+	// condition the operator sees.
+	if grpcRouteWillBeAccepted(bindingInfo, diagnostics, len(route.Spec.Rules), syncErr, params.acceptedOverride) {
+		emitGRPCEdgeHint(r.Recorder, route)
 	}
 
 	return updateRouteStatusGeneric(

--- a/internal/controller/grpcroute_edge_hint_test.go
+++ b/internal/controller/grpcroute_edge_hint_test.go
@@ -1,0 +1,211 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/routebinding"
+)
+
+// grpcEdgeHintSubstring is the load-bearing phrase the breadcrumb Event must
+// carry so an operator scanning `kubectl describe grpcroute` lands on the
+// dashboard toggle. Pinned here so the tests fail loudly if the message is
+// reworded into something that no longer names the fix.
+const grpcEdgeHintSubstring = "Network → gRPC"
+
+// acceptedGRPCBinding is a routeBindingInfo with one managed parent accepted —
+// the shape a GRPCRoute carries once it has bound to a managed Gateway (the only
+// state in which the controller programs it and the edge breadcrumb applies).
+func acceptedGRPCBinding() routeBindingInfo {
+	return routeBindingInfo{
+		bindingResults: map[int]routebinding.BindingResult{
+			0: {Accepted: true, Reason: gatewayv1.RouteReasonAccepted, Message: "Route accepted"},
+		},
+	}
+}
+
+// TestGRPCRouteReconciler_updateRouteStatus_EmitsEdgeHint pins that an accepted
+// GRPCRoute on a gRPC-capable transport (auto/unset/http2) gets a non-fatal
+// breadcrumb Event reminding the operator to enable Cloudflare zone gRPC
+// proxying. The edge 403 for application/grpc happens upstream of the tunnel, so
+// this Event is the only in-cluster signal the operator has — without it the
+// route looks healthy while every gRPC call fails.
+func TestGRPCRouteReconciler_updateRouteStatus_EmitsEdgeHint(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.GRPCRoute{ObjectMeta: metav1.ObjectMeta{Name: "grpc", Namespace: "default"}}
+	scheme, builder := eventDiagSchemeAndClient(t)
+	cli := builder.WithObjects(route).WithStatusSubresource(route).Build()
+
+	rec := events.NewFakeRecorder(5)
+	r := &GRPCRouteReconciler{
+		Client:         cli,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		Recorder:       rec,
+		// TunnelProtocol left empty (auto/unset) — the gRPC-capable path.
+	}
+
+	require.NoError(t, r.updateRouteStatus(context.Background(), route, acceptedGRPCBinding(), nil, nil, nil))
+
+	got := drainEvents(rec)
+
+	var hints []string
+
+	for _, e := range got {
+		if strings.Contains(e, grpcEdgeHintSubstring) {
+			hints = append(hints, e)
+		}
+	}
+
+	require.Len(t, hints, 1, "an accepted GRPCRoute on a gRPC-capable transport must emit exactly one edge-toggle breadcrumb")
+	assert.Contains(t, hints[0], "gRPC proxying", "the breadcrumb must name the prerequisite, not just the dashboard path")
+}
+
+// TestGRPCRouteReconciler_updateRouteStatus_NoEdgeHintOnExplicitQUIC pins that
+// the breadcrumb is suppressed when the transport is explicitly quic: that route
+// is already rejected Accepted=False / UnsupportedProtocol (gRPC cannot work over
+// QUIC at all), so the edge-toggle reminder would be misleading noise on a route
+// that fails for a different, already-surfaced reason.
+func TestGRPCRouteReconciler_updateRouteStatus_NoEdgeHintOnExplicitQUIC(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.GRPCRoute{ObjectMeta: metav1.ObjectMeta{Name: "grpc", Namespace: "default"}}
+	scheme, builder := eventDiagSchemeAndClient(t)
+	cli := builder.WithObjects(route).WithStatusSubresource(route).Build()
+
+	rec := events.NewFakeRecorder(5)
+	r := &GRPCRouteReconciler{
+		Client:         cli,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		Recorder:       rec,
+		TunnelProtocol: "quic",
+	}
+
+	require.NoError(t, r.updateRouteStatus(context.Background(), route, acceptedGRPCBinding(), nil, nil, nil))
+
+	for _, e := range drainEvents(rec) {
+		assert.NotContains(t, e, grpcEdgeHintSubstring,
+			"an explicit-quic GRPCRoute must not get the edge-toggle breadcrumb (it is rejected for a different reason)")
+	}
+}
+
+// TestGRPCRouteReconciler_updateRouteStatus_NoEdgeHintOnBindingRejected pins that
+// the breadcrumb is suppressed for a GRPCRoute that bound to a managed Gateway
+// but was rejected at binding validation (Accepted=False / e.g. NoMatchingParent).
+// updateRouteStatus runs over RejectedGRPCRoutes too, so without an acceptance
+// guard the hint would fire on a route that is provably not Accepted — its
+// message would claim the route is Accepted and send the operator to flip an
+// unrelated edge setting.
+func TestGRPCRouteReconciler_updateRouteStatus_NoEdgeHintOnBindingRejected(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.GRPCRoute{ObjectMeta: metav1.ObjectMeta{Name: "grpc", Namespace: "default"}}
+	scheme, builder := eventDiagSchemeAndClient(t)
+	cli := builder.WithObjects(route).WithStatusSubresource(route).Build()
+
+	rec := events.NewFakeRecorder(5)
+	r := &GRPCRouteReconciler{
+		Client:         cli,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		Recorder:       rec,
+	}
+
+	rejected := routeBindingInfo{
+		bindingResults: map[int]routebinding.BindingResult{
+			0: {Accepted: false, Reason: gatewayv1.RouteReasonNoMatchingParent, Message: "no matching parent"},
+		},
+	}
+
+	require.NoError(t, r.updateRouteStatus(context.Background(), route, rejected, nil, nil, nil))
+
+	for _, e := range drainEvents(rec) {
+		assert.NotContains(t, e, grpcEdgeHintSubstring,
+			"a binding-rejected GRPCRoute (Accepted=False) must not get the edge-toggle breadcrumb")
+	}
+}
+
+// TestGRPCRouteReconciler_updateRouteStatus_NoEdgeHintOnSyncError pins that the
+// breadcrumb is suppressed when the sync failed: the route is Accepted=False /
+// Pending, so the "this route is Accepted" framing of the hint would be wrong.
+func TestGRPCRouteReconciler_updateRouteStatus_NoEdgeHintOnSyncError(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.GRPCRoute{ObjectMeta: metav1.ObjectMeta{Name: "grpc", Namespace: "default"}}
+	scheme, builder := eventDiagSchemeAndClient(t)
+	cli := builder.WithObjects(route).WithStatusSubresource(route).Build()
+
+	rec := events.NewFakeRecorder(5)
+	r := &GRPCRouteReconciler{
+		Client:         cli,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		Recorder:       rec,
+	}
+
+	require.NoError(t, r.updateRouteStatus(context.Background(), route, acceptedGRPCBinding(), nil, nil, errCloudflareSync))
+
+	for _, e := range drainEvents(rec) {
+		assert.NotContains(t, e, grpcEdgeHintSubstring,
+			"a GRPCRoute pending on a sync error must not get the edge-toggle breadcrumb")
+	}
+}
+
+// TestGRPCRouteReconciler_updateRouteStatus_NoEdgeHintWhenEveryRuleUnservable
+// pins that the breadcrumb is suppressed when converter diagnostics mark every
+// rule of the route wholly unservable. That flips the route to
+// Accepted=False / UnsupportedValue even with no sync error and a bound parent,
+// so — like the binding-rejected and sync-error cases — the edge reminder would
+// land on a route the same status update reports as not Accepted.
+func TestGRPCRouteReconciler_updateRouteStatus_NoEdgeHintWhenEveryRuleUnservable(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "grpc", Namespace: "default"},
+		Spec:       gatewayv1.GRPCRouteSpec{Rules: []gatewayv1.GRPCRouteRule{{}}},
+	}
+	scheme, builder := eventDiagSchemeAndClient(t)
+	cli := builder.WithObjects(route).WithStatusSubresource(route).Build()
+
+	rec := events.NewFakeRecorder(5)
+	r := &GRPCRouteReconciler{
+		Client:         cli,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		Recorder:       rec,
+	}
+
+	// The route's only rule is wholly unservable, so len(wholeRuleIdx) >= ruleCount
+	// and diagnosticConditions yields an Accepted=False/UnsupportedValue override.
+	diagnostics := []proxy.RouteDiagnostic{
+		{Namespace: "default", Name: "grpc", Target: proxy.DiagnosticAccepted, WholeRule: true, RuleIndex: 0, Message: "gRPC rule filters are not supported"},
+	}
+
+	require.NoError(t, r.updateRouteStatus(context.Background(), route, acceptedGRPCBinding(), nil, diagnostics, nil))
+
+	for _, e := range drainEvents(rec) {
+		assert.NotContains(t, e, grpcEdgeHintSubstring,
+			"a GRPCRoute whose every rule is unservable (Accepted=False) must not get the edge-toggle breadcrumb")
+	}
+}
+
+// TestEmitGRPCEdgeHint_NilRecorderNoPanic pins the no-op-safety contract: a
+// reconciler constructed without a Recorder (e.g. in a unit test) must not panic
+// when the breadcrumb path runs. Mirrors emitDiagnosticEvents' nil guard.
+func TestEmitGRPCEdgeHint_NilRecorderNoPanic(t *testing.T) {
+	t.Parallel()
+
+	route := &gatewayv1.GRPCRoute{ObjectMeta: metav1.ObjectMeta{Name: "grpc", Namespace: "default"}}
+
+	assert.NotPanics(t, func() { emitGRPCEdgeHint(nil, route) })
+}

--- a/internal/controller/route_status.go
+++ b/internal/controller/route_status.go
@@ -448,6 +448,13 @@ func firstResolvedRefsDiagnostic(diagnostics []proxy.RouteDiagnostic) (proxy.Rou
 const (
 	eventReasonConfigOverridden = "ConfigOverridden"
 	eventActionConvert          = "Convert"
+
+	// Event reason / action tokens for the GRPCRoute edge-toggle breadcrumb (see
+	// emitGRPCEdgeHint). The Cloudflare zone gRPC toggle is dashboard-only with no
+	// API to read, so the controller cannot validate it; this Normal Event is the
+	// only in-cluster signal an operator gets when the edge 403s application/grpc.
+	eventReasonGRPCEdgeProxyingRequired = "GRPCEdgeProxyingRequired"
+	eventActionVerifyEdgeConfig         = "VerifyEdgeConfig"
 )
 
 // emitDiagnosticEvents emits a Kubernetes Event for each Event-target

--- a/internal/controller/route_syncer.go
+++ b/internal/controller/route_syncer.go
@@ -95,6 +95,20 @@ type routeBindingInfo struct {
 	bindingResults map[int]routebinding.BindingResult
 }
 
+// hasAcceptedParent reports whether the route bound to at least one managed
+// Gateway parent (the same condition bindRouteParents folds into its accepted
+// return). A route in this state is programmed into the tunnel; a route with no
+// accepted parent is in RejectedGRPCRoutes/RejectedHTTPRoutes with Accepted=False.
+func (b routeBindingInfo) hasAcceptedParent() bool {
+	for _, result := range b.bindingResults {
+		if result.Accepted {
+			return true
+		}
+	}
+
+	return false
+}
+
 // SyncResult contains the results of a sync operation.
 type SyncResult struct {
 	HTTPRoutes        []gatewayv1.HTTPRoute


### PR DESCRIPTION
# Pull Request

## Summary

A GRPCRoute served through the Cloudflare Tunnel only works if the Cloudflare zone has gRPC proxying enabled (dashboard → Network → gRPC). When it is disabled, the edge returns `403` with `content-type: text/html` zone-wide for any `application/grpc` request — upstream of the tunnel, so the controller never sees it. The GRPCRoute reports `Accepted=True` while every gRPC call fails with an opaque client error, and the toggle is dashboard-only (no API, no Terraform resource) so the controller cannot validate it. This adds a non-fatal in-cluster breadcrumb plus documentation so an operator can find the cause without edge packet inspection.

## Changes

- Emit a Normal Kubernetes Event (`reason: GRPCEdgeProxyingRequired`) on every GRPCRoute that will be `Accepted=True`, naming the zone gRPC prerequisite. The hint is gated to fire only when the route's `Accepted` condition is True — suppressed for explicit-quic (`UnsupportedProtocol`), sync failure (`Pending`), binding rejection, and a converter diagnostic that marks every rule unservable (`UnsupportedValue`) — so it never lands on a route reported `Accepted=False` for another reason.
- Document the failure mode in a dedicated Limitations subsection with the exact symptom (edge `403`, `content-type: text/html`, zone-wide), the opaque client-side gRPC error, why the controller is blind to it, why it cannot be auto-detected, and the fix. Add a prominent prerequisite note to the GRPCRoute guide and a brief mention in the README.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [ ] Manual testing completed (if applicable) — Gateway API conformance (HTTP+gRPC) + custom e2e against a real tunnel are run before the PR moves out of draft

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed) — not needed

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none, this is additive
- [x] Related issues referenced (if any)

## Additional Notes

No active edge probe: a true fail-fast self-check needs a reachable hostname, a polling cadence, and flap-guarding against transient edge errors for a signal the operator already gets from the documented symptom plus this breadcrumb. The decision against the probe is deliberate; the prerequisite is documented and surfaced instead.

Closes #393
