### PR TITLE
docs(conformance): document unsupported headless Service backends

### DIFF
--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -7,7 +7,7 @@ This document describes the known limitations of the Cloudflare Tunnel Gateway C
 | Limitation | Description |
 |------------|-------------|
 | Full sync | Any change triggers full config sync |
-| Backend kinds | `Service` (ClusterIP, NodePort, LoadBalancer, ExternalName), `ServiceImport` (multicluster.x-k8s.io, resolved via `clusterset.local` DNS), and `ExternalBackend` (`cf.k8s.lex.la`, an out-of-cluster HTTP(S) URL). Any other kind → `ResolvedRefs=False, InvalidKind`. |
+| Backend kinds | `Service` (ClusterIP, NodePort, LoadBalancer, ExternalName — but not headless `clusterIP: None`, see [Headless Service backends](#headless-service-backends)), `ServiceImport` (multicluster.x-k8s.io, resolved via `clusterset.local` DNS), and `ExternalBackend` (`cf.k8s.lex.la`, an out-of-cluster HTTP(S) URL). Any other kind → `ResolvedRefs=False, InvalidKind`. |
 
 ## Unsupported config is surfaced on resource status
 
@@ -32,6 +32,14 @@ Because the v3 data plane is a generic in-process L7 proxy that ultimately dials
 - **`ExternalBackend` (`cf.k8s.lex.la`)** — a namespaced CRD declaring an out-of-cluster HTTP(S) origin (`spec.scheme` / `spec.host` / `spec.port` / optional `spec.path`). The proxy dials that URL directly from the pod. The `backendRef` port is ignored in favour of `spec.port`. A missing `ExternalBackend` is surfaced as `ResolvedRefs=False, BackendNotFound` and returns HTTP 500 for its traffic fraction. There is no SSRF allowlist: an `ExternalBackend` is operator-authored and the trust boundary is namespace write-access plus `ReferenceGrant`, identical to a `Service` of type `ExternalName`. gRPC over an `ExternalBackend` uses h2c when `scheme: http` and HTTP/2 over TLS (ALPN) when `scheme: https`.
 
 A cross-namespace `ServiceImport` or `ExternalBackend` `backendRef` requires a `ReferenceGrant` whose `to` entry names the matching `group`/`kind` (`multicluster.x-k8s.io`/`ServiceImport` or `cf.k8s.lex.la`/`ExternalBackend`) — a Service-only grant does not authorize them.
+
+## Headless Service backends
+
+A `backendRef` targeting a **headless** `Service` (`spec.clusterIP: None`) is not supported and returns HTTP 502. The proxy dials each backend as the Service FQDN at the `backendRef` port — `<name>.<namespace>.svc.<cluster-domain>:<port>` — and relies on kube-proxy to translate the Service VIP port to the endpoint `targetPort`. A headless Service has no VIP: its FQDN resolves straight to the endpoint pod IPs, so the proxy dials those IPs at the Service port while the pods listen on the (usually different) `targetPort`, and the connection fails.
+
+A normal `Service` works regardless of how its `EndpointSlices` are managed — including a selector-less Service with hand-authored `EndpointSlices` — because the request still goes through the Service VIP and kube-proxy. Only the headless case is affected.
+
+Workaround: give the backend Service a ClusterIP (omit `clusterIP: None`). Headless backend support is tracked in [#426](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/426); the conformance `HTTPRouteServiceTypes` test is skipped until it lands.
 
 ## Traffic Splitting and Load Balancing
 

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -237,7 +237,20 @@ func conformanceSkipTests() []string {
 		// Tunnel doesn't expose multiple ports.
 		"HTTPRouteListenerPortMatching",
 
-		// We only support ClusterIP backends.
+		// HTTPRouteServiceTypes routes to three backends: a normal ClusterIP
+		// Service with manual EndpointSlices (passes), and two headless
+		// Services (clusterIP: None) — one with a selector, one with manual
+		// EndpointSlices (both 502). The proxy builds upstreams as the Service
+		// FQDN at the Service port (converter.go buildServiceURL) and relies on
+		// kube-proxy to translate the Service VIP port to the endpoint
+		// targetPort. A headless Service has no VIP, so the FQDN resolves to the
+		// endpoint IPs and the proxy dials them at the Service port (8080) while
+		// the endpoints listen on the targetPort (3000) -> connection fails.
+		// Headless backend support is tracked in #426; until then the whole test
+		// is skipped (the suite cannot skip individual sub-cases). The
+		// manual-endpointslices sub-case already passes, so the earlier "only
+		// ClusterIP backends" reason was inaccurate — non-headless Services with
+		// hand-managed EndpointSlices route fine.
 		"HTTPRouteServiceTypes",
 
 		// Mesh: not supported — tunnel architecture, no service mesh.


### PR DESCRIPTION
# Pull Request

## Summary

The `HTTPRouteServiceTypes` conformance skip carried an inaccurate reason — "We only support ClusterIP backends". A trial un-skip against a live tunnel showed the real picture: the normal-Service sub-case passes and only the two headless (`clusterIP: None`) sub-cases fail with 502. This corrects the skip comment and documents the actual limitation, with a tracking issue for proper support.

## Changes

- Rewrites the `HTTPRouteServiceTypes` skip comment in the conformance suite to describe the real mechanism: the proxy dials backends as the Service FQDN at the Service port (`converter.go` `buildServiceURL`) and relies on kube-proxy VIP→`targetPort` translation; a headless Service has no VIP, so the proxy dials the endpoint IPs at the Service port while they listen on the `targetPort`, and the connection fails (502).
- Adds a "Headless Service backends" section to `docs/gateway-api/limitations.md` (with the workaround — give the Service a ClusterIP) and flags it in the backend-kinds table row.

## Trial result (live tunnel)

| Sub-case | Backend | Result |
|---|---|---|
| `/manual-endpointslices` | normal Service (ClusterIP) + manual EndpointSlices | 200 PASS |
| `/headless` | `clusterIP: None` + selector | 502 FAIL |
| `/headless-manual-endpointslices` | `clusterIP: None` + manual EndpointSlices | 502 FAIL |

The pass/fail split is exactly headless-vs-not, isolating the missing kube-proxy port translation as the cause. The old "only ClusterIP backends" reason was wrong — a non-headless Service with hand-managed EndpointSlices routes fine.

## Testing

- [x] Markdown linting passes (`markdownlint-cli2`)
- [x] `mkdocs build --strict` clean
- [x] Conformance package compiles and its skip-list guard tests pass (`go vet -tags conformance`, `TestStaleSkipsStayLifted`)
- [x] Manual testing completed — the trial un-skip run above

## Documentation

- [x] README updated (n/a — README delegates backend-kind detail to the Limitations page)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (not needed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [ ] Breaking changes documented (none — docs + comment only)
- [x] Related issues referenced

## Additional Notes

Documentation + skip-comment change only; no controller or proxy code is touched, and the set of conformance tests run is identical to master (the skip is restored to its prior state — only the comment text differs). The full conformance + e2e suites would therefore be byte-identical to the most recent green run, so they are not re-executed here. Proper headless backend support is tracked in #426.
