### PR TITLE
fix(docs): restore versionless link redirect and pin doc links to /latest/

### DIFF
--- a/.github/scripts/check-404-redirect.test.js
+++ b/.github/scripts/check-404-redirect.test.js
@@ -1,0 +1,103 @@
+// check-404-redirect.test.js — unit tests for the versionless-link redirect
+// shipped inline in docs/404.html.
+//
+// The docs site is versioned with mike: only /latest/<page>/ (and /vX.Y/<page>/)
+// resolve, so a versionless https://cf.k8s.lex.la/<page>/ hits GitHub Pages'
+// fallback. docs/404.html, served at the gh-pages root, JS-redirects such paths
+// to /latest/. These tests pin that behaviour.
+//
+// Runs under stdlib `node --test`; no third-party test framework so the CI step
+// doesn't have to install npm deps.
+//
+// The test extracts and executes the REAL inline <script> from docs/404.html
+// (not a copy) so it can't drift from the file GitHub Pages actually serves.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const html = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'docs', '404.html'),
+  'utf8',
+);
+
+const scriptMatch = html.match(/<script>([\s\S]*?)<\/script>/);
+assert.ok(scriptMatch, 'docs/404.html must contain an inline <script> redirect');
+const scriptSource = scriptMatch[1];
+
+// Execute the inline script against a stubbed window.location for the given URL.
+// Returns the argument passed to location.replace(), or null if no redirect.
+function redirectFor(pathname, search = '', hash = '') {
+  let redirectedTo = null;
+  const location = {
+    pathname,
+    search,
+    hash,
+    replace(target) {
+      redirectedTo = target;
+    },
+  };
+  const sandbox = { window: { location } };
+  vm.createContext(sandbox);
+  vm.runInContext(scriptSource, sandbox);
+  return redirectedTo;
+}
+
+test('redirects a versionless doc path to /latest/', () => {
+  assert.equal(
+    redirectFor('/gateway-api/limitations/'),
+    '/latest/gateway-api/limitations/',
+  );
+});
+
+test('preserves the hash fragment', () => {
+  assert.equal(
+    redirectFor('/reference/security/', '', '#rbac-configuration'),
+    '/latest/reference/security/#rbac-configuration',
+  );
+});
+
+test('preserves the query string', () => {
+  assert.equal(
+    redirectFor('/operations/metrics/', '?q=test'),
+    '/latest/operations/metrics/?q=test',
+  );
+});
+
+test('redirects a section whose name starts with "dev" (development != dev)', () => {
+  // Guards against a prefix-match bug: the version allowlist must match the
+  // whole first segment, not a prefix, or /development/ would be mistaken for
+  // the /dev/ alias and never redirect.
+  assert.equal(
+    redirectFor('/development/architecture/'),
+    '/latest/development/architecture/',
+  );
+});
+
+test('does not redirect a path already under /latest/ (loop-safe)', () => {
+  assert.equal(redirectFor('/latest/gateway-api/limitations/'), null);
+});
+
+test('does not redirect a semver-versioned path', () => {
+  assert.equal(redirectFor('/3.0.0/gateway-api/limitations/'), null);
+});
+
+test('does not redirect a v-prefixed versioned path', () => {
+  assert.equal(redirectFor('/v3.0/gateway-api/limitations/'), null);
+});
+
+test('does not redirect the dev alias', () => {
+  assert.equal(redirectFor('/dev/index.html'), null);
+});
+
+test('does not redirect site assets', () => {
+  assert.equal(redirectFor('/assets/stylesheets/main.css'), null);
+});
+
+test('does not redirect the bare root', () => {
+  assert.equal(redirectFor('/'), null);
+});

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -83,3 +83,29 @@ jobs:
           else
             mike deploy --push "${VERSION}"
           fi
+
+      - name: Publish versionless 404 redirect to gh-pages root
+        run: |
+          set -euo pipefail
+
+          # mike deploy --push lays each version under its own gh-pages subdir
+          # but never writes a root 404.html. GitHub Pages serves <root>/404.html
+          # for any unmatched path, so copy our redirect there -- it sends
+          # versionless links and stale bookmarks to their /latest/ equivalent.
+          # Done in a throwaway worktree so the main checkout's branch is
+          # untouched; idempotent, so steady-state runs push nothing.
+          cp docs/404.html "${RUNNER_TEMP}/404.html"
+
+          git fetch origin gh-pages
+          git worktree add "${RUNNER_TEMP}/ghp" origin/gh-pages
+          cp "${RUNNER_TEMP}/404.html" "${RUNNER_TEMP}/ghp/404.html"
+          git -C "${RUNNER_TEMP}/ghp" add 404.html
+
+          if git -C "${RUNNER_TEMP}/ghp" diff --cached --quiet; then
+            echo "404.html already current at gh-pages root"
+          else
+            git -C "${RUNNER_TEMP}/ghp" commit -m "docs: publish versionless 404 redirect to site root"
+            git -C "${RUNNER_TEMP}/ghp" push origin HEAD:gh-pages
+          fi
+
+          git worktree remove --force "${RUNNER_TEMP}/ghp"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,6 +83,13 @@ jobs:
         with:
           globs: '**/*.md'
 
+      # The docs site is versioned with mike, so a versionless
+      # https://cf.k8s.lex.la/<page>/ link 404s. mkdocs build --strict does not
+      # catch http(s) absolutes. Runs on every PR (no path filter) so a bad
+      # link in any markdown file -- README included -- fails the build.
+      - name: Check documentation links
+        run: ./hack/check-doc-links.sh
+
   # Lint shell scripts and GitHub Actions workflows. actionlint validates the
   # workflow YAML and runs shellcheck on inline `run:` blocks; the standalone
   # shellcheck pass covers hack/*.sh. Both tools are installed at a pinned,

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -8,6 +8,10 @@ on:
       - scripts/requirements-reflow.txt
       - .github/scripts/pr-labels.js
       - .github/scripts/pr-labels.test.js
+      - .github/scripts/check-404-redirect.test.js
+      - docs/404.html
+      - hack/check-doc-links.sh
+      - hack/check-doc-links_test.sh
       # labels.yml is included so the drift-pin tests
       # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
       # when labels.yml changes. Cost: the reflow job also fires on
@@ -22,6 +26,10 @@ on:
       - scripts/requirements-reflow.txt
       - .github/scripts/pr-labels.js
       - .github/scripts/pr-labels.test.js
+      - .github/scripts/check-404-redirect.test.js
+      - docs/404.html
+      - hack/check-doc-links.sh
+      - hack/check-doc-links_test.sh
       # labels.yml is included so the drift-pin tests
       # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
       # when labels.yml changes. Cost: the reflow job also fires on
@@ -70,3 +78,24 @@ jobs:
       # therefore catches breakage in the mapping module itself.
       - name: Run pr-labels mapping tests
         run: node --test .github/scripts/pr-labels.test.js
+
+  check-404-redirect:
+    name: 404 redirect test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # Pins the versionless-link redirect shipped inline in docs/404.html by
+      # extracting and running the real script against stubbed window.location.
+      - name: Run 404 redirect tests
+        run: node --test .github/scripts/check-404-redirect.test.js
+
+  check-doc-links:
+    name: Doc-link guard test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # Pins hack/check-doc-links.sh (the live gate runs in pr.yaml's lint job).
+      - name: Run doc-link guard tests
+        run: bash hack/check-doc-links_test.sh

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The controller runs an in-process L7 reverse proxy inside the cloudflared proces
 
 All tunnel traffic is intercepted by the in-process proxy, which applies Gateway API routing rules before forwarding requests to backends. Cloudflare Tunnel API configuration is used only for DNS/edge routing — actual request routing is handled entirely by the proxy.
 
-See [L7 Proxy Architecture](https://cf.k8s.lex.la/development/architecture/) for full details.
+See [L7 Proxy Architecture](https://cf.k8s.lex.la/latest/development/architecture/) for full details.
 
 ## Quick Start
 
@@ -124,7 +124,7 @@ helm install cloudflare-tunnel-gateway-controller \
 
 See [charts/cloudflare-tunnel-gateway-controller/README.md](charts/cloudflare-tunnel-gateway-controller/README.md) for all configuration options.
 
-For manual installation without Helm, see [Manual Installation](https://cf.k8s.lex.la/operations/manual-installation/).
+For manual installation without Helm, see [Manual Installation](https://cf.k8s.lex.la/latest/operations/manual-installation/).
 
 ## Usage
 
@@ -167,13 +167,13 @@ All matching and filter behavior is performed by the in-process L7 proxy that th
 | `spec.rules[].backendRefs[].namespace` | ✅ | Cross-namespace refs require ReferenceGrant |
 | `spec.rules[].backendRefs[].weight` | ✅ | True weighted traffic splitting across backends |
 
-**GRPCRoute:** ✅ Supported — served by the in-process L7 proxy. gRPC service/method matches map onto `/{service}/{method}` path rules. The upstream hop is cleartext h2c by default; attaching a `BackendTLSPolicy` upgrades the hop to TLS with HTTP/2 negotiated via ALPN, and the Gateway's `clientCertificateRef` is presented on the handshake for mTLS. See [GRPCRoute docs](https://cf.k8s.lex.la/gateway-api/grpcroute/).
+**GRPCRoute:** ✅ Supported — served by the in-process L7 proxy. gRPC service/method matches map onto `/{service}/{method}` path rules. The upstream hop is cleartext h2c by default; attaching a `BackendTLSPolicy` upgrades the hop to TLS with HTTP/2 negotiated via ALPN, and the Gateway's `clientCertificateRef` is presented on the handshake for mTLS. See [GRPCRoute docs](https://cf.k8s.lex.la/latest/gateway-api/grpcroute/).
 
-> **Load Balancing:** All traffic flows through the in-process L7 proxy, so full weighted traffic splitting between multiple backends is supported end-to-end. See [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/#traffic-splitting-and-load-balancing) for the edge-side caveats that still apply.
+> **Load Balancing:** All traffic flows through the in-process L7 proxy, so full weighted traffic splitting between multiple backends is supported end-to-end. See [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/#traffic-splitting-and-load-balancing) for the edge-side caveats that still apply.
 
 ### Known Limitations
 
-The in-process L7 proxy handles routing for every tunnel request. Edge-side caveats (Cloudflare hostname registration, edge HTTPS termination, etc.) are documented in the [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/) page. In particular, a GRPCRoute also needs Cloudflare zone gRPC proxying enabled (dashboard → Network → gRPC); if disabled, the edge returns `403` zone-wide for `application/grpc` and gRPC fails before reaching the proxy ([details](https://cf.k8s.lex.la/gateway-api/limitations/#grpc-requires-cloudflare-zone-grpc-proxying)).
+The in-process L7 proxy handles routing for every tunnel request. Edge-side caveats (Cloudflare hostname registration, edge HTTPS termination, etc.) are documented in the [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/) page. In particular, a GRPCRoute also needs Cloudflare zone gRPC proxying enabled (dashboard → Network → gRPC); if disabled, the edge returns `403` zone-wide for `application/grpc` and gRPC fails before reaching the proxy ([details](https://cf.k8s.lex.la/latest/gateway-api/limitations/#grpc-requires-cloudflare-zone-grpc-proxying)).
 
 `BackendTLSPolicy` (proxy → backend TLS) is supported at minimum-viable scope:
 
@@ -186,17 +186,17 @@ The in-process L7 proxy handles routing for every tunnel request. Edge-side cave
 - Backend WebSocket is supported via `Service.spec.ports[].appProtocol: kubernetes.io/ws` (and `kubernetes.io/wss` when paired with a `BackendTLSPolicy`). The proxy handles the upgrade on a custom path (`proxyWebSocketUpgrade`) rather than `httputil.ReverseProxy`, because the stdlib path hijacks the conn before writing the 101 status — which fails over cloudflared's HTTP/2 response writer. Route-level `ResponseHeaderModifier` filters apply to the 101 (and to the non-101 fallback when the backend refuses the upgrade), matching how filters apply to plain HTTP responses. If `kubernetes.io/wss` is declared without a `BackendTLSPolicy` the proxy logs a WARN at conversion time and falls through to plaintext — the backend will then reject the upgrade. The proxy does not enforce the precondition; operators must attach the policy themselves.
 - `spec.rules[].timeouts.request` and `timeouts.backendRequest` are enforced as header-only deadlines on the backend transport (`http.Transport.ResponseHeaderTimeout`), not as full-request context deadlines. The deadline bounds only the wait for backend response headers; once headers arrive the body streams freely. This keeps Server-Sent Events, chunked transfer, large file downloads, and gRPC server-streaming responses alive past the timeout boundary — a context-based deadline would have truncated them at the timeout mark. Backends that miss the header deadline get a 504 to the client. WebSocket routes are naturally exempt (the upgrade path bypasses the cached transport). The `BackendProtocol: H2C` path uses `golang.org/x/net/http2.Transport`, which has no `ResponseHeaderTimeout` knob; the proxy synthesises one by wrapping the h2c transport with a `headerTimeoutRoundTripper` so h2c backends honour the same streaming-friendly contract.
 
-Besides a core `Service`, a `backendRef` may target a `ServiceImport` (`multicluster.x-k8s.io`, resolved via `clusterset.local` DNS) or an `ExternalBackend` (`cf.k8s.lex.la`, an out-of-cluster HTTP(S) URL). A kind outside that set is reported `ResolvedRefs=False, InvalidKind`. Cross-namespace `ServiceImport`/`ExternalBackend` refs need a `ReferenceGrant` keyed on the matching group/kind. See [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/#non-service-backend-kinds) for details.
+Besides a core `Service`, a `backendRef` may target a `ServiceImport` (`multicluster.x-k8s.io`, resolved via `clusterset.local` DNS) or an `ExternalBackend` (`cf.k8s.lex.la`, an out-of-cluster HTTP(S) URL). A kind outside that set is reported `ResolvedRefs=False, InvalidKind`. Cross-namespace `ServiceImport`/`ExternalBackend` refs need a `ReferenceGrant` keyed on the matching group/kind. See [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/#non-service-backend-kinds) for details.
 
-An unavailable backend in a weighted rule returns an HTTP status for its traffic fraction rather than dialing a dead address (a generic 502): an invalid `backendRef` (nonexistent Service, missing `ServiceImport`/`ExternalBackend`, unauthorized cross-namespace ref, or unsupported kind) returns `500`, and an authorized Service with no ready endpoints returns `503`. The backend stays in the weighted pool so the other backends keep serving their share, and the `503` clears automatically once an endpoint becomes ready. See [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/#unavailable-backends-return-a-status-not-a-dial-error) for details.
+An unavailable backend in a weighted rule returns an HTTP status for its traffic fraction rather than dialing a dead address (a generic 502): an invalid `backendRef` (nonexistent Service, missing `ServiceImport`/`ExternalBackend`, unauthorized cross-namespace ref, or unsupported kind) returns `500`, and an authorized Service with no ready endpoints returns `503`. The backend stays in the weighted pool so the other backends keep serving their share, and the `503` clears automatically once an endpoint becomes ready. See [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/#unavailable-backends-return-a-status-not-a-dial-error) for details.
 
 The L7 proxy implements the Gateway API `HTTPRouteCORS` filter (preflight + simple requests, wildcard origin / methods / headers, credentials-aware echoing), including the `HTTPRouteCORSAllowCredentialsBehavior` conformance subtest: `Access-Control-Allow-Credentials` is emitted only for a matched origin, and a credentialed response echoes the concrete request origin rather than `*`.
 
-See [Backend mTLS](https://cf.k8s.lex.la/gateway-api/limitations/#backend-mtls-backendtlspolicy) for details.
+See [Backend mTLS](https://cf.k8s.lex.la/latest/gateway-api/limitations/#backend-mtls-backendtlspolicy) for details.
 
-The proxy can emit a structured per-request access log (method, host, path, query, status, bytes_written, duration_ms, user_agent) via `proxy.accessLog.enabled: true` in Helm values. Off by default; sampling-rate knob keeps log volume manageable on busy gateways. See [Access Logging](https://cf.k8s.lex.la/operations/access-logging/) for the full contract.
+The proxy can emit a structured per-request access log (method, host, path, query, status, bytes_written, duration_ms, user_agent) via `proxy.accessLog.enabled: true` in Helm values. Off by default; sampling-rate knob keeps log volume manageable on busy gateways. See [Access Logging](https://cf.k8s.lex.la/latest/operations/access-logging/) for the full contract.
 
-See [Gateway API documentation](https://cf.k8s.lex.la/gateway-api/) for full details and examples.
+See [Gateway API documentation](https://cf.k8s.lex.la/latest/gateway-api/) for full details and examples.
 
 ## External-DNS Integration
 
@@ -221,13 +221,13 @@ Full documentation is available at **[cf.k8s.lex.la](https://cf.k8s.lex.la)**.
 
 | Section | Description |
 |---------|-------------|
-| [Getting Started](https://cf.k8s.lex.la/getting-started/) | Prerequisites, installation, and quick start |
-| [Configuration](https://cf.k8s.lex.la/configuration/) | Controller configuration and Helm values |
-| [Gateway API](https://cf.k8s.lex.la/gateway-api/) | Supported resources, examples, and limitations |
-| [Guides](https://cf.k8s.lex.la/guides/) | L7 proxy setup, external-dns, cross-namespace, monitoring |
-| [Operations](https://cf.k8s.lex.la/operations/) | Troubleshooting, metrics, manual installation |
-| [Development](https://cf.k8s.lex.la/development/) | Development setup, architecture, contributing |
-| [Reference](https://cf.k8s.lex.la/reference/) | CRD reference, Helm chart, security policy |
+| [Getting Started](https://cf.k8s.lex.la/latest/getting-started/) | Prerequisites, installation, and quick start |
+| [Configuration](https://cf.k8s.lex.la/latest/configuration/) | Controller configuration and Helm values |
+| [Gateway API](https://cf.k8s.lex.la/latest/gateway-api/) | Supported resources, examples, and limitations |
+| [Guides](https://cf.k8s.lex.la/latest/guides/) | L7 proxy setup, external-dns, cross-namespace, monitoring |
+| [Operations](https://cf.k8s.lex.la/latest/operations/) | Troubleshooting, metrics, manual installation |
+| [Development](https://cf.k8s.lex.la/latest/development/) | Development setup, architecture, contributing |
+| [Reference](https://cf.k8s.lex.la/latest/reference/) | CRD reference, Helm chart, security policy |
 
 ## Roadmap
 
@@ -238,7 +238,7 @@ Planned features and improvements:
 | -- | L7 reverse proxy for full Gateway API HTTPRoute support | Done |
 | [#45](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/45) | Weighted backend traffic splitting | Done |
 | [#44](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/44) | Warning logs for partially ignored route configuration | Planned |
-| [#40](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/40) | TCPRoute and TLSRoute support (GRPCRoute removed from the runtime in v3 — see [migration guide](https://cf.k8s.lex.la/upgrading/v2-to-v3/)) | In Progress |
+| [#40](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/40) | TCPRoute and TLSRoute support (GRPCRoute removed from the runtime in v3 — see [migration guide](https://cf.k8s.lex.la/latest/upgrading/v2-to-v3/)) | In Progress |
 | [#33](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/33) | Auto-generate artifacthub.io/changes from git history | Planned |
 | [#25](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/25) | Increase unit test coverage for core packages | Ongoing |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,7 +60,7 @@ The Cloudflare API token is sensitive and should be:
 
 The controller requires specific Kubernetes permissions:
 
-The canonical v3 RBAC scope is rendered by the Helm chart; see [docs/reference/security.md](https://cf.k8s.lex.la/reference/security/#rbac-configuration) for the rendered ClusterRole. The controller reads Secrets / ConfigMaps, writes Gateway status subresources, and updates `gateways` finalizers (legacy v2 finalizer strip on delete) — no cluster-wide write on Pods, Deployments, ReplicaSets, or ServiceAccounts.
+The canonical v3 RBAC scope is rendered by the Helm chart; see [docs/reference/security.md](https://cf.k8s.lex.la/latest/reference/security/#rbac-configuration) for the rendered ClusterRole. The controller reads Secrets / ConfigMaps, writes Gateway status subresources, and updates `gateways` finalizers (legacy v2 finalizer strip on delete) — no cluster-wide write on Pods, Deployments, ReplicaSets, or ServiceAccounts.
 
 The v3 controller is status-only — it does not create or mutate workloads. The v2 chart granted cluster-wide write on Pods, Deployments, ReplicaSets and ServiceAccounts for the Helm-SDK code path that managed cloudflared in-cluster; those rules were removed when the code path itself was deleted.
 

--- a/charts/cloudflare-tunnel-gateway-controller/templates/NOTES.txt
+++ b/charts/cloudflare-tunnel-gateway-controller/templates/NOTES.txt
@@ -97,7 +97,7 @@ App Version: {{ .Chart.AppVersion }}
 
   Documentation: https://github.com/lexfrei/cloudflare-tunnel-gateway-controller
   Examples: https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/tree/master/charts/cloudflare-tunnel-gateway-controller/examples
-  Troubleshooting: https://cf.k8s.lex.la/operations/troubleshooting/
+  Troubleshooting: https://cf.k8s.lex.la/latest/operations/troubleshooting/
   Issues: https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/docs/404.html
+++ b/docs/404.html
@@ -4,13 +4,20 @@
   <meta charset="utf-8">
   <title>Redirecting...</title>
   <script>
-    // Redirect non-versioned paths to /latest/
+    // The docs site is versioned with mike: real pages live under /latest/
+    // (and /vX.Y/). A versionless path like /gateway-api/limitations/ lands
+    // here as a 404 — redirect it to its /latest/ equivalent.
+    //
+    // The first path segment is left alone when it already looks like a mike
+    // version or a build asset, so /latest/, /dev/, /3.0.0/, /v3.0/ and
+    // /assets/ are not rewritten (and a 404 already under /latest/ doesn't
+    // loop). Matching is anchored to the whole segment so a real section like
+    // /development/ is not mistaken for the /dev/ alias.
     var path = window.location.pathname;
-    var defined = ['latest', 'dev', '0.8.0', '0.9.0', '0.9.1', '0.9.2', '1.0.0'];
-    var firstSegment = path.split('/').filter(Boolean)[0];
+    var firstSegment = path.split('/').filter(Boolean)[0] || '';
+    var looksVersioned = /^(latest|dev|assets|v?\d+\.\d+.*)$/.test(firstSegment);
 
-    // If path doesn't start with a known version, redirect to /latest/
-    if (firstSegment && defined.indexOf(firstSegment) === -1) {
+    if (firstSegment && !looksVersioned) {
       window.location.replace('/latest' + path + window.location.search + window.location.hash);
     }
   </script>

--- a/hack/check-doc-links.sh
+++ b/hack/check-doc-links.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# check-doc-links.sh — fail if any tracked markdown links to the versioned docs
+# site (https://cf.k8s.lex.la) without the required /latest/ (or /vX.Y/) prefix.
+#
+# The site is versioned with mike, so only /latest/<page>/ and /vX.Y/<page>/
+# resolve; a versionless https://cf.k8s.lex.la/<page>/ hits GitHub Pages'
+# fallback and 404s. README.md and the other repo-root files are not part of
+# the mkdocs build, so their links to the site must be absolute and carry
+# /latest/. mkdocs build --strict validates relative/internal links but not
+# http(s) absolutes, which is why this guard exists.
+#
+# The CRD apiVersion (cf.k8s.lex.la/v1alpha1) and the controllerName
+# (cf.k8s.lex.la/tunnel-*) are identifiers, never written with an https://
+# scheme, so anchoring the match on https://cf.k8s.lex.la/ already excludes
+# them.
+#
+# Usage:
+#   check-doc-links.sh [FILE...]
+# With no arguments, scans every tracked text file (vendor and this guard's own
+# test fixtures excluded) -- doc links also live in non-.md sources such as the
+# Helm NOTES.txt that is printed after `helm install`. Explicit file arguments
+# are scanned as-is (used by the test).
+set -euo pipefail
+
+# A docs-site URL whose first path segment starts with a letter — i.e. a doc
+# page (gateway-api, operations, ...) or the latest / vX alias. The match stops
+# at whitespace or a markdown/HTML delimiter. The bare host (no trailing path)
+# and digit-versioned paths (/3.0.0/) do not match.
+url_re='https?://cf\.k8s\.lex\.la/[A-Za-z][^[:space:])">`]*'
+# A link is allowed when its FIRST path segment is the latest alias or a version
+# directory. The release workflow strips the leading v
+# (VERSION="${GITHUB_REF_NAME#v}") and mike publishes semver dirs (3.0.0), so
+# /latest/ and a leading digit cover every real version path; v?[0-9] also
+# tolerates a hand-written /vX/ link rather than flag it. Anchored to the
+# file:line: prefix that grep -Hn prepends so the check binds to the segment
+# right after the host, not to a "cf.k8s.lex.la/latest" that appears later in
+# the path or query of an otherwise-versionless link.
+allowed_re='^[^:]+:[0-9]+:https?://cf\.k8s\.lex\.la/(latest|v?[0-9])'
+
+if [[ "$#" -gt 0 ]]; then
+  files=("$@")
+else
+  # check-doc-links_test.sh is excluded: it embeds versionless links on purpose
+  # as test fixtures, which would otherwise self-trip this guard.
+  mapfile -t files < <(git ls-files ':!vendor/**' ':!hack/check-doc-links_test.sh')
+fi
+
+# grep exits 1 when nothing matches; that is success here, so swallow it.
+# -I skips binary files (images, etc.) now that the scan is not limited to *.md.
+matches="$(grep -oEHnI "${url_re}" -- "${files[@]}" || true)"
+
+offenders=""
+if [[ -n "${matches}" ]]; then
+  offenders="$(printf '%s\n' "${matches}" | grep -Ev "${allowed_re}" || true)"
+fi
+
+if [[ -n "${offenders}" ]]; then
+  {
+    echo "ERROR: documentation links to https://cf.k8s.lex.la must carry the"
+    echo "       /latest/ version prefix — the site is versioned with mike, so a"
+    echo "       versionless deep link 404s. Offending links:"
+    echo ""
+    printf '%s\n' "${offenders}"
+  } >&2
+  exit 1
+fi
+
+echo "OK: no versionless cf.k8s.lex.la documentation links found"

--- a/hack/check-doc-links_test.sh
+++ b/hack/check-doc-links_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# check-doc-links_test.sh — tests for check-doc-links.sh.
+#
+# Pins the guard's behaviour: a versionless cf.k8s.lex.la documentation link
+# fails, while /latest/ links, the bare host, and the CRD apiVersion /
+# controllerName identifiers pass. Plain bash + a temp dir, no test framework.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+guard="${script_dir}/check-doc-links.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+fail=0
+
+# check <expected-exit> <label> <file>
+check() {
+  local expected="$1" label="$2" file="$3" actual=0
+  bash "${guard}" "${file}" >/dev/null 2>&1 || actual=$?
+  if [[ "${actual}" -eq "${expected}" ]]; then
+    echo "ok   - ${label} (exit ${actual})"
+  else
+    echo "FAIL - ${label}: expected exit ${expected}, got ${actual}"
+    fail=1
+  fi
+}
+
+# check_repo <expected-exit> <label> <relpath> <content>
+# Stages <content> at <relpath> in a throwaway git repo and runs the guard in
+# its default (no-argument) mode, exercising the git ls-files file scope -- the
+# part that decides which files are even looked at. A bad link in a non-.md
+# source like a Helm NOTES.txt must be in scope.
+check_repo() {
+  local expected="$1" label="$2" relpath="$3" content="$4" actual=0 repo
+  repo="$(mktemp -d)"
+  git -C "${repo}" init --quiet
+  mkdir -p "${repo}/$(dirname "${relpath}")"
+  printf '%s\n' "${content}" > "${repo}/${relpath}"
+  git -C "${repo}" add --all
+  ( cd "${repo}" && bash "${guard}" ) >/dev/null 2>&1 || actual=$?
+  rm -rf "${repo}"
+  if [[ "${actual}" -eq "${expected}" ]]; then
+    echo "ok   - ${label} (exit ${actual})"
+  else
+    echo "FAIL - ${label}: expected exit ${expected}, got ${actual}"
+    fail=1
+  fi
+}
+
+printf 'See [Limitations](https://cf.k8s.lex.la/gateway-api/limitations/).\n' \
+  > "${tmp}/bad.md"
+printf 'See [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/).\n' \
+  > "${tmp}/good_latest.md"
+printf 'Docs: [home](https://cf.k8s.lex.la) and <https://cf.k8s.lex.la>.\n' \
+  > "${tmp}/good_root.md"
+printf 'apiVersion: cf.k8s.lex.la/v1alpha1\ncontrollerName: cf.k8s.lex.la/tunnel-controller\n' \
+  > "${tmp}/good_identifiers.md"
+printf 'Links: [a](https://cf.k8s.lex.la/latest/guides/) [b](https://cf.k8s.lex.la/operations/).\n' \
+  > "${tmp}/bad_mixed.md"
+# Versionless links whose path or query happens to contain the substring
+# "cf.k8s.lex.la/latest" later on must still be caught: the version check is
+# anchored to the URL's first path segment, not matched anywhere on the line.
+printf 'Sneaky: [x](https://cf.k8s.lex.la/guides/cf.k8s.lex.la/latest/x).\n' \
+  > "${tmp}/bad_sneaky_path.md"
+printf 'Query: [x](https://cf.k8s.lex.la/operations/?ref=cf.k8s.lex.la/latest).\n' \
+  > "${tmp}/bad_sneaky_query.md"
+
+check 1 "versionless doc link fails"         "${tmp}/bad.md"
+check 0 "/latest/ link passes"               "${tmp}/good_latest.md"
+check 0 "bare host passes"                   "${tmp}/good_root.md"
+check 0 "apiVersion / controllerName pass"   "${tmp}/good_identifiers.md"
+check 1 "mixed line: bad link still caught"  "${tmp}/bad_mixed.md"
+check 1 "downstream /latest/ in path caught" "${tmp}/bad_sneaky_path.md"
+check 1 "downstream /latest/ in query caught" "${tmp}/bad_sneaky_query.md"
+
+# Default-scope coverage: a Helm NOTES.txt (a non-.md, user-facing doc-link
+# source) must be scanned, not just *.md files.
+check_repo 1 "default scope catches a versionless link in NOTES.txt" \
+  "charts/x/templates/NOTES.txt" \
+  "  Troubleshooting: https://cf.k8s.lex.la/operations/troubleshooting/"
+check_repo 0 "default scope passes a /latest/ link in NOTES.txt" \
+  "charts/x/templates/NOTES.txt" \
+  "  Troubleshooting: https://cf.k8s.lex.la/latest/operations/troubleshooting/"
+
+if [[ "${fail}" -ne 0 ]]; then
+  echo "doc-link guard tests FAILED"
+  exit 1
+fi
+echo "doc-link guard tests passed"


### PR DESCRIPTION
## Summary

The documentation site is versioned with `mike`, so only `https://cf.k8s.lex.la/latest/<page>/` resolves; a versionless `https://cf.k8s.lex.la/<page>/` hits GitHub Pages' fallback and returns 404. Repo-root docs (README, SECURITY, the Helm `NOTES.txt`) carried absolute deep links without the `/latest/` prefix, all of which 404'd. Separately, the `docs/404.html` redirect that was meant to bounce versionless paths to `/latest/` was never published to the gh-pages root, so it did nothing — GitHub served its default not-found page.

This restores the redirect, fixes every versionless deep link, and adds a CI guard so the class can't recur. `mkdocs build --strict` validates relative/internal links but not `http(s)` absolutes, which is why these slipped through.

## Changes

- Rewrite every absolute `cf.k8s.lex.la` documentation deep link in `README.md`, `SECURITY.md`, and the chart `NOTES.txt` to carry the `/latest/` prefix. Bare homepage links are left as-is (the gh-pages root redirects to `/latest/`). The CRD `apiVersion` and `controllerName` identifiers are not links and are untouched.
- Make `docs/404.html` resilient to new releases: replace the hardcoded version allowlist (which went stale and mis-redirected newer version dirs) with whole-segment version-shape detection, and publish it to the gh-pages root from the docs workflow so GitHub Pages actually serves it for unmatched paths.
- Add `hack/check-doc-links.sh`, a guard that fails when any tracked file links to the site without the `/latest/` (or version) prefix, wired into the lint job so it runs on every PR. Both the guard and the 404 redirect logic have tests that exercise the real shipped artifacts.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

Additional local verification: `helm lint` + `helm unittest` (239 tests), `shellcheck`, `actionlint`, `mkdocs build --strict`, the new `node --test` redirect suite, and the doc-link guard self-tests all pass. The live 404 behavior was confirmed against the running site (`/<page>/` → 404, `/latest/<page>/` → 200), which the gh-pages root republish step fixes on the next deploy.

The Gateway API conformance and custom e2e suites were not run: this change touches only documentation prose, browser-side `404.html` JavaScript, CI shell/YAML, and a console-only `NOTES.txt` string — no controller, proxy, tunnel, or rendered-manifest code. Those suites build and run the controller/proxy binaries against a live tunnel and cannot exercise any file in this diff; the chart template is covered by `helm unittest`.

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

Closes #429.
