### PR TITLE
docs: pre-v3.0.0 proofread + accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [L7 Proxy Architecture](https://cf.k8s.lex.la/development/architecture/) for
 
 ```bash
 # 1. Install Gateway API CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 
 # 2. Create credentials Secrets
 kubectl create namespace cloudflare-tunnel-system

--- a/docs/configuration/controller.md
+++ b/docs/configuration/controller.md
@@ -15,8 +15,16 @@ This document describes all configuration options for the controller binary. For
 | `--leader-elect` | `CF_LEADER_ELECT` | `false` | Enable leader election for HA |
 | `--leader-election-namespace` | `CF_LEADER_ELECTION_NAMESPACE` | | Namespace for leader election lease |
 | `--leader-election-name` | `CF_LEADER_ELECTION_NAME` | `cloudflare-tunnel-gateway-controller-leader` | Leader election lease name |
-| `--proxy-endpoints` | `CF_PROXY_ENDPOINTS` | | Proxy config API endpoints for L7 proxy sync |
+| `--proxy-endpoints` | `CF_PROXY_ENDPOINTS` | | Proxy config API endpoints for L7 proxy sync (required in v3) |
 | `--proxy-auth-token` | `CF_PROXY_AUTH_TOKEN` | | Bearer token for proxy config push authentication |
+| `--proxy-token-secret` | `CF_PROXY_TOKEN_SECRET` | | Tunnel-token Secret to watch in `<namespace>/<name>` form; the controller rolls the proxy Deployment when the Secret data changes. Empty disables the watcher |
+| `--proxy-deployment-label` | `CF_PROXY_DEPLOYMENT_LABEL` | `app.kubernetes.io/component=proxy` | Label selector (`key=value`) identifying the proxy Deployment(s) to roll on tunnel-token change |
+| `--tunnel-protocol` | `CF_TUNNEL_PROTOCOL` | `auto` | Edge transport protocol (`auto`, `http2`, `quic`); used to warn when GRPCRoutes are present on an explicit `quic` tunnel |
+| `--tracing-enabled` | `CF_TRACING_ENABLED` | `false` | Enable OpenTelemetry distributed tracing |
+| `--tracing-endpoint` | `CF_TRACING_ENDPOINT` | | OTLP/gRPC collector endpoint (defers to `OTEL_EXPORTER_OTLP_ENDPOINT` when empty) |
+| `--tracing-sample-rate` | `CF_TRACING_SAMPLE_RATE` | `1.0` | Head-sampling probability in `[0,1]` |
+
+For full distributed-tracing setup, see [Distributed Tracing](../operations/tracing.md).
 
 ## Environment Variables
 

--- a/docs/configuration/gatewayclassconfig.md
+++ b/docs/configuration/gatewayclassconfig.md
@@ -24,8 +24,8 @@ spec:
   # Required: Cloudflare Tunnel UUID
   tunnelID: "550e8400-e29b-41d4-a716-446655440000"
 
-  # Optional: Cloudflare Account ID (auto-detected if not specified)
-  accountId: "1234567890abcdef"
+  # Optional: Cloudflare Account ID (32-character lowercase hex; auto-detected if not specified)
+  accountId: "0123456789abcdef0123456789abcdef"
 
   # Required: Reference to Secret containing API token
   cloudflareCredentialsSecretRef:
@@ -46,11 +46,11 @@ spec:
 
 ### `spec.accountId` (optional)
 
-The Cloudflare account ID. If not specified, it is auto-detected from the API token when the token has access to a single account.
+The Cloudflare account ID. Must be a 32-character lowercase hexadecimal string (the format Cloudflare uses for account IDs); a value that does not match this pattern is rejected at admission time by a CRD-level CEL rule. If not specified, it is read from the `account-id` key in the credentials Secret; if that key is also absent, it is auto-detected from the Cloudflare API when the token has access to a single account. Tokens with access to multiple accounts must set this field (or the `account-id` Secret key) explicitly.
 
 ```yaml
 spec:
-  accountId: "1234567890abcdef"
+  accountId: "0123456789abcdef0123456789abcdef"
 ```
 
 ### `spec.cloudflareCredentialsSecretRef` (required)
@@ -61,10 +61,11 @@ Reference to a Kubernetes Secret containing the Cloudflare API token.
 spec:
   cloudflareCredentialsSecretRef:
     name: cloudflare-credentials
+    # namespace: cloudflare-tunnel-system  # Optional, defaults to the controller namespace
     key: api-token  # Optional, defaults to "api-token"
 ```
 
-The referenced Secret must exist in the same namespace as the controller:
+The reference accepts three fields: `name` (required), `namespace` (optional), and `key` (optional). The referenced Secret defaults to the controller's own namespace. To place the Secret in a different namespace, set `cloudflareCredentialsSecretRef.namespace` explicitly:
 
 ```yaml
 apiVersion: v1
@@ -188,7 +189,7 @@ flowchart LR
 1. GatewayClass references GatewayClassConfig via `parametersRef`
 2. Controller reads GatewayClassConfig
 3. Controller fetches the referenced credentials Secret
-4. Controller auto-detects account ID if not specified
+4. Controller resolves the account ID: `spec.accountId` first, then the `account-id` key in the credentials Secret, then auto-detection via the Cloudflare API
 5. Resolved configuration is used by controllers
 
 ## Troubleshooting
@@ -211,7 +212,7 @@ If the controller cannot find the referenced Secret:
 kubectl get secret cloudflare-credentials --namespace cloudflare-tunnel-system
 ```
 
-Ensure the Secret exists in the controller's namespace.
+Ensure the Secret exists in the controller's namespace, or set `cloudflareCredentialsSecretRef.namespace` to the namespace where it actually lives.
 
 ### Account ID Detection Failed
 

--- a/docs/configuration/helm-values.md
+++ b/docs/configuration/helm-values.md
@@ -71,7 +71,7 @@ podDisruptionBudget:
 
 ```yaml
 serviceMonitor:
-  enabled: true       # Creates ServiceMonitor for the proxy's /metrics endpoint
+  enabled: true       # Creates two ServiceMonitors: one for the controller (Prometheus /metrics on port 8080) and one for the proxy (config-API health on port 8081)
   interval: 30s
   labels:
     prometheus: kube-prometheus

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -8,7 +8,7 @@ The controller can be configured at multiple levels:
 
 1. **Controller Options** - CLI flags and environment variables
 2. **Helm Values** - Deployment configuration via Helm chart
-3. **GatewayClassConfig** - Tunnel credentials and cloudflared settings
+3. **GatewayClassConfig** - Cloudflare API credentials and tunnel UUID
 
 ## Sections
 
@@ -34,7 +34,7 @@ The controller can be configured at multiple levels:
 
     ---
 
-    Custom Resource for tunnel credentials and cloudflared configuration.
+    Custom Resource for tunnel credentials and tunnel identity (Cloudflare API token + Tunnel UUID).
 
     [:octicons-arrow-right-24: GatewayClassConfig](gatewayclassconfig.md)
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -155,7 +155,7 @@ Converts HTTPRoute specs to Cloudflare Tunnel ingress rules:
 
 **Rule Ordering**:
 
-1. Alphabetically by hostname
+1. Specific hostnames before the wildcard `*` (Cloudflare requirement), then alphabetically among specific hostnames
 2. Exact matches before prefix matches
 3. Longer paths before shorter paths
 
@@ -210,16 +210,14 @@ flowchart TB
     CHECK -->|No| SKIP[Skip]
     CHECK -->|Yes| DELETED{Resource<br/>deleted?}
 
-    DELETED -->|Yes| CLEANUP[Cleanup]
+    DELETED -->|Yes| GONE[Nothing to do<br/>proxy lifecycle managed by Helm chart]
     DELETED -->|No| RECONCILE[Reconcile]
 
     RECONCILE --> SYNC[Sync to Cloudflare]
     SYNC --> STATUS[Update Status]
 
-    CLEANUP --> FINALIZER[Remove Finalizer]
-
     STATUS --> END([Complete])
-    FINALIZER --> END
+    GONE --> END
     SKIP --> END
 ```
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -72,7 +72,7 @@ fix(ingress): handle empty hostnames correctly
 
 docs(readme): add installation instructions
 
-chore(deps): update controller-runtime to v0.22.4
+chore(deps): update controller-runtime to v0.24.0
 ```
 
 ## Pull Request Process

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -69,12 +69,12 @@ golangci-lint run --timeout=5m
 ## Project Structure
 
 ```text
-api/v1alpha1/            # GatewayClassConfig CRD types
+api/v1alpha1/            # GatewayClassConfig and ExternalBackend CRD types
 cmd/controller/          # Controller entrypoint and CLI
 cmd/proxy/               # L7 proxy binary entrypoint
 internal/
   config/                # GatewayClassConfig resolver
-  controller/            # Kubernetes controllers (Gateway, HTTPRoute, GRPCRoute, ProxySyncer)
+  controller/            # Kubernetes controllers (GatewayClass, GatewayClassConfig, Gateway, ListenerSet, HTTPRoute, GRPCRoute, BackendTLSPolicy, ProxySyncer)
   dns/                   # Cluster domain detection
   ingress/               # HTTPRoute → Cloudflare ingress rule conversion
   proxy/                 # L7 reverse proxy (router, matcher, filter, config API)

--- a/docs/development/proxy-architecture.md
+++ b/docs/development/proxy-architecture.md
@@ -90,10 +90,11 @@ The router uses `atomic.Pointer[routingTable]` for lock-free reads during config
 ### Precedence (Gateway API spec)
 
 1. Longest hostname (exact before wildcard)
-2. Longest path match
-3. Method present
-4. Most header matches
-5. Most query parameter matches
+2. Path type: Exact > Regex > Prefix
+3. Longest path value
+4. Method present
+5. Most header matches
+6. Most query parameter matches
 
 ## Config Push
 
@@ -120,6 +121,7 @@ Config versioning prevents stale updates. Each push includes a monotonically inc
 | RequestRedirect | Request | Return redirect response (short-circuit) |
 | URLRewrite | Request | Modify URL path and/or host |
 | RequestMirror | Request | Clone request to mirror backend (async) |
+| CORS | Response | Short-circuit preflight (204 + CORS headers) and attach CORS headers to simple cross-origin responses |
 
 ## Backend Selection
 
@@ -143,8 +145,9 @@ Weighted random selection using cumulative weight sums:
 - Build edge TLS configs (Cloudflare root CAs + system pool)
 - Create protocol selector (auto: QUIC preferred)
 - **In-process mode** (default): Set `OverrideProxy` on supervisor config to route all requests directly to `proxy.Handler`, bypassing ingress rules entirely
-- **Standalone mode**: Build catch-all ingress to `http://localhost:PROXY_PORT` so cloudflared forwards traffic to the local proxy HTTP server
 - Start `supervisor.StartTunnelDaemon`
+
+When `TUNNEL_TOKEN` is unset the binary runs in **standalone mode** instead: `runStandaloneMode` (`cmd/proxy/main.go`) starts a plain HTTP server on `PROXY_ADDR` (default `:8080`) that serves `proxy.Handler` directly, plus the config API on `PROXY_CONFIG_ADDR`. `StartTunnel` is never called, so no cloudflared tunnel is started — this mode is for local development and testing.
 
 ## Tunnel-Mode Response Writer Semantics
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -4,7 +4,7 @@ This guide covers setting up a development environment for the Cloudflare Tunnel
 
 ## Prerequisites
 
-- Go 1.26.1 or later
+- Go 1.26.4 or later
 - kubectl configured with cluster access
 - A Kubernetes cluster (kind, minikube, or remote)
 - Cloudflare account with a tunnel configured
@@ -64,13 +64,12 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 
 ### With kubeconfig
 
-```bash
-# Set required environment variables
-export CF_TUNNEL_ID="your-tunnel-id"
-export CF_API_TOKEN="your-api-token"
+The controller binary takes no credential environment variables. In v3, Cloudflare credentials and the tunnel UUID live in a Kubernetes Secret referenced by the GatewayClassConfig CRD, not in the controller process. The only mandatory flag is `--proxy-endpoints`, which points the controller at the in-process L7 proxy's config API.
 
-# Run controller
+```bash
+# Run controller (--proxy-endpoints is required in v3)
 ./bin/controller \
+  --proxy-endpoints=http://127.0.0.1:8081/config \
   --log-level=debug \
   --log-format=text
 ```
@@ -79,7 +78,7 @@ export CF_API_TOKEN="your-api-token"
 
 ```bash
 # Install Gateway API CRDs
-kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 
 # Create namespace
 kubectl create namespace cloudflare-tunnel-system
@@ -192,7 +191,7 @@ Settings (`.vscode/settings.json`):
 1. Enable golangci-lint integration:
    - Settings → Go → Linters → Enable golangci-lint
 2. Configure run configuration:
-   - Add environment variables: `CF_TUNNEL_ID`, `CF_API_TOKEN`
+   - Add environment variables the controller reads via viper (the `CF` prefix maps each flag, with `-` replaced by `_`): `CF_PROXY_ENDPOINTS` (required), and optionally `CF_CONTROLLER_NAME`, `CF_LOG_LEVEL`, `CF_LOG_FORMAT`
    - Set working directory to project root
 
 ## Common Tasks
@@ -223,7 +222,7 @@ go get -u ./...
 go mod tidy
 
 # Update specific dependency
-go get -u github.com/cloudflare/cloudflare-go/v4@latest
+go get -u github.com/cloudflare/cloudflare-go/v7@latest
 go mod tidy
 ```
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -261,10 +261,10 @@ Tests run automatically in CI:
 ```yaml
 # .github/workflows/pr.yaml
 - name: Run tests
-  run: go test -v -race -coverprofile=coverage.out ./...
+  run: go test -v -race -tags=envtest -coverprofile=coverage.out -covermode=atomic ./...
 
 - name: Upload coverage
-  uses: codecov/codecov-action@v4
+  uses: codecov/codecov-action@v6
   with:
     files: coverage.out
 ```
@@ -292,7 +292,7 @@ E2E_TUNNEL_HOSTNAME=<your-tunnel-hostname> \
 # Run a single test
 E2E_TUNNEL_HOSTNAME=<your-tunnel-hostname> \
   go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/... \
-  -run TestHTTPRouteSimpleSameNamespace
+  -run TestHTTPRouteConformance/Core/HTTPRouteSimpleSameNamespace
 ```
 
 ### E2E Environment Variables
@@ -304,14 +304,14 @@ E2E_TUNNEL_HOSTNAME=<your-tunnel-hostname> \
 | `E2E_NAMESPACE` | `CONFORMANCE_NAMESPACE` | `cloudflare-tunnel-system` | Controller namespace |
 | `E2E_TEST_NAMESPACE` | `CONFORMANCE_TEST_NAMESPACE` | `e2e-test` | Test resources namespace |
 | `E2E_GATEWAY_NAME` | `CONFORMANCE_GATEWAY_NAME` | `e2e-gateway` | Gateway resource name |
-| `E2E_SKIP_CLEANUP_ON_FAILURE` | (none) | unset | When non-empty, retains test resources (HTTPRoutes, Services) after a failed test for post-mortem `kubectl` inspection. CI leaves it unset so resources never accumulate. **Caveat: pair this with `-run TestName/SubtestName` to isolate the failing case.** The cleanup helpers wipe the entire test namespace, so in a full-suite run a passing sibling that comes after the failing subtest will delete its retained state -- only the last failing subtest after the final passing sibling actually survives. Retention is also scoped to a single `go test` run; the initial `deleteAllRoutes` at the start of `TestHTTPRouteConformance` wipes leftover state from a previous invocation, so `kubectl`-inspect happens between runs, not across them. |
+| `E2E_SKIP_CLEANUP_ON_FAILURE` | (none) | unset | When non-empty, retains test resources (HTTPRoutes, Services) after a failed test for post-mortem `kubectl` inspection. CI leaves it unset so resources never accumulate. **Caveat: pair this with `-run TestName/SubtestName` to isolate the failing case.** The cleanup helpers wipe the entire test namespace, so in a full-suite run a passing sibling that comes after the failing subtest will delete its retained state -- only the last failing subtest after the final passing sibling actually survives. Retention is also scoped to a single `go test` run; the initial `wipeAllRoutesInNamespace` at the start of `TestHTTPRouteConformance` wipes leftover state from a previous invocation, so `kubectl`-inspect happens between runs, not across them. |
 
-### E2E Test Coverage (24 tests)
+### E2E Test Coverage (25 tests)
 
 Tests cover both Cloudflare Tunnel and L7 proxy features:
 
 - **Core (4):** SimpleSameNamespace, PathPrefixMatching, ExactPathMatching, MatchingAcrossRoutes
-- **Extended (18):** HeaderMatching, MethodMatching, QueryParamMatching, Weight, RequestHeaderModifier, ResponseHeaderModifier, RequestRedirect, RegexPathMatching, RegexHeaderMatching, RegexQueryParamMatching, PathMatchOrder, URLRewritePath, URLRewriteHost, RequestMirror, RedirectPort, RedirectPath, CombinedMatching, MultipleMatchesOR
+- **Extended (19):** HeaderMatching, MethodMatching, QueryParamMatching, Weight, RequestHeaderModifier, ResponseHeaderModifier, RequestRedirect, RegexPathMatching, RegexHeaderMatching, RegexQueryParamMatching, PathMatchOrder, URLRewritePath, URLRewriteHost, RequestMirror, RedirectPort, RedirectPath, RedirectSchemeProbe, CombinedMatching, MultipleMatchesOR
 - **Gateway (2):** AcceptedCondition, ObservedGenerationBump
 
 ### Official Gateway API Conformance Suite

--- a/docs/gateway-api/external-backend.md
+++ b/docs/gateway-api/external-backend.md
@@ -93,6 +93,8 @@ spec:
       kind: ExternalBackend
 ```
 
+The `from` entry is keyed on the referencing route's kind. For a cross-namespace GRPCRoute reference, replace `kind: HTTPRoute` with `kind: GRPCRoute` — an HTTPRoute-keyed grant does not authorize a GRPCRoute backendRef.
+
 ## Status and failure modes
 
 - A missing `ExternalBackend` surfaces `ResolvedRefs=False, BackendNotFound` on the referencing route and returns HTTP 500 for that backend's traffic fraction (other weighted backends keep serving).

--- a/docs/gateway-api/httproute.md
+++ b/docs/gateway-api/httproute.md
@@ -302,7 +302,7 @@ Expected output includes `"type":"Accepted","status":"True"`.
 
 | Condition | Meaning |
 |-----------|---------|
-| `Accepted: True` | Route is active and synced to Cloudflare |
+| `Accepted: True` | Route is accepted and programmed in the in-process proxy; Cloudflare Tunnel config updated (L7 routing happens in-cluster, not at the Cloudflare edge) |
 | `Accepted: False` | Route was rejected (check reason) |
 | `ResolvedRefs: True` | All backend references resolved |
 | `ResolvedRefs: False` | Backend reference failed (missing service or ReferenceGrant) |

--- a/docs/gateway-api/index.md
+++ b/docs/gateway-api/index.md
@@ -4,7 +4,7 @@ This section documents the Gateway API implementation in the Cloudflare Tunnel G
 
 ## Overview
 
-The controller implements the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) to configure Cloudflare Tunnel ingress rules. It watches Gateway and Route resources and translates them into Cloudflare Tunnel configuration via the Cloudflare API.
+The controller implements the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) to manage an in-process L7 reverse proxy data plane. It watches Gateway and Route resources, pushes routing configuration to the in-cluster proxy, and registers tunnel endpoints with the Cloudflare API for DNS/edge connectivity. All L7 routing, matching, and filter logic executes in the in-cluster proxy; the Cloudflare API is used only for edge configuration.
 
 ## Supported Resources
 
@@ -65,7 +65,7 @@ flowchart TB
         HR[HTTPRoute]
         SVC[Services]
         CTRL[Controller]
-        CFD[cloudflared]
+        PROXY[Proxy Pod<br/>embedded cloudflared transport]
     end
 
     subgraph Cloudflare["Cloudflare Edge"]
@@ -77,18 +77,19 @@ flowchart TB
     HR -->|watch| CTRL
     SVC -->|resolve| CTRL
     CTRL -->|configure| API
-    API -->|push config| CFD
-    CFD -->|tunnel| EDGE
-    EDGE -->|traffic| CFD
-    CFD -->|route| SVC
+    CTRL -->|sync routes| PROXY
+    API -->|tunnel config| PROXY
+    PROXY -->|tunnel| EDGE
+    EDGE -->|traffic| PROXY
+    PROXY -->|route| SVC
 ```
 
 ## Key Concepts
 
 !!! info "TLS Termination"
 
-    Cloudflare Tunnel terminates TLS at Cloudflare's edge network. Gateway listener configuration for ports, protocols, and TLS settings has no effect on routing behavior.
+    Cloudflare Tunnel terminates TLS at Cloudflare's edge network; in-cluster TLS termination settings on Gateway listeners have no effect. Listener port and protocol still govern route binding per the Gateway API spec.
 
 !!! info "Full Sync"
 
-    Any change to an HTTPRoute or GRPCRoute triggers a full configuration sync to Cloudflare Tunnel. The controller rebuilds the entire ingress configuration and re-pushes the merged proxy config on each reconciliation.
+    Any change to an HTTPRoute or GRPCRoute triggers a full configuration sync. The controller rebuilds the entire route table and pushes the merged config to every proxy replica (via `PUT /config`), then updates edge registration with the Cloudflare API.

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -81,7 +81,7 @@ Cloudflare's free [Universal SSL](https://developers.cloudflare.com/ssl/edge-cer
 
 For multi-level subdomains, you need:
 
-- [Advanced Certificate Manager](https://developers.cloudflare.com/ssl/edge-certificates/advanced-certificate-manager/) ($10/month)
+- [Advanced Certificate Manager](https://developers.cloudflare.com/ssl/edge-certificates/advanced-certificate-manager/) (paid add-on — see Cloudflare pricing)
 - Business or Enterprise plan
 
 ## Gateway Listener Configuration
@@ -154,13 +154,13 @@ The L7 proxy supports Gateway API `BackendTLSPolicy` for proxy → backend TLS, 
 | `SubjectAltNames` of type `Hostname` (OR-matching) | Yes | Cert must match at least one entry. Wildcards in the cert SAN list are honoured via `x509.Certificate.VerifyHostname` |
 | `SubjectAltNames` of type `URI` (e.g. SPIFFE) | Yes | Matched by exact string equality against the leaf cert's `URIs` field. OR-matched alongside Hostname SANs in the same policy — either path passing accepts the handshake (matches `BackendTLSPolicySANValidation` conformance) |
 | SNI / authentication split when SANs are set | Yes | When ANY `SubjectAltNames` entry is present (Hostname OR URI), `Hostname` is used only for SNI and NOT for authentication, per Gateway API spec. Authentication runs against the SAN list |
-| `WellKnownCACertificates: System` | No | Only explicit `CACertificateRefs` are honoured |
+| `WellKnownCACertificates: System` | No | Only explicit `CACertificateRefs` are honoured. A policy relying solely on `WellKnownCACertificates` is rejected with `Accepted=False, Reason=Invalid` and a message naming the unsupported value and directing the operator to configure explicit `caCertificateRefs` instead |
 | Multiple `targetRefs` per policy | Yes | All targeted Services share the same TLS config |
 | `SectionName` per-port targeting | Yes | When a `TargetRef` carries `sectionName`, only the matching named Service port receives TLS; siblings on the same Service stay plaintext |
 | Conflict resolution across multiple policies on the same target | Yes | Oldest-creationTimestamp wins, alphabetical name on tie. Losers are stamped `Accepted=False, Reason=Conflicted, Message="conflicts with BackendTLSPolicy <ns/name>"` per GEP-713; the upstream `BackendTLSPolicyConflictResolution` conformance subtest passes. Distinct `SectionName` scopes do not conflict (a policy targeting all Service ports and another scoped to a specific named port are different scopes). When a losing policy also has an invalid CA, `Reason=InvalidCACertificateRef` / `NoValidCACertificate` dominates over `Conflicted` — the actionable CA error surfaces first |
 | Cross-namespace CA refs | No | Same-namespace only |
 | `GatewayBackendClientCertificate` (mutual TLS) | Yes | The Gateway's `spec.tls.backend.clientCertificateRef` (Standard channel) loads a `kubernetes.io/tls` Secret and the proxy presents the keypair during backend TLS handshakes. Cross-namespace refs require ReferenceGrant. The client cert is attached **only** when the target Service has a `BackendTLSPolicy` — sending a cert over plaintext is meaningless. When an HTTPRoute attaches to multiple Gateways, the first parentRef managed by this controller that has a resolvable client cert wins; foreign-controller parents and parents without a cert are skipped, not blocking. The conformance test does not exercise this multi-parent edge case |
-| HTTPS-listener Re-encrypt (frontend TLS termination + backend TLS) | No | Cloudflare terminates TLS at the edge, so HTTPS listeners aren't supported (see the HTTPRoute HTTPS Listener limitation). The upstream `BackendTLSPolicy` parent test is skipped for the same reason |
+| HTTPS-listener Re-encrypt (frontend TLS termination + backend TLS) | No | Cloudflare terminates TLS at the edge, so frontend `protocol: HTTPS` listeners have no in-cluster TLS-termination data plane and re-encrypt is structurally unsupported (see [Gateway Listener Configuration](#gateway-listener-configuration)). The upstream `BackendTLSPolicy` parent test is skipped for the same reason |
 
 Policy status (`Accepted` / `ResolvedRefs`) is maintained per-Gateway-ancestor. Edits to the CA `ConfigMap` (creation, content patch, or deletion) re-trigger status reconciliation. The `Status.Ancestors` slice is capped at the spec's limit of 16 entries; entries are sorted deterministically by `{namespace, name}` so the truncated set stays stable across reconciles. `LastTransitionTime` is maintained via `meta.SetStatusCondition`, so it only flips when `Status`, `Reason`, or `Message` actually changes.
 
@@ -198,7 +198,7 @@ The toggle is dashboard-only: there is no zone-settings API for it (`PATCH /sett
 
 A rotation of the `Secret` referenced by `Gateway.spec.tls.backend.clientCertificateRef` enqueues the affected routes directly — `ConfigMapper.MapSecretToRequests` matches credentials and Gateway-level client-cert Secrets, including cross-namespace refs guarded by a matching `ReferenceGrant` (`from: Gateway`, `to: Secret`). On the resulting reconcile the new keypair is loaded by `loadGatewayClientCertPEM`, the converter stamps it onto every affected `BackendTLSConfig`, and the per-cert transport-pool hash on the proxy evicts the stale transport. The next request to that backend handshakes with the rotated keypair.
 
-Frontend listener `certificateRefs` are not in scope — Cloudflare terminates TLS at the edge, so frontend HTTPS listeners are structurally unsupported (see the HTTPRoute HTTPS Listener limitation).
+Frontend listener `certificateRefs` are not in scope — Cloudflare terminates TLS at the edge, so frontend `protocol: HTTPS` listeners have no in-cluster TLS-termination data plane and are structurally unsupported (see [Gateway Listener Configuration](#gateway-listener-configuration)).
 
 ### RequestMirror filter honours BackendTLSPolicy
 
@@ -255,11 +255,12 @@ Any change to an HTTPRoute or GRPCRoute triggers a full configuration sync to Cl
 1. Controller lists all HTTPRoutes and GRPCRoutes
 2. Filters by GatewayClass
 3. Rebuilds entire ingress configuration
-4. Pushes to Cloudflare API
+4. Pushes hostname/edge routing to the Cloudflare API (one GET + one PUT)
+5. Pushes the rebuilt L7 routing config to every in-process proxy replica (the primary v3 data-plane mechanism)
 
 ### Implications
 
-- More API calls than incremental updates
+- Every change triggers a full desired-state rebuild, but the controller diffs the result and makes a single Cloudflare API update (one GET + one PUT) regardless of how many routes changed
 - Brief delay when many routes are present
 - All routes are re-evaluated on any change
 
@@ -305,9 +306,9 @@ rules:
 
 Route B's `/api/v2` matches first (longer path), then Route A's `/api` matches remaining traffic.
 
-## No Multi-Cluster Support
+## No Native Multi-Cluster Discovery
 
-The controller only routes to Services within the same Kubernetes cluster. Cross-cluster routing is not supported.
+The controller performs no direct peer-cluster discovery or mesh-style cross-cluster routing on its own. It does not connect clusters together or watch endpoints in remote clusters. Cross-cluster backends ARE reachable, however, through the Multi-Cluster Services (MCS) API: a `backendRef` targeting a `ServiceImport` (`multicluster.x-k8s.io`) resolves to the `clusterset.local` DNS plane, so the cluster's own MCS implementation routes to the imported remote endpoints (see [Non-Service backend kinds](#non-service-backend-kinds)).
 
 ### Workaround
 

--- a/docs/gateway-api/listenerset.md
+++ b/docs/gateway-api/listenerset.md
@@ -1,6 +1,6 @@
 # ListenerSet
 
-`ListenerSet` (`gateway.networking.k8s.io/v1`, Standard channel as of v1.5.1) lets a separate resource attach additional listeners to an existing Gateway without modifying the Gateway itself. The typical use case is multi-tenant Gateway management — a platform team owns the Gateway, individual teams own a `ListenerSet` per tenant that contributes hostnames and route-binding rules without ever touching the Gateway spec.
+`ListenerSet` (`gateway.networking.k8s.io/v1`, Standard channel as of v1.5.0) lets a separate resource attach additional listeners to an existing Gateway without modifying the Gateway itself. The typical use case is multi-tenant Gateway management — a platform team owns the Gateway, individual teams own a `ListenerSet` per tenant that contributes hostnames and route-binding rules without ever touching the Gateway spec.
 
 ## Quick example
 
@@ -86,7 +86,7 @@ The route's effective hostname is the parent listener's `team-a.example.com` (in
 A `ListenerSet` is successfully attached to a Gateway when:
 
 1. The parent Gateway's `spec.allowedListeners.namespaces.from` permits the ListenerSet's namespace (`Same`, `All`, `Selector`, or unset/`None` to reject).
-2. The ListenerSet has `Accepted: True` on its status — at least one of its listener entries is conflict-free.
+2. The ListenerSet has `Accepted: True` on its status — at least one of its listener entries is conflict-free AND has its TLS cert refs resolved (`ResolvedRefs: True`, or it carries no TLS material).
 
 The Gateway's `status.attachedListenerSets` field is the count of ListenerSets meeting both criteria.
 
@@ -100,7 +100,7 @@ Per Gateway API spec the effective listener list is concatenated as follows:
 
 When two listeners share the same `(port, hostname)` tuple, the higher-precedence one wins; the lower-precedence one is marked `Conflicted: true` with reason `HostnameConflict` and `Accepted: false`. When two listeners share a port but disagree on `protocol`, the same precedence applies with reason `ProtocolConflict`. Gateway listeners always win conflicts against ListenerSets.
 
-A ListenerSet with at least one conflict-free listener still surfaces `Accepted: true` overall; only the individual conflicting entries are rejected. A ListenerSet whose every listener conflicts gets `Accepted: false / ListenersNotValid`.
+A ListenerSet with at least one conflict-free, fully-resolved (`ResolvedRefs: True`) listener still surfaces `Accepted: true` overall; only the individual conflicting or unresolved entries are rejected. A ListenerSet whose every listener conflicts (or has unresolved refs) gets `Accepted: false / ListenersNotValid`.
 
 ## ReferenceGrant scoping
 

--- a/docs/gateway-api/referencegrant.md
+++ b/docs/gateway-api/referencegrant.md
@@ -105,7 +105,7 @@ spec:
 
 !!! warning "Wildcard Not Supported"
 
-    The Gateway API does not support wildcards in `namespace`. You must create individual entries for each namespace, or create the ReferenceGrant in each source namespace.
+    The Gateway API does not support wildcards in `namespace`. You must create individual `from[]` entries for each source namespace in a single ReferenceGrant that resides in the target namespace (where the Service is).
 
 ## Allow Specific Service
 
@@ -207,7 +207,7 @@ status:
         - type: ResolvedRefs
           status: "False"
           reason: RefNotPermitted
-          message: "Cross-namespace reference not permitted by ReferenceGrant"
+          message: "cross-namespace reference not permitted by ReferenceGrant"
 ```
 
 ## Checking ReferenceGrants

--- a/docs/gateway-api/supported-resources.md
+++ b/docs/gateway-api/supported-resources.md
@@ -177,12 +177,13 @@ All matching is performed by the in-process L7 proxy:
 
 ## gRPC Method Matching
 
-gRPC methods are mapped to HTTP/2 paths using the standard format `/package.Service/Method`.
+gRPC methods are mapped to HTTP/2 paths using the standard format `/package.Service/Method`. All matching happens inside the in-process L7 proxy (see the [GRPCRoute](#grpcroute) table above for the same mapping in the route context).
 
-| Match Type | Example | Cloudflare Rule |
+| Match Type | Example | Proxy path rule |
 | --- | --- | --- |
-| Service only | `service: mypackage.MyService` | `/mypackage.MyService/*` |
-| Service + Method | `service: mypackage.MyService, method: GetUser` | `/mypackage.MyService/GetUser` |
+| Service only | `service: mypackage.MyService` | prefix `/mypackage.MyService/` |
+| Service + Method | `service: mypackage.MyService, method: GetUser` | exact `/mypackage.MyService/GetUser` |
+| Method only | `method: GetUser` | regex `/[^/]+/GetUser` (any service) |
 | No match | (empty) | Matches all gRPC traffic |
 
 ## Weight and Traffic Splitting
@@ -192,9 +193,9 @@ True weighted traffic splitting across multiple backends is performed by the in-
 - **Default weight**: `1` (per Gateway API specification)
 - **Zero weight**: Backends with `weight: 0` are disabled
 
-!!! danger "A failed backend ref clears the whole rule"
+!!! warning "An invalid backend ref fails its own traffic fraction"
 
-    If any backend ref in a rule fails validation — cross-namespace denial (`RefNotPermitted`), a missing Service (`BackendNotFound`), or an unsupported kind/port — that rule's backends are all cleared so the proxy returns HTTP 500 (no backend), and the route status shows `ResolvedRefs=False`. Sibling rules with valid backends are unaffected. Weighting is not failover: valid backends within a rule share traffic in proportion to their weights, but one invalid ref fails the entire rule closed rather than silently shifting its traffic to the others.
+    If a backend ref in a rule fails validation — cross-namespace denial (`RefNotPermitted`), a missing Service (`BackendNotFound`), or an unsupported kind/port — it stays in the weighted pool and the proxy returns HTTP 500 for its traffic fraction only; the other backends in the same rule keep serving their proportional share. The route status shows `ResolvedRefs=False`. Weighting is not failover: an invalid ref fails closed for its fraction rather than silently shifting that traffic to the healthy backends. Only when *every* backend in a rule is unavailable (or all carry `weight: 0`) does the rule return 500 for all of its traffic. A `weight: 0` invalid ref carries no traffic, so it is dropped rather than marked. See [Unavailable backends return a status, not a dial error](limitations.md#unavailable-backends-return-a-status-not-a-dial-error).
 
 ## Status Conditions
 
@@ -203,6 +204,7 @@ True weighted traffic splitting across multiple backends is performed by the in-
 | Type | Status | Reason | Description |
 | --- | --- | --- | --- |
 | `Accepted` | `True` | `Accepted` | Gateway accepted by controller |
+| `Accepted` | `False` | `ListenersNotValid` | One or more of the Gateway's own listeners conflict (carry `Conflicted=True`) |
 | `Programmed` | `True` | `Programmed` | Gateway configured in Cloudflare |
 
 ### Gateway Listener Conditions
@@ -210,8 +212,11 @@ True weighted traffic splitting across multiple backends is performed by the in-
 | Type | Status | Reason | Description |
 | --- | --- | --- | --- |
 | `Accepted` | `True` | `Accepted` | Listener accepted |
+| `Accepted` | `False` | `HostnameConflict` / `ProtocolConflict` | Listener conflicts with a higher-precedence listener on the same port |
 | `Programmed` | `True` | `Programmed` | Listener programmed |
 | `Programmed` | `False` | `Invalid` | Listener has unresolved references |
+| `Programmed` | `False` | `HostnameConflict` / `ProtocolConflict` | Listener conflicts with a higher-precedence listener |
+| `Conflicted` | `True` | `HostnameConflict` / `ProtocolConflict` | Listener clashes with another listener on hostname (same port + hostname) or protocol (different protocol on the same port) |
 | `ResolvedRefs` | `True` | `ResolvedRefs` | References resolved |
 | `ResolvedRefs` | `False` | `InvalidCertificateRef` | TLS certificate reference invalid |
 | `ResolvedRefs` | `False` | `RefNotPermitted` | Cross-namespace TLS ref denied by ReferenceGrant |
@@ -225,6 +230,7 @@ True weighted traffic splitting across multiple backends is performed by the in-
 | `Accepted` | `False` | `NoMatchingParent` | No matching listener found |
 | `Accepted` | `False` | `NoMatchingListenerHostname` | Route hostnames don't intersect with listener |
 | `Accepted` | `False` | `NotAllowedByListeners` | Route namespace or kind not allowed by listener |
+| `Accepted` | `False` | `Conflicted` | Route lost a cross-route-type conflict (HTTPRoute vs GRPCRoute on a shared Gateway with intersecting hostnames); the oldest Route by `creationTimestamp` is accepted |
 | `ResolvedRefs` | `True` | `ResolvedRefs` | Backend references resolved |
 | `ResolvedRefs` | `False` | `RefNotPermitted` | Cross-namespace reference denied |
 | `ResolvedRefs` | `False` | `BackendNotFound` | Backend Service not found |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -120,7 +120,7 @@ helm uninstall cloudflare-tunnel-gateway-controller \
 
 !!! warning "Cleanup"
 
-    Uninstalling the Helm release will remove the controller and cloudflared pods. The tunnel configuration in Cloudflare will remain. To fully clean up, delete the tunnel from the Cloudflare dashboard.
+    Uninstalling the Helm release will remove the controller and proxy pods. The tunnel configuration in Cloudflare will remain. To fully clean up, delete the tunnel from the Cloudflare dashboard.
 
 ## Alternative: External Secrets
 

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -18,11 +18,11 @@ The controller requires Gateway API Custom Resource Definitions (CRDs) to be ins
 kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 ```
 
-!!! warning "v1.5.1 is the minimum supported version"
+!!! warning "v1.5.0 is the minimum supported version"
 
-    The controller watches `ListenerSet` resources as part of its core reconcile loop. The `listenersets.gateway.networking.k8s.io` CRD entered the **Standard** channel in Gateway API v1.5.1. Installing the controller against an older Gateway API bundle (including v1.5.0) leaves the manager unable to start because the watch target is missing.
+    The controller watches `ListenerSet` resources as part of its core reconcile loop. The `listenersets.gateway.networking.k8s.io` CRD entered the **Standard** channel in Gateway API v1.5.0. Installing the controller against an older Gateway API bundle (v1.4.x or earlier) leaves the manager unable to start because the watch target is missing. The controller is built and tested against v1.5.1, which is the recommended bundle.
 
-    If you previously installed v1.5.0, apply the v1.5.1 standard bundle before upgrading this controller.
+    If you are on an older Gateway API bundle, apply the v1.5.1 standard bundle before installing this controller.
 
 ## Cloudflare Account
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -66,7 +66,7 @@ The controller sets the Gateway address to `TUNNEL_ID.cfargotunnel.com`. Create 
 
 !!! tip "External-DNS"
 
-    If you have [external-dns](https://external-dns.io/) configured with Gateway API source, DNS records are created automatically. See [External-DNS Integration](../guides/external-dns.md) for setup.
+    If you have [external-dns](https://github.com/kubernetes-sigs/external-dns) configured with Gateway API source, DNS records are created automatically. See [External-DNS Integration](../guides/external-dns.md) for setup.
 
 ## Access Your Application
 
@@ -136,7 +136,7 @@ spec:
 
 ## Advanced Routing
 
-When the L7 proxy is enabled, HTTPRoute gains full Gateway API matching and filter support. Below are short examples of the most common patterns.
+The in-process L7 proxy is the only data plane in v3, so full Gateway API matching and filter support is always available. Below are short examples of the most common patterns.
 
 ### Header-Based Routing
 
@@ -211,9 +211,9 @@ spec:
             statusCode: 301
 ```
 
-!!! tip "Enable the proxy first"
+!!! tip "L7 proxy configuration"
 
-    These features require the L7 proxy. See the [L7 Proxy Guide](../guides/l7-proxy.md) for installation instructions.
+    These features are served by the always-on in-process L7 proxy. See the [L7 Proxy Guide](../guides/l7-proxy.md) for proxy configuration options and tuning.
 
 ## Troubleshooting
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -9,6 +9,40 @@ Ensure you have completed:
 - [Prerequisites](prerequisites.md) - Cloudflare Tunnel and API token created
 - [Installation](installation.md) - Controller installed and running
 
+## Create a Gateway
+
+The chart installs the `cloudflare-tunnel` GatewayClass, but you create the Gateway that HTTPRoutes attach to. Create one in the controller namespace:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cloudflare-tunnel
+  namespace: cloudflare-tunnel-system
+spec:
+  gatewayClassName: cloudflare-tunnel
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+```
+
+Apply it:
+
+```bash
+kubectl apply --filename gateway.yaml
+```
+
+Cloudflare terminates TLS at its edge, so the listener carries no `certificateRefs` — the `port`/`protocol` are accepted for route binding but the actual TLS is handled by Cloudflare. Once the controller reconciles it, the Gateway's status address is set to `<tunnel-id>.cfargotunnel.com`:
+
+```bash
+kubectl get gateway cloudflare-tunnel --namespace cloudflare-tunnel-system \
+  --output jsonpath='{.status.addresses[*].value}'
+```
+
 ## Deploy a Sample Application
 
 First, deploy a simple application to expose:

--- a/docs/guides/cross-namespace.md
+++ b/docs/guides/cross-namespace.md
@@ -282,11 +282,13 @@ kubectl get service api-service --namespace backend
 
 If using NetworkPolicy, ensure traffic is allowed between namespaces:
 
+In v3 all backend traffic originates from the in-process proxy pod, which runs in the controller release namespace (for example `cloudflare-tunnel-system`). There is no separate cloudflared pod. Select that pod precisely with a compound `namespaceSelector` + `podSelector`:
+
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-from-cloudflared
+  name: allow-from-gateway-proxy
   namespace: backend
 spec:
   podSelector: {}
@@ -295,4 +297,7 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: cloudflare-tunnel-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: proxy
 ```

--- a/docs/guides/external-dns.md
+++ b/docs/guides/external-dns.md
@@ -95,20 +95,25 @@ sequenceDiagram
     participant ExtDNS as external-dns
     participant CF as Cloudflare
 
+    User->>K8s: Create Gateway
+    K8s->>Ctrl: Watch event (GatewayReconciler)
+    Ctrl->>K8s: Set Gateway status.addresses to tunnel CNAME
     User->>K8s: Create HTTPRoute
-    K8s->>Ctrl: Watch event
+    K8s->>Ctrl: Watch event (RouteReconciler)
     Ctrl->>CF: Update tunnel config
-    Ctrl->>K8s: Update Gateway status.addresses
+    Ctrl->>K8s: Update HTTPRoute status
     K8s->>ExtDNS: Watch Gateway/HTTPRoute
     ExtDNS->>CF: Create DNS CNAME record
     Note over CF: app.example.com → TUNNEL_ID.cfargotunnel.com
 ```
 
-1. User creates HTTPRoute with hostnames
-2. Controller updates tunnel configuration in Cloudflare
-3. Controller sets Gateway `status.addresses` to tunnel CNAME
-4. external-dns watches Gateway and HTTPRoute
-5. external-dns creates CNAME record pointing to tunnel
+The two controller writes come from separate reconcilers. `GatewayReconciler` sets `status.addresses` when the Gateway is first accepted, while the route reconcilers update the Cloudflare tunnel config and route status when an HTTPRoute or GRPCRoute changes. Creating an HTTPRoute re-enqueues the Gateway only to refresh `AttachedRoutes` and listener conditions, not to set `status.addresses` for the first time.
+
+1. User creates a Gateway; the controller sets Gateway `status.addresses` to the tunnel CNAME once the Gateway is accepted
+2. User creates an HTTPRoute with hostnames
+3. Controller updates the tunnel configuration in Cloudflare and the HTTPRoute status
+4. external-dns watches the Gateway and HTTPRoute
+5. external-dns creates a CNAME record pointing to the tunnel
 
 ## Verifying DNS Records
 
@@ -186,6 +191,10 @@ extraArgs:
 
 ## Example: Complete Setup
 
+!!! note "external-dns version"
+
+    Use external-dns `v0.21.0` or later. The controller stores Gateway, HTTPRoute, and GRPCRoute resources under the stable `gateway.networking.k8s.io/v1` API. external-dns migrated its Gateway API sources to `v1` in `v0.21.0`; older releases query `v1alpha2` and find no routes. This matches the minimum version cited in the [ListenerSet guide](../gateway-api/listenerset.md).
+
 ```yaml
 ---
 # external-dns deployment
@@ -205,7 +214,7 @@ spec:
     spec:
       containers:
         - name: external-dns
-          image: registry.k8s.io/external-dns/external-dns:v0.14.0
+          image: registry.k8s.io/external-dns/external-dns:v0.21.0
           args:
             - --source=gateway-httproute
             - --source=gateway-grpcroute

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -26,7 +26,7 @@ This section contains step-by-step guides for common integration scenarios and a
 
     ---
 
-    Enable the L7 reverse proxy for full HTTPRoute support including header matching, traffic splitting, and request filters.
+    Configure the built-in L7 reverse proxy for full HTTPRoute support including header matching, traffic splitting, and request filters.
 
     [:octicons-arrow-right-24: L7 Proxy](l7-proxy.md)
 
@@ -52,7 +52,7 @@ Before following these guides, ensure you have:
 
 | Use Case | Recommended Guide |
 |----------|-------------------|
-| Full HTTPRoute matching and filters | [L7 Proxy](l7-proxy.md) |
+| L7 proxy configuration and tuning | [L7 Proxy](l7-proxy.md) |
 | Automatic DNS record creation | [External-DNS](external-dns.md) |
 | Multi-namespace service mesh | [Cross-Namespace Routing](cross-namespace.md) |
 | Production observability | [Monitoring](monitoring.md) |

--- a/docs/guides/l7-proxy.md
+++ b/docs/guides/l7-proxy.md
@@ -156,7 +156,9 @@ spec:
 
 ## Monitoring
 
-The proxy exposes Prometheus metrics on the config API port. Enable the ServiceMonitor to scrape them automatically:
+The proxy does not expose a Prometheus `/metrics` endpoint — its config API serves only `GET /config`, `PUT /config`, `GET /healthz`, and `GET /readyz`. Prometheus metrics are emitted by the controller, which exposes `/metrics` on its dedicated metrics port (via controller-runtime).
+
+Setting `serviceMonitor.enabled: true` renders two ServiceMonitors: one targeting the controller's `metrics` port (the real Prometheus endpoint) and one targeting the proxy's `config-api` port (health and config API only — there is nothing to scrape there yet):
 
 ```yaml
 serviceMonitor:

--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -58,6 +58,23 @@ spec:
 | `controller_runtime_max_concurrent_reconciles` | Gauge | Max concurrent reconciles |
 | `controller_runtime_active_workers` | Gauge | Current active workers |
 
+### Custom Controller Metrics
+
+These `cftunnel_*` metrics are emitted by the controller itself on the same `/metrics` endpoint (port 8080).
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `cftunnel_sync_duration_seconds` | Histogram | Duration of route synchronization to Cloudflare (labelled by `status`) |
+| `cftunnel_synced_routes` | Gauge | Number of routes synced (labelled by `type`) |
+| `cftunnel_ingress_rules` | Gauge | Total ingress rules in tunnel config |
+| `cftunnel_failed_backend_refs` | Gauge | Number of failed backend references (labelled by `type`) |
+| `cftunnel_sync_errors_total` | Counter | Total sync errors (labelled by `error_type`) |
+| `cftunnel_cloudflare_api_duration_seconds` | Histogram | Duration of Cloudflare API calls (labelled by `method`, `resource`) |
+| `cftunnel_cloudflare_api_calls_total` | Counter | Total Cloudflare API calls (labelled by `method`, `resource`, `status`) |
+| `cftunnel_cloudflare_api_errors_total` | Counter | Total Cloudflare API errors (labelled by `method`, `error_type`) |
+| `cftunnel_ingress_build_duration_seconds` | Histogram | Duration of ingress rule building (labelled by `type`) |
+| `cftunnel_backend_ref_validation_total` | Counter | Backend reference validation results (labelled by `type`, `result`, `reason`) |
+
 ### Workqueue Metrics
 
 | Metric | Type | Description |

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,17 +38,27 @@ See the [L7 Proxy Guide](guides/l7-proxy.md) for setup and examples.
 
 ```bash
 # 1. Install Gateway API CRDs
-kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 
-# 2. Install the controller
+# 2. Create the credentials and tunnel-token Secrets
+kubectl create namespace cloudflare-tunnel-system
+kubectl create secret generic cloudflare-credentials \
+  --namespace cloudflare-tunnel-system \
+  --from-literal=api-token="YOUR_API_TOKEN"
+kubectl create secret generic cloudflare-tunnel-token \
+  --namespace cloudflare-tunnel-system \
+  --from-literal=tunnel-token="YOUR_TUNNEL_TOKEN"
+
+# 3. Install the controller
 helm install cloudflare-tunnel-gateway-controller \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel-gateway-controller \
   --namespace cloudflare-tunnel-system \
-  --create-namespace \
-  --set config.tunnelID=YOUR_TUNNEL_ID \
-  --set config.apiToken=YOUR_API_TOKEN
+  --set gatewayClassConfig.create=true \
+  --set gatewayClassConfig.tunnelID=YOUR_TUNNEL_ID \
+  --set gatewayClassConfig.cloudflareCredentialsSecretRef.name=cloudflare-credentials \
+  --set proxy.tunnelTokenSecretRef.name=cloudflare-tunnel-token
 
-# 3. Create HTTPRoute to expose your service
+# 4. Create HTTPRoute to expose your service
 kubectl apply --filename - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -67,7 +77,7 @@ spec:
 EOF
 ```
 
-See [Getting Started](getting-started/index.md) for detailed setup instructions.
+See [Getting Started](getting-started/index.md) for detailed setup instructions, including full Secret creation and `gatewayClassConfig` reference.
 
 ## Documentation Sections
 

--- a/docs/operations/access-logging.md
+++ b/docs/operations/access-logging.md
@@ -4,7 +4,7 @@ The in-process L7 proxy can emit a structured access log for every request it ro
 
 ## Why
 
-Without access logging, diagnosing incidents that flow through Cloudflare Tunnel is a black box from inside the cluster: the proxy emits warnings about config churn and connection errors, but there is no per-request record of who saw what status. Cluster log aggregators end up with cloudflared's edge-side logs only, which lack the post-routing context (matched hostname, observed status, response size).
+Without access logging, diagnosing incidents that flow through Cloudflare Tunnel is a black box from inside the cluster: the proxy emits warnings about config churn and connection errors, but there is no per-request record of who saw what status. Cluster log aggregators end up with cloudflared's tunnel/connection logs only, which lack the post-routing context (matched hostname, observed status, response size).
 
 When enabled, the proxy emits one JSON line per request via the same stdout `slog` sink the controller already uses, so existing cluster logging pipelines pick it up without additional wiring.
 
@@ -90,7 +90,7 @@ Mitigations:
 ## What is NOT logged
 
 - **WebSocket upgrades (`101 Switching Protocols`).** `pipeWebSocket` writes the 101 status BEFORE hijacking the conn, so the wrapper records `status=101`; the access-log emission is then suppressed for that status. Without the skip, every WS upgrade would produce a log line whose `duration_ms` equals the entire WS session lifetime (because the deferred emission runs after the bidirectional copy goroutines exit) and `bytes_written=0` (post-Hijack bytes bypass the wrapper). Both signals would mislead triage. The WS upgrade path emits its own diagnostics.
-- **Headers** beyond `User-Agent`. Per-route filters (`HTTPRoute.spec.rules[].filters[].requestHeaderModifier`) are not summarised. If you need that level of detail, add a `responseHeaderModifier` to inject the desired headers into the response, which the access log will then record on the client-visible side.
+- **Headers** beyond `User-Agent`. Per-route filters (`HTTPRoute.spec.rules[].filters[].requestHeaderModifier`) are not summarised. The access log emits a fixed set of fields and never reads request or response headers other than `User-Agent`. If you need deeper per-request inspection (e.g. which header values the proxy added or removed), use distributed tracing (see the tracing page) or structured sidecar logging of the backend responses.
 - **Request bodies.** Streaming and large uploads make body logging both expensive and a privacy hazard.
 - **Backend URL** the proxy forwarded to. The router decision context isn't visible to the deferred log emission today; a future enhancement can plumb a `route_id` once the router exposes a stable identifier.
 

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -38,6 +38,22 @@ Operating the controller effectively requires understanding:
 
     [:octicons-arrow-right-24: Manual Installation](manual-installation.md)
 
+-   :material-text-box-outline:{ .lg .middle } **Access Logging**
+
+    ---
+
+    Structured per-request access logs from the in-process L7 proxy.
+
+    [:octicons-arrow-right-24: Access Logging](access-logging.md)
+
+-   :material-transit-connection-variant:{ .lg .middle } **Distributed Tracing**
+
+    ---
+
+    OpenTelemetry tracing for the controller and proxy.
+
+    [:octicons-arrow-right-24: Distributed Tracing](tracing.md)
+
 </div>
 
 ## Quick Diagnostics
@@ -65,4 +81,4 @@ kubectl get httproute --all-namespaces \
 - [ ] Prometheus ServiceMonitor deployed
 - [ ] Alerting rules configured
 - [ ] Log aggregation set up
-- [ ] Backup strategy for GatewayClassConfig secrets
+- [ ] Backup strategy for proxy tunnel-token Secret and (if used) GatewayClassConfig credentials Secret

--- a/docs/operations/manual-installation.md
+++ b/docs/operations/manual-installation.md
@@ -15,7 +15,7 @@
 ### 1. Install Gateway API CRDs
 
 ```bash
-kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 ```
 
 ### 2. Create Namespace
@@ -45,6 +45,10 @@ kubectl apply --filename deploy/rbac/
 kubectl apply --filename deploy/controller/
 ```
 
+!!! danger "Manual manifests ship the controller only — the L7 proxy is not included"
+
+    Under v3 the in-process L7 proxy is the only data plane, and the controller pushes routing config to it at the `--proxy-endpoints` URL. The `deploy/` manifests intentionally ship only the controller (and the RBAC it needs); they do NOT include the proxy Deployment, Services, or config. Without the proxy running, no HTTPRoute or GRPCRoute takes effect and all traffic is silently non-functional — even though step 3 created the `cloudflare-tunnel-token` Secret. Use the [Helm chart](../getting-started/installation.md) for a complete, working v3 installation, or supply your own proxy Deployment that consumes the tunnel token and serves the config API at the `--proxy-endpoints` URL.
+
 ### 5. Create GatewayClassConfig, GatewayClass, and Gateway
 
 Edit `deploy/samples/gatewayclassconfig.yaml` with your tunnel ID:
@@ -62,9 +66,9 @@ The `deploy/` directory contains:
 ```text
 deploy/
 ├── rbac/
-│   ├── serviceaccount.yaml
-│   ├── clusterrole.yaml
-│   └── clusterrolebinding.yaml
+│   ├── service_account.yaml
+│   ├── role.yaml
+│   └── role_binding.yaml
 ├── controller/
 │   └── deployment.yaml
 └── samples/
@@ -88,7 +92,7 @@ spec:
   # accountId: "1234567890abcdef"  # Optional, auto-detected
 ```
 
-The tunnel token is consumed by the L7 proxy pod directly (via the `TUNNEL_TOKEN` env var wired by the Helm chart's `proxy.tunnelTokenSecretRef` value) — it is not part of the CRD spec.
+The tunnel token is passed to the L7 proxy pod as the `TUNNEL_TOKEN` environment variable. In the Helm chart this is wired via `proxy.tunnelTokenSecretRef`; for a manual proxy deployment, expose the `cloudflare-tunnel-token` Secret to the proxy container the same way. The token is not part of the GatewayClassConfig CRD spec.
 
 ## Sample GatewayClass
 
@@ -116,9 +120,13 @@ metadata:
 spec:
   gatewayClassName: cloudflare-tunnel
   listeners:
-    - name: http
-      port: 80
-      protocol: HTTP
+    - name: https
+      port: 443
+      protocol: HTTPS
+      # Allow HTTPRoutes from all namespaces
+      allowedRoutes:
+        namespaces:
+          from: All
 ```
 
 ## Upgrading

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -41,22 +41,6 @@ Track Cloudflare API interactions for performance and reliability monitoring.
 - `status`: `success`, `error`
 - `error_type`: `auth`, `rate_limit`, `timeout`, `server_error`, `network`
 
-### Helm Operations Metrics
-
-When cloudflared is managed by the controller via Helm.
-
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `cftunnel_helm_operation_duration_seconds` | Histogram | `operation` | Helm operation latency |
-| `cftunnel_helm_operations_total` | Counter | `operation`, `status` | Helm operations count |
-| `cftunnel_helm_errors_total` | Counter | `operation`, `error_type` | Helm errors |
-| `cftunnel_helm_chart_info` | Gauge | `chart`, `version`, `app_version` | Deployed chart version info |
-
-**Label values:**
-
-- `operation`: `install`, `upgrade`, `uninstall`, `get_version`, `load_chart`
-- `status`: `success`, `error`
-
 ### Ingress Builder Metrics
 
 Track the conversion of Gateway API routes to Cloudflare ingress rules.
@@ -185,20 +169,6 @@ histogram_quantile(0.99,
 
 # API errors by type
 sum(rate(cftunnel_cloudflare_api_errors_total[5m])) by (method, error_type)
-```
-
-### Helm Operations
-
-```promql
-# Helm operation success rate
-sum(rate(cftunnel_helm_operations_total{status="success"}[5m])) by (operation)
-/
-sum(rate(cftunnel_helm_operations_total[5m])) by (operation)
-
-# Helm operation latency P95
-histogram_quantile(0.95,
-  sum(rate(cftunnel_helm_operation_duration_seconds_bucket[5m])) by (le, operation)
-)
 ```
 
 ### Reconciliation Rate

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -27,10 +27,10 @@ kubectl get httproute --all-namespaces
 
 **Common causes**:
 
-1. Empty or invalid `tunnelID`:
+1. Empty `tunnelID`:
 
     ```text
-    Error: at '/gatewayClassConfig/tunnelID': minLength: got 0, want 1
+    Error: execution error at (...gatewayclassconfig.yaml:20:16): gatewayClassConfig.tunnelID is required
     ```
 
     **Solution**: Provide a valid Tunnel ID from Cloudflare Zero Trust Dashboard
@@ -41,15 +41,23 @@ kubectl get httproute --all-namespaces
     Error: at '/gatewayClassConfig/tunnelID': pattern mismatch
     ```
 
-    **Solution**: Use only alphanumeric characters and hyphens
+    **Solution**: Use a valid UUID from the Cloudflare Zero Trust Dashboard (format: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` with lowercase hex digits a-f and 0-9 only)
 
 3. Missing API credentials:
 
     ```text
-    Error: cloudflareCredentialsSecretRef.name is required
+    Error: execution error at (...gatewayclassconfig.yaml:10:12): gatewayClassConfig.cloudflareCredentialsSecretRef.name is required
     ```
 
     **Solution**: Set `gatewayClassConfig.cloudflareCredentialsSecretRef.name` to the name of a Secret containing an `api-token` key
+
+4. Missing proxy tunnel token:
+
+    ```text
+    Error: execution error at (...deployment-proxy.yaml:41:18): proxy.tunnelTokenSecretRef.name is required
+    ```
+
+    **Solution**: Set `proxy.tunnelTokenSecretRef.name` to the name of a Secret containing a `tunnel-token` key (see Getting Started / Prerequisites). This field is required on every install, before any `gatewayClassConfig.*` value.
 
 **Verification**:
 
@@ -129,7 +137,7 @@ curl --header "Authorization: Bearer $CF_API_TOKEN" \
 **Solution**:
 
 1. Create new API token with required scopes:
-   - Account.Cloudflare Tunnel:Edit
+   - Account > Cloudflare Tunnel > Edit
 
 2. Update secret:
 

--- a/docs/reference/crd-reference.md
+++ b/docs/reference/crd-reference.md
@@ -1,6 +1,6 @@
 # CRD Reference
 
-This document provides the API reference for Custom Resource Definitions (CRDs) used by the Cloudflare Tunnel Gateway Controller.
+This document provides the API reference for Custom Resource Definitions (CRDs) used by the Cloudflare Tunnel Gateway Controller. The controller ships two project-owned CRDs, `GatewayClassConfig` and `ExternalBackend`, and watches the standard Gateway API resources.
 
 ## GatewayClassConfig
 
@@ -14,15 +14,16 @@ Starting v3 the spec carries only the contract the controller needs for Cloudfla
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `tunnelID` | string | Yes | Cloudflare Tunnel UUID |
-| `accountId` | string | No | Cloudflare Account ID (auto-detected if not specified) |
-| `cloudflareCredentialsSecretRef` | SecretKeySelector | Yes | Reference to Secret containing API token |
+| `tunnelID` | string | Yes | Cloudflare Tunnel UUID. Must match the pattern `^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$` |
+| `accountId` | string | No | Cloudflare Account ID. If unset, it is read from the `account-id` key in the credentials Secret; if that key is also absent, it is auto-detected from the Cloudflare API when the token has access to a single account. When set, it must be a 32-character lowercase hexadecimal string (validated by a CRD-level CEL rule) |
+| `cloudflareCredentialsSecretRef` | SecretReference | Yes | Reference to the Secret containing the Cloudflare API token |
 
-### SecretKeySelector
+### SecretReference
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `name` | string | - | Secret name |
+| `name` | string | - | Secret name (required) |
+| `namespace` | string | controller namespace | Namespace of the Secret. Defaults to the controller's own namespace; set it to place the Secret in a different namespace |
 | `key` | string | `api-token` | Key within the Secret |
 
 ### Example
@@ -34,7 +35,7 @@ metadata:
   name: cloudflare-tunnel-config
 spec:
   tunnelID: "550e8400-e29b-41d4-a716-446655440000"
-  # accountId: "1234567890abcdef"  # Optional, auto-detected
+  # accountId: "0123456789abcdef0123456789abcdef"  # Optional 32-char hex; auto-detected if omitted
   cloudflareCredentialsSecretRef:
     name: cloudflare-credentials
     key: api-token
@@ -46,6 +47,36 @@ GatewayClassConfig has a `status.conditions` subresource. The reconciler emits:
 
 - `SecretsResolved` — `True` when the referenced credentials Secret exists and carries the expected key, `False` otherwise.
 - `Valid` — `True` when all validation checks pass; `False` with the first failure message otherwise.
+
+## ExternalBackend
+
+**API Version**: `cf.k8s.lex.la/v1alpha1` **Kind**: `ExternalBackend` **Scope**: Namespaced
+
+ExternalBackend defines an out-of-cluster HTTP(S) endpoint that an HTTPRoute or GRPCRoute may target as a `backendRef`. The in-process L7 proxy ultimately dials a URL, so a route can point at an arbitrary external origin without a Service standing in for it. Unlike a Service of type `ExternalName` (which only carries a DNS name and infers the scheme from the port), ExternalBackend makes the scheme explicit and lets the host be an address that is not a valid Service name. It is a spec-only resource (no status): a route referencing a missing or malformed ExternalBackend surfaces the failure on the route's own `ResolvedRefs` condition, mirroring how an unresolvable Service backendRef is reported. See [ExternalBackend](../gateway-api/external-backend.md) for usage details.
+
+### ExternalBackend Spec
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `scheme` | string | Yes | Protocol used to dial the backend: `http` or `https` |
+| `host` | string | Yes | Backend hostname or IP address (no scheme, port, or path). IPv6 literals must be bracketed, e.g. `[2001:db8::1]` |
+| `port` | integer | Yes | Backend TCP port (1-65535) |
+| `path` | string | No | Optional base path prepended to the request path; must begin with `/`. May include a query string whose parameters merge into every dialed request (the request's own parameters win on a key conflict) |
+
+### ExternalBackend Example
+
+```yaml
+apiVersion: cf.k8s.lex.la/v1alpha1
+kind: ExternalBackend
+metadata:
+  name: external-api
+  namespace: default
+spec:
+  scheme: https
+  host: api.example.com
+  port: 443
+  path: /v1
+```
 
 ## Gateway API Resources
 
@@ -159,7 +190,10 @@ spec:
 | Condition | Status | Reason | Description |
 |-----------|--------|--------|-------------|
 | `Accepted` | `True` | `Accepted` | Gateway accepted by controller |
+| `Accepted` | `False` | `ListenersNotValid` | Gateway has conflicted own listeners (one or more own listeners carry `Conflicted: True`); per-listener status reports the conflict |
+| `Accepted` | `False` | `InvalidParameters` | GatewayClassConfig referenced by the GatewayClass cannot be resolved |
 | `Programmed` | `True` | `Programmed` | Gateway configured in Cloudflare |
+| `Programmed` | `False` | `Invalid` | GatewayClassConfig referenced by the GatewayClass cannot be resolved |
 
 ### HTTPRoute/GRPCRoute Status
 
@@ -169,8 +203,9 @@ spec:
 | `Accepted` | `False` | `NoMatchingParent` | No listener matched the parentRef's `sectionName` or `port`; also fires when hostname is the failure reason and the parentRef pinned a `sectionName` or `port` |
 | `Accepted` | `False` | `NoMatchingListenerHostname` | Route hostnames do not intersect with any listener hostname (no `sectionName`/`port` pin on the parentRef) |
 | `Accepted` | `False` | `NotAllowedByListeners` | Route namespace or kind not allowed by listener |
-| `Accepted` | `False` | `Pending` | Sync to the Cloudflare Tunnel API failed; reconcile will retry. Proxy-push failures are best-effort: they are logged and counted via the `proxy_push` sync-error metric but do **not** flip `Accepted` to False / Reason=`Pending` |
+| `Accepted` | `False` | `Pending` | Sync to the Cloudflare Tunnel API failed; reconcile will retry. Proxy-push failures are best-effort: they are logged and counted via the `cftunnel_sync_errors_total{error_type="proxy_push"}` counter but do **not** flip `Accepted` to False / Reason=`Pending` |
 | `Accepted` | `False` | `UnsupportedProtocol` | GRPCRoute only: gRPC cannot be served over an explicit `proxy.tunnel.protocol: quic` tunnel (cloudflared drops HTTP trailers over QUIC, losing `grpc-status`). Switch to `http2`, or `auto`/unset which the proxy upgrades to `http2` for gRPC |
+| `Accepted` | `False` | `Conflicted` | An HTTPRoute and a GRPCRoute conflict on the same Gateway with intersecting hostnames; the oldest Route by `creationTimestamp` (ties broken by `{namespace}/{name}`) is accepted and the other is rejected |
 | `ResolvedRefs` | `True` | `ResolvedRefs` | Backend references resolved |
 | `ResolvedRefs` | `False` | `RefNotPermitted` | Cross-namespace reference denied |
 | `ResolvedRefs` | `False` | `BackendNotFound` | Backend Service not found |
@@ -181,6 +216,7 @@ spec:
 | Resource | API Group | Version | Status |
 |----------|-----------|---------|--------|
 | GatewayClassConfig | `cf.k8s.lex.la` | `v1alpha1` | Alpha |
+| ExternalBackend | `cf.k8s.lex.la` | `v1alpha1` | Alpha |
 | GatewayClass | `gateway.networking.k8s.io` | `v1` | GA |
 | Gateway | `gateway.networking.k8s.io` | `v1` | GA |
 | HTTPRoute | `gateway.networking.k8s.io` | `v1` | GA |
@@ -192,10 +228,10 @@ spec:
 ### Gateway API CRDs
 
 ```bash
-kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 ```
 
-### GatewayClassConfig CRD
+### Project CRDs (GatewayClassConfig and ExternalBackend)
 
 Installed automatically by the Helm chart. For manual installation:
 

--- a/docs/reference/helm-chart.md
+++ b/docs/reference/helm-chart.md
@@ -100,7 +100,7 @@ Pin to specific versions in production:
 ```bash
 helm upgrade cloudflare-tunnel-gateway-controller \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel-gateway-controller \
-  --version 0.8.0 \
+  --version 1.0.0 \
   --namespace cloudflare-tunnel-system \
   --values values.yaml
 ```
@@ -114,14 +114,14 @@ helm uninstall cloudflare-tunnel-gateway-controller \
 
 !!! warning "Cleanup"
 
-    Uninstalling the Helm release removes the controller and cloudflared pods. The tunnel configuration in Cloudflare will remain. To fully clean up, delete the tunnel from the Cloudflare dashboard.
+    Uninstalling the Helm release removes the controller and proxy pods. The tunnel configuration in Cloudflare will remain. To fully clean up, delete the tunnel from the Cloudflare dashboard.
 
 ## CRDs
 
-The chart installs the GatewayClassConfig CRD. Gateway API CRDs must be installed separately:
+The chart installs two CRDs: `GatewayClassConfig` and `ExternalBackend`. Gateway API CRDs must be installed separately:
 
 ```bash
-kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+kubectl apply --filename https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 ```
 
 ## Components

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -6,7 +6,8 @@ This document covers the security policy and best practices for the Cloudflare T
 
 | Version | Supported |
 |---------|-----------|
-| 0.x.x | Yes |
+| 3.x.x | Yes |
+| 2.x.x | No |
 
 ## Reporting Vulnerabilities
 
@@ -69,16 +70,20 @@ The controller requires specific Kubernetes permissions:
 rules:
   # Gateway API - read specs
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gatewayclasses", "httproutes", "grpcroutes", "referencegrants", "backendtlspolicies"]
+    resources: ["gatewayclasses", "httproutes", "grpcroutes", "referencegrants", "backendtlspolicies", "listenersets"]
     verbs: ["get", "list", "watch"]
-  # Gateways - finalizers + status patches require update/patch on the parent resource
+  # Gateways - status patches require update/patch on the parent resource
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways"]
     verbs: ["get", "list", "watch", "update", "patch"]
   # Gateway API status subresources - write status
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status", "backendtlspolicies/status"]
+    resources: ["gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status", "backendtlspolicies/status", "listenersets/status"]
     verbs: ["get", "update", "patch"]
+  # ServiceImport - a backendRef may target an imported multicluster Service
+  - apiGroups: ["multicluster.x-k8s.io"]
+    resources: ["serviceimports"]
+    verbs: ["get", "list", "watch"]
 
   # Core API - read only
   - apiGroups: [""]
@@ -87,9 +92,26 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps"]
     verbs: ["get", "list", "watch"]
+  # EndpointSlice - the proxy endpoint reconciler discovers proxy pods so a
+  # newly-joined replica gets the cached config pushed immediately
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+  # Events - route reconcilers emit Events via both the core (v1) and the new
+  # (events.k8s.io/v1) recorders; grant both so neither path is denied
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+  # Deployments - the proxy Secret reconciler patches the proxy Deployment's
+  # pod-template annotation to roll pods when the tunnel-token Secret rotates;
+  # patch only, no create/delete (the chart owns Deployment lifecycle)
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
 
   # GatewayClassConfig CRD
   - apiGroups: ["cf.k8s.lex.la"]
@@ -98,6 +120,10 @@ rules:
   - apiGroups: ["cf.k8s.lex.la"]
     resources: ["gatewayclassconfigs/status"]
     verbs: ["get", "update", "patch"]
+  # ExternalBackend CRD - a backendRef may target an out-of-cluster endpoint
+  - apiGroups: ["cf.k8s.lex.la"]
+    resources: ["externalbackends"]
+    verbs: ["get", "list", "watch"]
 
   # Leader election
   - apiGroups: ["coordination.k8s.io"]
@@ -106,7 +132,7 @@ rules:
 ```
 
 !!! note "v3 RBAC scope"
-    The v3 controller is status-only and reads Secrets/ConfigMaps; it does not create, mutate, or delete workloads. The v2 chart granted cluster-wide write on Pods, Deployments, ReplicaSets and ServiceAccounts for the Helm-SDK code path that managed cloudflared; those rules were removed when that code path was deleted.
+    The v3 controller reads Secrets and ConfigMaps and writes only status subresources; it does not create or delete workloads. The one workload mutation it makes is patching the proxy Deployment's pod-template annotation when the tunnel-token Secret rotates (to trigger a native rolling restart) — it does not manage Deployment lifecycle. The v2 chart additionally granted cluster-wide write on Pods, ReplicaSets and ServiceAccounts for the Helm-SDK code path that managed cloudflared; those rules were removed when that code path was deleted.
 
 ### Container Security
 
@@ -184,7 +210,7 @@ cosign verify ghcr.io/lexfrei/cloudflare-tunnel-gateway-controller:latest \
 ### Helm Chart Verification
 
 ```bash
-helm verify cloudflare-tunnel-gateway-controller-0.1.0.tgz
+helm verify cloudflare-tunnel-gateway-controller-1.0.0.tgz
 ```
 
 ## Secrets in Logs

--- a/docs/upgrading/v2-to-v3.md
+++ b/docs/upgrading/v2-to-v3.md
@@ -59,7 +59,7 @@ v3 collapses the two data plane modes that the v1/v2 chart supported (a separate
     helm uninstall <release-name> --namespace <namespace>
     ```
 
-4. **Make sure the controller deployment passes `--proxy-endpoints`.** The chart wires this unconditionally — only out-of-tree deployments that ran the controller binary directly need to add the flag. The expected value points at the proxy's headless Service (`http://<release>-proxy-headless.<namespace>.svc.<cluster-domain>:<proxy.configAPIPort>/config`).
+4. **Make sure the controller deployment passes `--proxy-endpoints`.** The chart wires this unconditionally — only out-of-tree deployments that ran the controller binary directly need to add the flag. The expected value points at the proxy's headless Service (`http://<fullname>-proxy-headless.<namespace>.svc.<cluster-domain>:<proxy.configAPIPort>/config`), where `<fullname>` is the Helm release fullname (typically `<release>-cloudflare-tunnel-gateway-controller`, or just `<release>` when the release name already contains the chart name). To read the exact name your release rendered, run `helm get manifest <release> | grep -m1 'proxy-headless'`.
 
 5. **No data migration is required for CRs.** The Kubernetes API server prunes unknown fields when you apply the new CRD schema (the v3 CRD does not set `x-kubernetes-preserve-unknown-fields: true`, so apiextensions/v1's default pruning applies), so existing GatewayClassConfig resources continue to work — the removed `cloudflared` and `tunnelTokenSecretRef` fields are silently dropped on next read/write.
 


### PR DESCRIPTION
# Pull Request

## Summary

Final pre-v3.0.0 documentation proofread and accuracy pass (closes #390). Every page on the docs site plus `README.md` was checked against the shipped v3 behaviour — pre-v3 leftovers removed, factual claims verified against the code/chart/CRD, and the primary user journey run end-to-end on a live kind cluster.

## Changes

- **Currency.** Removed pre-v3 leftovers: the v2 architecture diagram with a standalone cloudflared node (now a single in-process proxy node), the retired Helm-SDK operation metrics and their PromQL/RBAC references, and the controller-only manual-install path now warns it omits the proxy data plane.
- **Install correctness.** Fixed the homepage and Quick Start Helm commands to the real chart keys (`gatewayClassConfig.*` + `proxy.tunnelTokenSecretRef`, pre-created Secrets) and pinned the Gateway API CRD install to v1.5.1 everywhere. Added the missing "Create a Gateway" step to the Quick Start — the chart ships only the GatewayClass, so the route had no parent to bind to.
- **Reference accuracy.** Renamed the CRD `SecretKeySelector` to the real `SecretReference` type, added its optional `namespace` field, documented the `accountId` 32-char-hex CEL constraint and three-source resolution, and added the previously missing `ExternalBackend` CRD section. Documented six previously-undocumented controller flags and corrected the proxy ServiceMonitor / no-proxy-`/metrics` reality.
- **Post-audit.** Corrected stale text after the spec-compliance audit (route precedence, gRPC filter support, conflicted-listener and per-backend-fraction behaviour) and fixed the ListenerSet Standard-channel version (it graduated in v1.5.0, not v1.5.1).
- **Links.** Replaced the domain-hijacked `external-dns.io` link with the project repository.

## Testing

- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'` — 0 errors on docs + README)
- [x] `mkdocs build --strict` clean (no broken internal links, all pages in nav)
- [x] Manual testing completed — see below

## Documentation

- [x] README updated
- [x] Code comments added for complex logic (n/a — docs only)
- [ ] CLAUDE.md updated (not needed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [ ] Breaking changes documented (none — docs only)
- [x] Related issues referenced

## Additional Notes

Documentation-as-tested: the primary journey was run end-to-end on a live kind cluster against the test tunnel — `helm template` validates the documented install keys resolve, the controller + proxy deploy and the GatewayClass reaches `Accepted=True`, the Quick Start Gateway + HTTPRoute bind (`Accepted=True`/`ResolvedRefs=True`), the Gateway status address is the tunnel CNAME, and a `curl` to the tunnel hostname returns the backend (HTTP 200). A redirect-filter route also bound, the documented logs selector and `gatewayclassconfig` lookup work, and the controller `/metrics` endpoint serves the documented `cftunnel_*` metrics (the proxy correctly serves none).

This is a documentation-only diff with no code change since #422 (whose merge already passed the full conformance + e2e suite on master), so the Go conformance/e2e suites are not re-run here; the live journey above is the relevant end-to-end validation for the docs.

Closes #390.
