### PR TITLE
fix(controller): route to headless Service backends

### DIFF
--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -7,7 +7,7 @@ This document describes the known limitations of the Cloudflare Tunnel Gateway C
 | Limitation | Description |
 |------------|-------------|
 | Full sync | Any change triggers full config sync |
-| Backend kinds | `Service` (ClusterIP, NodePort, LoadBalancer, ExternalName — but not headless `clusterIP: None`, see [Headless Service backends](#headless-service-backends)), `ServiceImport` (multicluster.x-k8s.io, resolved via `clusterset.local` DNS), and `ExternalBackend` (`cf.k8s.lex.la`, an out-of-cluster HTTP(S) URL). Any other kind → `ResolvedRefs=False, InvalidKind`. |
+| Backend kinds | `Service` (ClusterIP, NodePort, LoadBalancer, ExternalName, and headless `clusterIP: None` — expanded to one backend per ready endpoint), `ServiceImport` (multicluster.x-k8s.io, resolved via `clusterset.local` DNS), and `ExternalBackend` (`cf.k8s.lex.la`, an out-of-cluster HTTP(S) URL). Any other kind → `ResolvedRefs=False, InvalidKind`. |
 
 ## Unsupported config is surfaced on resource status
 
@@ -33,17 +33,11 @@ Because the v3 data plane is a generic in-process L7 proxy that ultimately dials
 
 A cross-namespace `ServiceImport` or `ExternalBackend` `backendRef` requires a `ReferenceGrant` whose `to` entry names the matching `group`/`kind` (`multicluster.x-k8s.io`/`ServiceImport` or `cf.k8s.lex.la`/`ExternalBackend`) — a Service-only grant does not authorize them.
 
-## Headless Service backends
-
-A `backendRef` targeting a **headless** `Service` (`spec.clusterIP: None`) is not supported and returns HTTP 502. The proxy dials each backend as the Service FQDN at the `backendRef` port — `<name>.<namespace>.svc.<cluster-domain>:<port>` — and relies on kube-proxy to translate the Service VIP port to the endpoint `targetPort`. A headless Service has no VIP: its FQDN resolves straight to the endpoint pod IPs, so the proxy dials those IPs at the Service port while the pods listen on the (usually different) `targetPort`, and the connection fails.
-
-A normal `Service` works regardless of how its `EndpointSlices` are managed — including a selector-less Service with hand-authored `EndpointSlices` — because the request still goes through the Service VIP and kube-proxy. Only the headless case is affected.
-
-Workaround: give the backend Service a ClusterIP (omit `clusterIP: None`). Headless backend support is tracked in [#426](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/426); the conformance `HTTPRouteServiceTypes` test is skipped until it lands.
-
 ## Traffic Splitting and Load Balancing
 
 The in-process L7 proxy performs weighted traffic splitting across the `backendRefs` of a rule, for both HTTPRoute and GRPCRoute. Each backend's `weight` is honoured by a weighted-random selection at request time: traffic is distributed in proportion to the weights, and a backend with `weight: 0` receives no traffic (a rule whose backends all have weight 0 serves nothing). Weighted splitting works directly in the proxy and does not require an external load balancer.
+
+A headless `Service` (`spec.clusterIP: None`) has no VIP for kube-proxy to balance, so the controller resolves its `EndpointSlices` and expands the `backendRef` into one backend per ready endpoint, dialing each pod at its `targetPort`. The endpoints share the `backendRef`'s weight equally, so a headless Service is load-balanced per-endpoint by the proxy's own weighted-random selection while preserving the `backendRef`'s overall traffic proportion against any siblings. A normal Service with a ClusterIP is left to route through its VIP and kube-proxy.
 
 For plain round-robin between pods of one Deployment, a standard Kubernetes `Service` is still the simplest option — point the route at the Service and let kube-proxy balance:
 

--- a/internal/controller/headless_backends.go
+++ b/internal/controller/headless_backends.go
@@ -1,0 +1,217 @@
+package controller
+
+import (
+	"context"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// expandHeadlessBackends replaces the Service-FQDN backend of every headless
+// Service (spec.clusterIP: None) with one backend per ready endpoint, dialing the
+// endpoint targetPort instead of the Service port. A headless Service has no VIP,
+// so its FQDN resolves straight to the pod IPs and dialing the Service port
+// (8080) reaches a pod listening on the targetPort (3000) and fails (502). This
+// pass resolves the EndpointSlices and hands the addresses to the proxy's
+// weighted multi-backend selection.
+//
+// It runs after the 500 invalid-ref marking and before the 503 zero-endpoint
+// marking: a headless Service with ready endpoints is expanded (so its FQDN host
+// disappears from cfg and the 503 pass skips it), while a headless Service with
+// no ready endpoints is left as the FQDN backend so the 503 pass marks it.
+//
+// Only backends that are present and unmarked in cfg are inspected — the same
+// proxy.UnmarkedBackendHosts gate as the 503 pass — so a ref the converter
+// dropped (unauthorized cross-namespace, invalid kind/port) is never read,
+// keeping ReferenceGrant authorization symmetric across passes. Each Service
+// identity is inspected once per reconcile.
+func expandHeadlessBackends(
+	ctx context.Context,
+	cli client.Client,
+	cfg *proxy.Config,
+	clusterDomain string,
+	routes []*gatewayv1.HTTPRoute,
+	grpcRoutes []*gatewayv1.GRPCRoute,
+) {
+	if cli == nil || cfg == nil {
+		return
+	}
+
+	visitAuthorizedServiceBackends(ctx, cfg, clusterDomain, routes, grpcRoutes,
+		func(ctx context.Context, svcNamespace, name string, port int32) {
+			expandBackendIfHeadless(ctx, cli, cfg, clusterDomain, svcNamespace, name, port)
+		})
+}
+
+// expandBackendIfHeadless expands the backend when the named Service is headless
+// (clusterIP: None) and has at least one ready endpoint. A normal Service keeps
+// routing through its VIP; an ExternalName Service is never expanded; a headless
+// Service with no ready endpoints is left for the 503 pass.
+func expandBackendIfHeadless(
+	ctx context.Context,
+	cli client.Client,
+	cfg *proxy.Config,
+	clusterDomain, svcNamespace, name string,
+	port int32,
+) {
+	var svc corev1.Service
+	if err := cli.Get(ctx, client.ObjectKey{Name: name, Namespace: svcNamespace}, &svc); err != nil {
+		// Missing Service is the 500 invalid-ref path; any other error leaves the
+		// backend to its normal dial behaviour. Either way, do not expand.
+		return
+	}
+
+	if svc.Spec.Type == corev1.ServiceTypeExternalName || svc.Spec.ClusterIP != corev1.ClusterIPNone {
+		return
+	}
+
+	endpoints, hadReady := resolveHeadlessEndpoints(ctx, cli, &svc, svcNamespace, name, port)
+	if len(endpoints) > 0 {
+		proxy.ExpandHeadlessBackend(cfg, clusterDomain, svcNamespace, name, port, endpoints)
+
+		return
+	}
+
+	if hadReady {
+		// Ready endpoints exist but none could be resolved to a dialable port
+		// (e.g. a named targetPort absent from the EndpointSlice). Fail closed:
+		// mark the backend 503 rather than leaving the FQDN backend to be dialed
+		// at the Service port and 502. The zero-endpoint 503 pass cannot catch
+		// this — it sees the endpoints as ready — so the marking must happen here.
+		proxy.MarkUnavailableBackends(cfg, clusterDomain, svcNamespace, name, port, http.StatusServiceUnavailable)
+	}
+
+	// No ready endpoints at all: leave the FQDN backend for the zero-endpoint pass.
+}
+
+// resolveHeadlessEndpoints lists the Service's EndpointSlices and returns one
+// ResolvedEndpoint per ready endpoint address, dialing the endpoint port that
+// corresponds (by port name) to the Service port the backendRef selected. The
+// second return reports whether any ready endpoint existed at all (even one whose
+// port could not be resolved), so the caller can distinguish "no ready endpoints"
+// (leave for the zero-endpoint 503 pass) from "ready endpoints but unresolvable
+// port" (fail closed).
+func resolveHeadlessEndpoints(
+	ctx context.Context,
+	cli client.Client,
+	svc *corev1.Service,
+	namespace, name string,
+	port int32,
+) ([]proxy.ResolvedEndpoint, bool) {
+	portName, fallbackPort := serviceTargetPort(svc, port)
+
+	var slices discoveryv1.EndpointSliceList
+	if err := cli.List(ctx, &slices,
+		client.InNamespace(namespace),
+		client.MatchingLabels{discoveryv1.LabelServiceName: name},
+	); err != nil {
+		return nil, false
+	}
+
+	var endpoints []proxy.ResolvedEndpoint
+
+	hadReady := false
+
+	for sliceIdx := range slices.Items {
+		eps, ready := sliceEndpoints(&slices.Items[sliceIdx], portName, fallbackPort)
+		endpoints = append(endpoints, eps...)
+		hadReady = hadReady || ready
+	}
+
+	return endpoints, hadReady
+}
+
+// serviceTargetPort returns the name of the Service port matching the backendRef
+// port (used to select the EndpointSlice port) and a numeric fallback: the Service
+// port's numeric targetPort, or 0 when the targetPort is a named port or no
+// Service port matches. A 0 fallback means only a port resolved from the
+// EndpointSlice is safe to dial — see sliceEndpoints. The Service port itself is
+// never a fallback: dialing it on a headless endpoint reaches a pod listening on
+// the (different) targetPort and 502s, which is the bug this pass fixes.
+func serviceTargetPort(svc *corev1.Service, port int32) (string, int32) {
+	for i := range svc.Spec.Ports {
+		svcPort := svc.Spec.Ports[i]
+		if svcPort.Port != port {
+			continue
+		}
+
+		if svcPort.TargetPort.Type == intstr.Int && svcPort.TargetPort.IntVal > 0 {
+			return svcPort.Name, svcPort.TargetPort.IntVal
+		}
+
+		return svcPort.Name, 0
+	}
+
+	return "", 0
+}
+
+// sliceEndpoints returns the ready endpoint addresses of one EndpointSlice, each
+// paired with the resolved endpoint port, plus whether the slice had any ready
+// endpoint at all. When the slice does not unambiguously resolve the port and there
+// is no numeric targetPort fallback, its endpoints are not dialed (a headless
+// endpoint dialed at the Service port 502s) — but a ready-endpoint sighting is
+// still reported via the second return so the caller can fail the backend closed
+// (503) instead of letting the FQDN backend fall through to a 502 dial.
+func sliceEndpoints(slice *discoveryv1.EndpointSlice, portName string, fallback int32) ([]proxy.ResolvedEndpoint, bool) {
+	endpointPort, resolvable := endpointSlicePort(slice, portName)
+	if !resolvable && fallback > 0 {
+		endpointPort = fallback
+		resolvable = true
+	}
+
+	var out []proxy.ResolvedEndpoint
+
+	hadReady := false
+
+	for epIdx := range slice.Endpoints {
+		ready := slice.Endpoints[epIdx].Conditions.Ready
+		if ready == nil || !*ready {
+			continue
+		}
+
+		hadReady = true
+
+		if !resolvable {
+			continue
+		}
+
+		for _, addr := range slice.Endpoints[epIdx].Addresses {
+			out = append(out, proxy.ResolvedEndpoint{Host: addr, Port: endpointPort})
+		}
+	}
+
+	return out, hadReady
+}
+
+// endpointSlicePort resolves the endpoint port from the slice: the port whose name
+// matches the selected Service port, or the sole port of a single-port slice. The
+// bool is false when the slice does not unambiguously resolve the port (a
+// multi-port slice with no name match), so the caller can fall back to a numeric
+// targetPort or skip rather than dial a guessed port.
+func endpointSlicePort(slice *discoveryv1.EndpointSlice, portName string) (int32, bool) {
+	for i := range slice.Ports {
+		slicePort := slice.Ports[i]
+		if slicePort.Port == nil {
+			continue
+		}
+
+		named := slicePort.Name != nil && *slicePort.Name == portName
+		unnamed := slicePort.Name == nil && portName == ""
+
+		if named || unnamed {
+			return *slicePort.Port, true
+		}
+	}
+
+	if len(slice.Ports) == 1 && slice.Ports[0].Port != nil {
+		return *slice.Ports[0].Port, true
+	}
+
+	return 0, false
+}

--- a/internal/controller/headless_backends_test.go
+++ b/internal/controller/headless_backends_test.go
@@ -1,0 +1,456 @@
+package controller
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// --- headless test fixtures -------------------------------------------------
+
+func svcPort(name string, port, target int32) corev1.ServicePort {
+	return corev1.ServicePort{
+		Name:       name,
+		Port:       port,
+		TargetPort: intstr.FromInt32(target),
+		Protocol:   corev1.ProtocolTCP,
+	}
+}
+
+// svcPortNamedTarget builds a Service port whose targetPort is a NAMED container
+// port (not numeric), so it can only be resolved to a number via the EndpointSlice.
+func svcPortNamedTarget(name string, port int32, targetName string) corev1.ServicePort {
+	return corev1.ServicePort{
+		Name:       name,
+		Port:       port,
+		TargetPort: intstr.FromString(targetName),
+		Protocol:   corev1.ProtocolTCP,
+	}
+}
+
+func headlessSvc(name, namespace string, ports ...corev1.ServicePort) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: corev1.ClusterIPNone,
+			Ports:     ports,
+		},
+	}
+}
+
+func epPort(name string, port int32) discoveryv1.EndpointPort {
+	pn := name
+	pp := port
+
+	return discoveryv1.EndpointPort{Name: &pn, Port: &pp}
+}
+
+type epAddr struct {
+	addr  string
+	ready bool
+}
+
+func headlessSlice(
+	sliceName, namespace, svcName string,
+	addrType discoveryv1.AddressType,
+	ports []discoveryv1.EndpointPort,
+	addrs []epAddr,
+) *discoveryv1.EndpointSlice {
+	endpoints := make([]discoveryv1.Endpoint, 0, len(addrs))
+	for _, a := range addrs {
+		ready := a.ready
+		endpoints = append(endpoints, discoveryv1.Endpoint{
+			Addresses:  []string{a.addr},
+			Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+		})
+	}
+
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sliceName,
+			Namespace: namespace,
+			Labels:    map[string]string{discoveryv1.LabelServiceName: svcName},
+		},
+		AddressType: addrType,
+		Ports:       ports,
+		Endpoints:   endpoints,
+	}
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestExpandHeadlessBackends_HeadlessWithReadyEndpoints proves a headless Service
+// is expanded into one backend per ready endpoint, dialing the endpoint
+// targetPort (3000) rather than the Service port (8080).
+func TestExpandHeadlessBackends_HeadlessWithReadyEndpoints(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(
+		headlessSvc("head", "default", svcPort("first-port", 8080, 3000)),
+		headlessSlice("head-ip4", "default", "head", discoveryv1.AddressTypeIPv4,
+			[]discoveryv1.EndpointPort{epPort("first-port", 3000)},
+			[]epAddr{{"10.1.0.1", true}, {"10.1.0.2", true}}),
+	).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://head.default.svc.cluster.local:8080", Weight: 1},
+	}}}}
+
+	routes := []*gatewayv1.HTTPRoute{httpRouteToSvc("r", "default", "head", 8080)}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", routes, nil)
+
+	assert.ElementsMatch(t, []string{
+		"http://10.1.0.1:3000",
+		"http://10.1.0.2:3000",
+	}, backendURLsCtrl(cfg.Rules[0].Backends), "headless Service dials each ready endpoint at the targetPort")
+}
+
+// TestExpandHeadlessBackends_NonHeadlessUnchanged proves a normal ClusterIP
+// Service (which has a VIP and is translated by kube-proxy) is left routing
+// through the Service FQDN.
+func TestExpandHeadlessBackends_NonHeadlessUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(
+		clusterIPSvc("app", "default"),
+		headlessSlice("app-ip4", "default", "app", discoveryv1.AddressTypeIPv4,
+			[]discoveryv1.EndpointPort{epPort("first-port", 3000)},
+			[]epAddr{{"10.1.0.1", true}}),
+	).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://app.default.svc.cluster.local:8080", Weight: 1},
+	}}}}
+
+	routes := []*gatewayv1.HTTPRoute{httpRouteToSvc("r", "default", "app", 8080)}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", routes, nil)
+
+	assert.Equal(t, []string{"http://app.default.svc.cluster.local:8080"},
+		backendURLsCtrl(cfg.Rules[0].Backends), "a ClusterIP Service must keep routing through its VIP")
+}
+
+// TestExpandHeadlessBackends_ExternalNameUnchanged proves an ExternalName Service
+// is never expanded (it has no ClusterIP and no EndpointSlices).
+func TestExpandHeadlessBackends_ExternalNameUnchanged(t *testing.T) {
+	t.Parallel()
+
+	extSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "ext", Namespace: "default"},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeExternalName, ExternalName: "api.example.com"},
+	}
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(extSvc).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://ext.default.svc.cluster.local:8080", Weight: 1},
+	}}}}
+
+	routes := []*gatewayv1.HTTPRoute{httpRouteToSvc("r", "default", "ext", 8080)}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", routes, nil)
+
+	assert.Equal(t, []string{"http://ext.default.svc.cluster.local:8080"},
+		backendURLsCtrl(cfg.Rules[0].Backends))
+}
+
+// TestExpandHeadlessBackends_NoReadyEndpoints_LeavesFQDN proves a headless
+// Service with zero ready endpoints keeps its FQDN backend so the downstream
+// zero-endpoint pass marks it 503 (rather than silently dropping all backends).
+func TestExpandHeadlessBackends_NoReadyEndpoints_LeavesFQDN(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(
+		headlessSvc("head", "default", svcPort("first-port", 8080, 3000)),
+		headlessSlice("head-ip4", "default", "head", discoveryv1.AddressTypeIPv4,
+			[]discoveryv1.EndpointPort{epPort("first-port", 3000)},
+			[]epAddr{{"10.1.0.1", false}}),
+	).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://head.default.svc.cluster.local:8080", Weight: 1},
+	}}}}
+
+	routes := []*gatewayv1.HTTPRoute{httpRouteToSvc("r", "default", "head", 8080)}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", routes, nil)
+
+	assert.Equal(t, []string{"http://head.default.svc.cluster.local:8080"},
+		backendURLsCtrl(cfg.Rules[0].Backends), "no ready endpoints → leave FQDN for the 503 path")
+}
+
+// TestExpandHeadlessBackends_OnlyReadyEndpoints proves a not-ready endpoint in an
+// otherwise-ready slice is excluded from the expansion.
+func TestExpandHeadlessBackends_OnlyReadyEndpoints(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(
+		headlessSvc("head", "default", svcPort("first-port", 8080, 3000)),
+		headlessSlice("head-ip4", "default", "head", discoveryv1.AddressTypeIPv4,
+			[]discoveryv1.EndpointPort{epPort("first-port", 3000)},
+			[]epAddr{{"10.1.0.1", true}, {"10.1.0.2", false}}),
+	).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://head.default.svc.cluster.local:8080", Weight: 1},
+	}}}}
+
+	routes := []*gatewayv1.HTTPRoute{httpRouteToSvc("r", "default", "head", 8080)}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", routes, nil)
+
+	assert.Equal(t, []string{"http://10.1.0.1:3000"},
+		backendURLsCtrl(cfg.Rules[0].Backends), "only ready endpoints are expanded")
+}
+
+// TestExpandHeadlessBackends_TargetPortNameMatch proves the endpoint port is
+// resolved by matching the EndpointSlice port NAME to the Service port the
+// backendRef selected — not by position — when a Service exposes multiple ports.
+func TestExpandHeadlessBackends_TargetPortNameMatch(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(
+		headlessSvc("head", "default",
+			svcPort("a", 8080, 3000),
+			svcPort("b", 9090, 4000)),
+		headlessSlice("head-ip4", "default", "head", discoveryv1.AddressTypeIPv4,
+			[]discoveryv1.EndpointPort{epPort("a", 3000), epPort("b", 4000)},
+			[]epAddr{{"10.1.0.1", true}}),
+	).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://head.default.svc.cluster.local:8080", Weight: 1},
+	}}}}
+
+	// backendRef selects Service port 8080 (name "a") → endpoint port 3000.
+	routes := []*gatewayv1.HTTPRoute{httpRouteToSvc("r", "default", "head", 8080)}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", routes, nil)
+
+	assert.Equal(t, []string{"http://10.1.0.1:3000"},
+		backendURLsCtrl(cfg.Rules[0].Backends), "the matching-named port (3000), not the other port (4000)")
+}
+
+// TestExpandHeadlessBackends_IPv6Endpoint proves an IPv6 endpoint address is
+// bracketed in the dial URL.
+func TestExpandHeadlessBackends_IPv6Endpoint(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(
+		headlessSvc("head", "default", svcPort("first-port", 8080, 3000)),
+		headlessSlice("head-ip6", "default", "head", discoveryv1.AddressTypeIPv6,
+			[]discoveryv1.EndpointPort{epPort("first-port", 3000)},
+			[]epAddr{{"2001:db8::1", true}}),
+	).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://head.default.svc.cluster.local:8080", Weight: 1},
+	}}}}
+
+	routes := []*gatewayv1.HTTPRoute{httpRouteToSvc("r", "default", "head", 8080)}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", routes, nil)
+
+	assert.Equal(t, []string{"http://[2001:db8::1]:3000"},
+		backendURLsCtrl(cfg.Rules[0].Backends))
+}
+
+// TestExpandHeadlessBackends_SkipsUnauthorizedCrossNamespace proves the pass is
+// gated on cfg membership (proxy.UnmarkedBackendHosts): a cross-namespace headless
+// backend the converter dropped (no ReferenceGrant) is absent from cfg and must
+// never be read, keeping authorization symmetric with the other passes.
+func TestExpandHeadlessBackends_SkipsUnauthorizedCrossNamespace(t *testing.T) {
+	t.Parallel()
+
+	cli, counts := countingClient(t,
+		headlessSvc("secret", "other", svcPort("first-port", 8080, 3000)),
+		headlessSlice("secret-ip4", "other", "secret", discoveryv1.AddressTypeIPv4,
+			[]discoveryv1.EndpointPort{epPort("first-port", 3000)},
+			[]epAddr{{"10.9.0.1", true}}),
+	)
+
+	// The converter dropped the unauthorized cross-namespace ref, so it is not
+	// in cfg — only the authorized in-namespace backend is.
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://app.default.svc.cluster.local:80", Weight: 1},
+	}}}}
+
+	otherNS := gatewayv1.Namespace("other")
+	pSecret := gatewayv1.PortNumber(8080)
+	pApp := gatewayv1.PortNumber(80)
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{Rules: []gatewayv1.HTTPRouteRule{{
+			BackendRefs: []gatewayv1.HTTPBackendRef{
+				{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: "app", Port: &pApp,
+				}}},
+				{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: "secret", Namespace: &otherNS, Port: &pSecret,
+				}}},
+			},
+		}}},
+	}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local",
+		[]*gatewayv1.HTTPRoute{route}, nil)
+
+	assert.Zero(t, counts.serviceGets["other/secret"],
+		"a dropped cross-namespace backend must never be read by the headless pass")
+	assert.Equal(t, []string{"http://app.default.svc.cluster.local:80"},
+		backendURLsCtrl(cfg.Rules[0].Backends), "the authorized backend is untouched")
+}
+
+// TestExpandHeadlessBackends_GRPCRoute proves a GRPCRoute referencing a headless
+// Service is expanded too, preserving the h2c backend protocol.
+func TestExpandHeadlessBackends_GRPCRoute(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(
+		headlessSvc("grpc", "default", svcPort("grpc", 8080, 3000)),
+		headlessSlice("grpc-ip4", "default", "grpc", discoveryv1.AddressTypeIPv4,
+			[]discoveryv1.EndpointPort{epPort("grpc", 3000)},
+			[]epAddr{{"10.1.0.5", true}}),
+	).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://grpc.default.svc.cluster.local:8080", Weight: 1, Protocol: proxy.BackendProtocolH2C},
+	}}}}
+
+	port := gatewayv1.PortNumber(8080)
+	grpcRoute := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "default"},
+		Spec: gatewayv1.GRPCRouteSpec{Rules: []gatewayv1.GRPCRouteRule{{
+			BackendRefs: []gatewayv1.GRPCBackendRef{
+				{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: "grpc", Port: &port,
+				}}},
+			},
+		}}},
+	}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", nil,
+		[]*gatewayv1.GRPCRoute{grpcRoute})
+
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Equal(t, "http://10.1.0.5:3000", cfg.Rules[0].Backends[0].URL)
+	assert.Equal(t, proxy.BackendProtocolH2C, cfg.Rules[0].Backends[0].Protocol,
+		"gRPC h2c protocol is inherited by the expanded endpoint")
+}
+
+// TestExpandHeadlessBackends_NamedTargetPortUnresolvable_FailsClosed proves the
+// fallback never reintroduces the 502: when a headless Service has READY endpoints
+// whose NAMED targetPort the EndpointSlice cannot resolve to a number (multi-port
+// slice, no matching port name), the backend is marked 503 rather than left as the
+// FQDN backend, which the proxy would dial at the Service port (8080) against a pod
+// listening on the targetPort → 502. The zero-endpoint pass cannot catch this (the
+// endpoints ARE ready), so the expand pass must fail it closed itself.
+func TestExpandHeadlessBackends_NamedTargetPortUnresolvable_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(
+		headlessSvc("head", "default",
+			svcPortNamedTarget("web", 8080, "http"),
+			svcPortNamedTarget("admin", 9090, "adminhttp")),
+		// Slice port names do not match the Service port names, so the named
+		// targetPort cannot be resolved to a number from the slice.
+		headlessSlice("head-ip4", "default", "head", discoveryv1.AddressTypeIPv4,
+			[]discoveryv1.EndpointPort{epPort("mismatch-a", 3000), epPort("mismatch-b", 4000)},
+			[]epAddr{{"10.1.0.1", true}}),
+	).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://head.default.svc.cluster.local:8080", Weight: 1},
+	}}}}
+
+	routes := []*gatewayv1.HTTPRoute{httpRouteToSvc("r", "default", "head", 8080)}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", routes, nil)
+
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Equal(t, "http://head.default.svc.cluster.local:8080", cfg.Rules[0].Backends[0].URL,
+		"an unresolvable named targetPort must NOT be expanded to dial the Service port (8080)")
+	assert.Equal(t, http.StatusServiceUnavailable, cfg.Rules[0].Backends[0].UnavailableStatus,
+		"ready-but-unresolvable endpoints must fail closed to 503, not fall through to a 502 dial")
+}
+
+// TestExpandHeadlessBackends_NumericTargetPortFallback proves that when the
+// EndpointSlice port name does not match (multi-port slice) but the Service port
+// has a NUMERIC targetPort, that numeric targetPort — the real pod port — is used,
+// never the Service port.
+func TestExpandHeadlessBackends_NumericTargetPortFallback(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(
+		headlessSvc("head", "default",
+			svcPort("a", 8080, 3000),
+			svcPort("b", 9090, 4000)),
+		// Slice port names do not match "a"/"b", forcing the numeric-targetPort fallback.
+		headlessSlice("head-ip4", "default", "head", discoveryv1.AddressTypeIPv4,
+			[]discoveryv1.EndpointPort{epPort("x", 3000), epPort("y", 4000)},
+			[]epAddr{{"10.1.0.1", true}}),
+	).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://head.default.svc.cluster.local:8080", Weight: 1},
+	}}}}
+
+	routes := []*gatewayv1.HTTPRoute{httpRouteToSvc("r", "default", "head", 8080)}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", routes, nil)
+
+	assert.Equal(t, []string{"http://10.1.0.1:3000"},
+		backendURLsCtrl(cfg.Rules[0].Backends),
+		"a numeric targetPort (3000) is the real pod port and must be used as the fallback, not the Service port")
+}
+
+// TestExpandHeadlessBackends_DualStack proves a dual-stack headless Service (one
+// IPv4 and one IPv6 EndpointSlice) expands to endpoints of both families.
+func TestExpandHeadlessBackends_DualStack(t *testing.T) {
+	t.Parallel()
+
+	cli := fake.NewClientBuilder().WithScheme(zeScheme(t)).WithObjects(
+		headlessSvc("head", "default", svcPort("first-port", 8080, 3000)),
+		headlessSlice("head-ip4", "default", "head", discoveryv1.AddressTypeIPv4,
+			[]discoveryv1.EndpointPort{epPort("first-port", 3000)},
+			[]epAddr{{"10.1.0.1", true}}),
+		headlessSlice("head-ip6", "default", "head", discoveryv1.AddressTypeIPv6,
+			[]discoveryv1.EndpointPort{epPort("first-port", 3000)},
+			[]epAddr{{"2001:db8::1", true}}),
+	).Build()
+
+	cfg := &proxy.Config{Rules: []proxy.RouteRule{{Backends: []proxy.BackendRef{
+		{URL: "http://head.default.svc.cluster.local:8080", Weight: 1},
+	}}}}
+
+	routes := []*gatewayv1.HTTPRoute{httpRouteToSvc("r", "default", "head", 8080)}
+
+	expandHeadlessBackends(context.Background(), cli, cfg, "cluster.local", routes, nil)
+
+	assert.ElementsMatch(t, []string{
+		"http://10.1.0.1:3000",
+		"http://[2001:db8::1]:3000",
+	}, backendURLsCtrl(cfg.Rules[0].Backends), "both IP families are expanded for a dual-stack headless Service")
+}
+
+// backendURLsCtrl collects backend URLs for assertions in controller-package tests.
+func backendURLsCtrl(backends []proxy.BackendRef) []string {
+	urls := make([]string, 0, len(backends))
+	for i := range backends {
+		urls = append(urls, backends[i].URL)
+	}
+
+	return urls
+}

--- a/internal/controller/proxy_syncer.go
+++ b/internal/controller/proxy_syncer.go
@@ -758,6 +758,15 @@ func (s *ProxySyncer) buildProxyConfig(
 		markUnavailableBackends(cfg, s.clusterDomain, grpcFailedRefs)
 	}
 
+	// Expand each headless Service (clusterIP: None) into one backend per ready
+	// endpoint, dialing the endpoint targetPort. A headless Service has no VIP, so
+	// the FQDN resolves to the pod IPs and dialing the Service port would reach a
+	// pod listening on the targetPort and 502. Runs after the 500 markings (so a
+	// dropped/invalid ref is never expanded) and before the 503 marking (so a
+	// headless Service with ready endpoints loses its FQDN host before the 503 pass
+	// looks, while one with no ready endpoints keeps it and gets marked 503).
+	expandHeadlessBackends(ctx, s.k8sClient, cfg, s.clusterDomain, routes, grpcRoutes)
+
 	// After the 500 (invalid-ref) markings, mark any backend whose Service
 	// exists but has no ready endpoints with 503 (Gateway API SHOULD). Runs
 	// last so the first-marking-wins rule keeps 500 for a backend that is both

--- a/internal/controller/proxy_syncer_test.go
+++ b/internal/controller/proxy_syncer_test.go
@@ -20,8 +20,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -869,4 +871,119 @@ func makeBackendRef(name string, port, weight int) gatewayv1.HTTPBackendRef {
 			Weight: &weightInt,
 		},
 	}
+}
+
+// syncHeadlessRouteConfig builds a headless Service (clusterIP: None, port 8080 →
+// targetPort 3000) with one EndpointSlice whose two endpoints carry the given
+// readiness, hands a route referencing it to SyncRoutes, and returns the pushed
+// proxy config. Shared by the headless expand / 503 integration tests.
+func syncHeadlessRouteConfig(t *testing.T, ready bool) proxy.Config {
+	t.Helper()
+
+	var receivedConfig proxy.Config
+
+	configServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodPut {
+			if decodeErr := json.NewDecoder(req.Body).Decode(&receivedConfig); decodeErr != nil {
+				writer.WriteHeader(http.StatusBadRequest)
+
+				return
+			}
+		}
+
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer configServer.Close()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, discoveryv1.AddToScheme(scheme))
+
+	portName := "first-port"
+	endpointPort := int32(3000)
+	epReady := ready
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "head", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: corev1.ClusterIPNone,
+			Ports: []corev1.ServicePort{
+				{Name: portName, Port: 8080, TargetPort: intstr.FromInt32(3000), Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+	slice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "head-ip4",
+			Namespace: "default",
+			Labels:    map[string]string{discoveryv1.LabelServiceName: "head"},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Ports:       []discoveryv1.EndpointPort{{Name: &portName, Port: &endpointPort}},
+		Endpoints: []discoveryv1.Endpoint{
+			{Addresses: []string{"10.1.0.1"}, Conditions: discoveryv1.EndpointConditions{Ready: &epReady}},
+			{Addresses: []string{"10.1.0.2"}, Conditions: discoveryv1.EndpointConditions{Ready: &epReady}},
+		},
+	}
+
+	testClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc, slice).Build()
+	syncer := controller.NewProxySyncer("cluster.local", "", "", testClient, slog.Default())
+
+	pathPrefix := gatewayv1.PathMatchPathPrefix
+	routes := []*gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "head-route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"head.example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches:     []gatewayv1.HTTPRouteMatch{{Path: &gatewayv1.HTTPPathMatch{Type: &pathPrefix, Value: new("/")}}},
+						BackendRefs: []gatewayv1.HTTPBackendRef{makeBackendRef("head", 8080, 1)},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := syncer.SyncRoutes(context.Background(), []string{configServer.URL + "/config"}, routes, nil, nil, nil)
+	require.NoError(t, err)
+
+	return receivedConfig
+}
+
+// TestProxySyncer_SyncRoutes_HeadlessBackend pins the end-to-end wiring: a route
+// to a headless Service with ready endpoints is pushed to the proxy as one
+// backend per endpoint, dialing the targetPort (3000) — not the Service port.
+func TestProxySyncer_SyncRoutes_HeadlessBackend(t *testing.T) {
+	t.Parallel()
+
+	cfg := syncHeadlessRouteConfig(t, true)
+
+	require.Len(t, cfg.Rules, 1)
+
+	urls := make([]string, 0, len(cfg.Rules[0].Backends))
+	for i := range cfg.Rules[0].Backends {
+		urls = append(urls, cfg.Rules[0].Backends[i].URL)
+		assert.Zero(t, cfg.Rules[0].Backends[i].UnavailableStatus, "ready endpoints are dialable, not marked")
+	}
+
+	assert.ElementsMatch(t, []string{"http://10.1.0.1:3000", "http://10.1.0.2:3000"}, urls,
+		"a headless Service expands to one backend per ready endpoint at the targetPort")
+}
+
+// TestProxySyncer_SyncRoutes_HeadlessNoReadyEndpoints503 pins the ordering: a
+// headless Service with no ready endpoints keeps its FQDN backend and is marked
+// 503 by the zero-endpoint pass (not silently dropped, not expanded).
+func TestProxySyncer_SyncRoutes_HeadlessNoReadyEndpoints503(t *testing.T) {
+	t.Parallel()
+
+	cfg := syncHeadlessRouteConfig(t, false)
+
+	require.Len(t, cfg.Rules, 1)
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Equal(t, "http://head.default.svc.cluster.local:8080", cfg.Rules[0].Backends[0].URL,
+		"no ready endpoints → the FQDN backend is kept")
+	assert.Equal(t, http.StatusServiceUnavailable, cfg.Rules[0].Backends[0].UnavailableStatus,
+		"and is marked 503 by the zero-endpoint pass")
 }

--- a/internal/controller/service_backend_visit.go
+++ b/internal/controller/service_backend_visit.go
@@ -1,0 +1,104 @@
+package controller
+
+import (
+	"context"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// serviceBackendAction is invoked once per distinct authorized, unmarked Service
+// backend referenced by the routes. The caller's closure captures cli/cfg/
+// clusterDomain; the visitor supplies the resolved Service identity.
+type serviceBackendAction func(ctx context.Context, svcNamespace, name string, port int32)
+
+// visitAuthorizedServiceBackends invokes action once per distinct Service backend
+// that is present and unmarked in cfg (proxy.UnmarkedBackendHosts) and referenced
+// by the given HTTP or gRPC routes. Gating on cfg membership keeps authorization
+// symmetric across the post-conversion passes (headless expansion, zero-endpoint
+// 503 marking): a ref the converter dropped — unauthorized cross-namespace,
+// invalid kind/port — or one already marked is never visited. Each Service
+// identity (host) is visited once per reconcile even when many rules reference it.
+func visitAuthorizedServiceBackends(
+	ctx context.Context,
+	cfg *proxy.Config,
+	clusterDomain string,
+	routes []*gatewayv1.HTTPRoute,
+	grpcRoutes []*gatewayv1.GRPCRoute,
+	action serviceBackendAction,
+) {
+	authorized := proxy.UnmarkedBackendHosts(cfg)
+	if len(authorized) == 0 {
+		return
+	}
+
+	visitor := &serviceBackendVisitor{
+		clusterDomain: clusterDomain,
+		authorized:    authorized,
+		seen:          make(map[string]struct{}),
+		action:        action,
+	}
+
+	for _, route := range routes {
+		for ruleIdx := range route.Spec.Rules {
+			for _, ref := range route.Spec.Rules[ruleIdx].BackendRefs {
+				visitor.visit(ctx, route.Namespace, ref.BackendObjectReference)
+			}
+		}
+	}
+
+	for _, route := range grpcRoutes {
+		for ruleIdx := range route.Spec.Rules {
+			for _, ref := range route.Spec.Rules[ruleIdx].BackendRefs {
+				visitor.visit(ctx, route.Namespace, ref.BackendObjectReference)
+			}
+		}
+	}
+}
+
+// serviceBackendVisitor carries the per-reconcile state shared by the
+// post-conversion Service-backend passes: the set of authorized, unmarked backend
+// hosts from cfg, the set of Service identities already visited (dedup), and the
+// action to run per distinct backend.
+type serviceBackendVisitor struct {
+	clusterDomain string
+	authorized    map[string]struct{}
+	seen          map[string]struct{}
+	action        serviceBackendAction
+}
+
+// visit runs the action for one backendRef unless it is not a Service ref, was
+// dropped/marked by the converter (absent from the authorized set), or has
+// already been visited this reconcile.
+func (v *serviceBackendVisitor) visit(ctx context.Context, routeNamespace string, ref gatewayv1.BackendObjectReference) {
+	if !proxy.IsServiceBackendRef(ref) {
+		return
+	}
+
+	svcNamespace := routeNamespace
+	if ref.Namespace != nil {
+		svcNamespace = string(*ref.Namespace)
+	}
+
+	port := defaultBackendPort
+	if ref.Port != nil {
+		// gatewayv1.PortNumber is a type alias for int32, so no conversion.
+		port = *ref.Port
+	}
+
+	name := string(ref.Name)
+
+	host := proxy.ServiceBackendHost(v.clusterDomain, svcNamespace, name, port)
+	if _, ok := v.authorized[host]; !ok {
+		return
+	}
+
+	if _, dup := v.seen[host]; dup {
+		return
+	}
+
+	v.seen[host] = struct{}{}
+
+	v.action(ctx, svcNamespace, name, port)
+}

--- a/internal/controller/zero_endpoint_backends.go
+++ b/internal/controller/zero_endpoint_backends.go
@@ -43,79 +43,10 @@ func markZeroEndpointBackends(
 		return
 	}
 
-	authorized := proxy.UnmarkedBackendHosts(cfg)
-	if len(authorized) == 0 {
-		return
-	}
-
-	scope := &zeroEndpointScope{
-		cli: cli, cfg: cfg, clusterDomain: clusterDomain,
-		authorized: authorized, seen: make(map[string]struct{}),
-	}
-
-	for _, route := range routes {
-		for ruleIdx := range route.Spec.Rules {
-			for _, ref := range route.Spec.Rules[ruleIdx].BackendRefs {
-				scope.visit(ctx, route.Namespace, ref.BackendObjectReference)
-			}
-		}
-	}
-
-	for _, route := range grpcRoutes {
-		for ruleIdx := range route.Spec.Rules {
-			for _, ref := range route.Spec.Rules[ruleIdx].BackendRefs {
-				scope.visit(ctx, route.Namespace, ref.BackendObjectReference)
-			}
-		}
-	}
-}
-
-// zeroEndpointScope carries the per-reconcile state for the 503 marking pass:
-// the set of authorized, unmarked backend hosts from cfg and the set of Service
-// identities already inspected this reconcile (dedup).
-type zeroEndpointScope struct {
-	cli           client.Client
-	cfg           *proxy.Config
-	clusterDomain string
-	authorized    map[string]struct{}
-	seen          map[string]struct{}
-}
-
-// visit inspects one backendRef: it is skipped unless it is a Service ref that
-// is present and unmarked in cfg (the converter's authorization decision) and
-// has not already been inspected this reconcile.
-func (s *zeroEndpointScope) visit(ctx context.Context, routeNamespace string, ref gatewayv1.BackendObjectReference) {
-	if !proxy.IsServiceBackendRef(ref) {
-		return
-	}
-
-	svcNamespace := routeNamespace
-	if ref.Namespace != nil {
-		svcNamespace = string(*ref.Namespace)
-	}
-
-	port := defaultBackendPort
-	if ref.Port != nil {
-		// gatewayv1.PortNumber is a type alias for int32, so no conversion.
-		port = *ref.Port
-	}
-
-	name := string(ref.Name)
-
-	host := proxy.ServiceBackendHost(s.clusterDomain, svcNamespace, name, port)
-	if _, ok := s.authorized[host]; !ok {
-		// Dropped by the converter (unauthorized / invalid) or already
-		// marked 500 — not ours to inspect.
-		return
-	}
-
-	if _, dup := s.seen[host]; dup {
-		return
-	}
-
-	s.seen[host] = struct{}{}
-
-	markBackendIfZeroEndpoints(ctx, s.cli, s.cfg, s.clusterDomain, svcNamespace, name, port)
+	visitAuthorizedServiceBackends(ctx, cfg, clusterDomain, routes, grpcRoutes,
+		func(ctx context.Context, svcNamespace, name string, port int32) {
+			markBackendIfZeroEndpoints(ctx, cli, cfg, clusterDomain, svcNamespace, name, port)
+		})
 }
 
 // markBackendIfZeroEndpoints marks the backend 503 when the named Service is a

--- a/internal/proxy/expand_headless.go
+++ b/internal/proxy/expand_headless.go
@@ -1,0 +1,187 @@
+package proxy
+
+import (
+	"math"
+	"net"
+	"net/url"
+	"strconv"
+)
+
+// ResolvedEndpoint is one ready endpoint of a headless Service: the dial host
+// (a pod IP, or rarely an FQDN for an FQDN-type EndpointSlice) and the endpoint
+// port — the resolved targetPort that the pod actually listens on, taken from the
+// EndpointSlice rather than the Service port.
+type ResolvedEndpoint struct {
+	Host string
+	Port int32
+}
+
+// ExpandHeadlessBackend replaces every unmarked, weight>0 backend in cfg whose
+// service host:port matches (namespace, name, servicePort) with one backend per
+// resolved endpoint, dialing the endpoint host:port instead of the Service FQDN
+// at the Service port. It is how the controller routes to a headless Service
+// (clusterIP: None), which has no VIP: the FQDN resolves straight to the pod IPs,
+// so dialing the Service port (8080) reaches a pod that listens on the targetPort
+// (3000) and fails. Each endpoint dials the resolved targetPort instead.
+//
+// Matching is on the URL host via ServiceBackendHost — the same scheme-agnostic
+// identity key as MarkUnavailableBackends — so an https (port-443 or TLS-policy)
+// backend still matches. Already-marked backends (500/503) and weight-0 refs are
+// left untouched: a marking carries that backend's traffic fraction and must
+// survive, and a weight-0 ref takes no traffic so expanding it would only perturb
+// sibling weights.
+//
+// Weight handling preserves the Gateway API traffic proportion. Within a rule,
+// the matched backend (weight W) becomes N endpoints each of weight W, and every
+// other backend's weight is scaled by N. The matched ref's aggregate is then N*W
+// against siblings scaled by N, so the inter-backendRef ratio is unchanged while
+// the N endpoints split that fraction equally. Applied once per Service, multiple
+// headless services in one rule compose to the correct aggregate ratio. After
+// scaling, the rule's weights are divided by their GCD to keep magnitudes small;
+// the per-backend scale is computed in int64 and clamped to guard int32 overflow.
+//
+// Per-endpoint backends inherit the matched backend's Protocol, TLS (the SNI/
+// ServerName lives in BackendTLSConfig, not the URL host, so it stays correct
+// when the URL becomes an IP), Filters and WebSocket flag — only the dial URL
+// changes. An empty endpoint set is a no-op, leaving the FQDN backend so the
+// zero-endpoint pass can mark it 503.
+func ExpandHeadlessBackend(cfg *Config, clusterDomain, namespace, name string, servicePort int32, endpoints []ResolvedEndpoint) {
+	if cfg == nil || len(endpoints) == 0 {
+		return
+	}
+
+	target := ServiceBackendHost(clusterDomain, namespace, name, servicePort)
+	if target == "" {
+		return
+	}
+
+	//nolint:gosec // endpoint count is bounded by EndpointSlice size, never overflows int32
+	scale := int32(len(endpoints))
+
+	for ruleIdx := range cfg.Rules {
+		expandRuleBackends(&cfg.Rules[ruleIdx], target, scale, endpoints)
+	}
+}
+
+// expandRuleBackends rewrites a single rule's backend list when it contains an
+// expandable backend matching target, scaling siblings and reducing by GCD.
+func expandRuleBackends(rule *RouteRule, target string, scale int32, endpoints []ResolvedEndpoint) {
+	if !ruleHasExpandableBackend(rule, target) {
+		return
+	}
+
+	expanded := make([]BackendRef, 0, len(rule.Backends)+len(endpoints))
+
+	for i := range rule.Backends {
+		backend := rule.Backends[i]
+		if backendMatchesHeadless(&backend, target) {
+			expanded = append(expanded, endpointBackends(&backend, endpoints)...)
+
+			continue
+		}
+
+		backend.Weight = scaleWeight(backend.Weight, scale)
+		expanded = append(expanded, backend)
+	}
+
+	rule.Backends = expanded
+	reduceWeightsByGCD(rule.Backends)
+}
+
+// ruleHasExpandableBackend reports whether the rule contains at least one
+// unmarked, weight>0 backend matching target.
+func ruleHasExpandableBackend(rule *RouteRule, target string) bool {
+	for i := range rule.Backends {
+		if backendMatchesHeadless(&rule.Backends[i], target) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// backendMatchesHeadless reports whether a backend is an expandable match for the
+// target service host: unmarked, carrying traffic, and on the target host.
+func backendMatchesHeadless(backend *BackendRef, target string) bool {
+	if backend.UnavailableStatus != 0 || backend.Weight <= 0 {
+		return false
+	}
+
+	parsed, err := url.Parse(backend.URL)
+
+	return err == nil && parsed.Host == target
+}
+
+// endpointBackends clones the matched backend once per endpoint, swapping only
+// the dial URL to the endpoint host:port (IPv6 auto-bracketed via JoinHostPort).
+func endpointBackends(matched *BackendRef, endpoints []ResolvedEndpoint) []BackendRef {
+	scheme := backendScheme(matched.URL)
+	out := make([]BackendRef, 0, len(endpoints))
+
+	for _, ep := range endpoints {
+		backend := *matched
+		backend.URL = scheme + "://" + net.JoinHostPort(ep.Host, strconv.Itoa(int(ep.Port)))
+		out = append(out, backend)
+	}
+
+	return out
+}
+
+// backendScheme extracts the scheme from a backend URL, defaulting to http when
+// it cannot be parsed.
+func backendScheme(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err == nil && parsed.Scheme != "" {
+		return parsed.Scheme
+	}
+
+	return schemeHTTP
+}
+
+// scaleWeight multiplies a weight by scale in int64, clamping to MaxInt32 so a
+// pathological product never wraps negative; GCD reduction keeps realistic
+// magnitudes small.
+func scaleWeight(weight, scale int32) int32 {
+	scaled := int64(weight) * int64(scale)
+	if scaled > math.MaxInt32 {
+		return math.MaxInt32
+	}
+
+	//nolint:gosec // clamped to MaxInt32 above; inputs are non-negative
+	return int32(scaled)
+}
+
+// reduceWeightsByGCD divides every weight in the slice by their greatest common
+// divisor, preserving ratios while shrinking magnitudes. A GCD of 0 or 1 is a
+// no-op.
+func reduceWeightsByGCD(backends []BackendRef) {
+	var divisor int32
+	for i := range backends {
+		divisor = gcdInt32(divisor, backends[i].Weight)
+	}
+
+	if divisor <= 1 {
+		return
+	}
+
+	for i := range backends {
+		backends[i].Weight /= divisor
+	}
+}
+
+// gcdInt32 returns the greatest common divisor of |m| and |n|; gcd(0, x) == |x|.
+func gcdInt32(m, n int32) int32 {
+	if m < 0 {
+		m = -m
+	}
+
+	if n < 0 {
+		n = -n
+	}
+
+	for n != 0 {
+		m, n = n, m%n
+	}
+
+	return m
+}

--- a/internal/proxy/expand_headless_test.go
+++ b/internal/proxy/expand_headless_test.go
@@ -1,0 +1,350 @@
+package proxy_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/proxy"
+)
+
+// backendURLs collects the resolved URLs of a rule's backends, preserving order,
+// so tests can assert on the expanded endpoint set.
+func backendURLs(backends []proxy.BackendRef) []string {
+	urls := make([]string, 0, len(backends))
+	for i := range backends {
+		urls = append(urls, backends[i].URL)
+	}
+
+	return urls
+}
+
+// TestExpandHeadlessBackend_SingleBackendExpands proves a lone headless backend
+// is replaced by one backend per resolved endpoint, dialing the endpoint port
+// (3000) rather than the Service port (8080).
+func TestExpandHeadlessBackend_SingleBackendExpands(t *testing.T) {
+	t.Parallel()
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Backends: []proxy.BackendRef{
+					{URL: "http://headless.default.svc.cluster.local:8080", Weight: 1},
+				},
+			},
+		},
+	}
+
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "headless", 8080, []proxy.ResolvedEndpoint{
+		{Host: "10.0.0.1", Port: 3000},
+		{Host: "10.0.0.2", Port: 3000},
+	})
+
+	assert.Equal(t, []string{
+		"http://10.0.0.1:3000",
+		"http://10.0.0.2:3000",
+	}, backendURLs(cfg.Rules[0].Backends))
+
+	for i := range cfg.Rules[0].Backends {
+		assert.Equal(t, int32(1), cfg.Rules[0].Backends[i].Weight, "single backendRef → equal endpoint weights")
+	}
+}
+
+// TestExpandHeadlessBackend_InheritsFields proves the per-endpoint backends carry
+// the matched backend's Protocol, TLS, Filters and WebSocket flag — only the dial
+// URL changes.
+func TestExpandHeadlessBackend_InheritsFields(t *testing.T) {
+	t.Parallel()
+
+	tlsCfg := &proxy.BackendTLSConfig{ServerName: "headless.default.svc.cluster.local"}
+	filters := []proxy.RouteFilter{{Type: proxy.FilterRequestHeaderModifier}}
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Backends: []proxy.BackendRef{
+					{
+						URL:       "https://headless.default.svc.cluster.local:8443",
+						Weight:    1,
+						Protocol:  proxy.BackendProtocolH2C,
+						TLS:       tlsCfg,
+						Filters:   filters,
+						WebSocket: true,
+					},
+				},
+			},
+		},
+	}
+
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "headless", 8443, []proxy.ResolvedEndpoint{
+		{Host: "10.0.0.1", Port: 3000},
+	})
+
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	got := cfg.Rules[0].Backends[0]
+	assert.Equal(t, "https://10.0.0.1:3000", got.URL, "scheme preserved, IP:targetPort dialed")
+	assert.Equal(t, proxy.BackendProtocolH2C, got.Protocol)
+	assert.Same(t, tlsCfg, got.TLS, "TLS config (with SNI) inherited")
+	assert.Equal(t, filters, got.Filters)
+	assert.True(t, got.WebSocket)
+}
+
+// TestExpandHeadlessBackend_IPv6Bracketed proves an IPv6 endpoint address is
+// bracketed in the dial URL so the host:port parses correctly.
+func TestExpandHeadlessBackend_IPv6Bracketed(t *testing.T) {
+	t.Parallel()
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Backends: []proxy.BackendRef{
+					{URL: "http://headless.default.svc.cluster.local:8080", Weight: 1},
+				},
+			},
+		},
+	}
+
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "headless", 8080, []proxy.ResolvedEndpoint{
+		{Host: "2001:db8::1", Port: 3000},
+	})
+
+	assert.Equal(t, []string{"http://[2001:db8::1]:3000"}, backendURLs(cfg.Rules[0].Backends))
+}
+
+// TestExpandHeadlessBackend_PreservesProportionWithSibling proves that expanding a
+// headless backendRef sharing a rule with a non-headless sibling keeps the
+// headless ref's Gateway API traffic proportion: the sibling weight is scaled by
+// the endpoint count so the aggregate ratio is unchanged.
+func TestExpandHeadlessBackend_PreservesProportionWithSibling(t *testing.T) {
+	t.Parallel()
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Backends: []proxy.BackendRef{
+					{URL: "http://headless.default.svc.cluster.local:8080", Weight: 1},
+					{URL: "http://clusterip.default.svc.cluster.local:80", Weight: 1},
+				},
+			},
+		},
+	}
+
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "headless", 8080, []proxy.ResolvedEndpoint{
+		{Host: "10.0.0.1", Port: 3000},
+		{Host: "10.0.0.2", Port: 3000},
+		{Host: "10.0.0.3", Port: 3000},
+	})
+
+	backends := cfg.Rules[0].Backends
+	require.Len(t, backends, 4, "3 endpoints + 1 sibling")
+
+	// Three endpoints, each weight 1 → headless aggregate 3.
+	var headlessTotal, sibling int32
+	for i := range backends {
+		if backends[i].URL == "http://clusterip.default.svc.cluster.local:80" {
+			sibling = backends[i].Weight
+			continue
+		}
+
+		assert.Equal(t, int32(1), backends[i].Weight, "endpoints split equally")
+		headlessTotal += backends[i].Weight
+	}
+
+	assert.Equal(t, int32(3), sibling, "sibling scaled by endpoint count")
+	assert.Equal(t, headlessTotal, sibling, "1:1 backendRef ratio preserved (3:3)")
+}
+
+// TestExpandHeadlessBackend_GCDReduction proves weights are reduced by their GCD
+// after scaling so magnitudes stay small while ratios are preserved.
+func TestExpandHeadlessBackend_GCDReduction(t *testing.T) {
+	t.Parallel()
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Backends: []proxy.BackendRef{
+					{URL: "http://headless.default.svc.cluster.local:8080", Weight: 2},
+					{URL: "http://clusterip.default.svc.cluster.local:80", Weight: 4},
+				},
+			},
+		},
+	}
+
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "headless", 8080, []proxy.ResolvedEndpoint{
+		{Host: "10.0.0.1", Port: 3000},
+		{Host: "10.0.0.2", Port: 3000},
+	})
+
+	// Pre-GCD: endpoints 2,2 ; sibling 4*2=8 → {2,2,8}, GCD 2 → {1,1,4}.
+	backends := cfg.Rules[0].Backends
+	require.Len(t, backends, 3)
+
+	var sibling int32
+	for i := range backends {
+		if backends[i].URL == "http://clusterip.default.svc.cluster.local:80" {
+			sibling = backends[i].Weight
+			continue
+		}
+
+		assert.Equal(t, int32(1), backends[i].Weight)
+	}
+
+	assert.Equal(t, int32(4), sibling)
+}
+
+// TestExpandHeadlessBackend_MultipleHeadlessCompose proves two sequential
+// expansions of distinct headless services in one rule compose to the correct
+// aggregate ratio (the controller calls the helper once per Service).
+func TestExpandHeadlessBackend_MultipleHeadlessCompose(t *testing.T) {
+	t.Parallel()
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Backends: []proxy.BackendRef{
+					{URL: "http://a.default.svc.cluster.local:8080", Weight: 1},
+					{URL: "http://b.default.svc.cluster.local:8080", Weight: 1},
+					{URL: "http://c.default.svc.cluster.local:80", Weight: 1},
+				},
+			},
+		},
+	}
+
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "a", 8080, []proxy.ResolvedEndpoint{
+		{Host: "10.0.0.1", Port: 3000},
+		{Host: "10.0.0.2", Port: 3000},
+	})
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "b", 8080, []proxy.ResolvedEndpoint{
+		{Host: "10.0.1.1", Port: 3000},
+		{Host: "10.0.1.2", Port: 3000},
+		{Host: "10.0.1.3", Port: 3000},
+	})
+
+	var aTotal, bTotal, cTotal int32
+	aCount, bCount := 0, 0
+	for _, b := range cfg.Rules[0].Backends {
+		switch {
+		case b.URL == "http://c.default.svc.cluster.local:80":
+			cTotal += b.Weight
+		case hasPrefix(b.URL, "http://10.0.0."):
+			aTotal += b.Weight
+			aCount++
+		case hasPrefix(b.URL, "http://10.0.1."):
+			bTotal += b.Weight
+			bCount++
+		}
+	}
+
+	assert.Equal(t, 2, aCount, "service a → 2 endpoints")
+	assert.Equal(t, 3, bCount, "service b → 3 endpoints")
+	assert.Equal(t, aTotal, bTotal, "a:b aggregate ratio preserved (1:1)")
+	assert.Equal(t, aTotal, cTotal, "a:c aggregate ratio preserved (1:1)")
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+// TestExpandHeadlessBackend_ZeroEndpoints_NoOp proves a headless Service with no
+// resolved endpoints leaves the FQDN backend untouched so the downstream
+// zero-endpoint pass can mark it 503.
+func TestExpandHeadlessBackend_ZeroEndpoints_NoOp(t *testing.T) {
+	t.Parallel()
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Backends: []proxy.BackendRef{
+					{URL: "http://headless.default.svc.cluster.local:8080", Weight: 1},
+				},
+			},
+		},
+	}
+
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "headless", 8080, nil)
+
+	assert.Equal(t, []string{"http://headless.default.svc.cluster.local:8080"}, backendURLs(cfg.Rules[0].Backends))
+}
+
+// TestExpandHeadlessBackend_NonMatchingHost_Untouched proves a backend on a
+// different service identity is not expanded.
+func TestExpandHeadlessBackend_NonMatchingHost_Untouched(t *testing.T) {
+	t.Parallel()
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Backends: []proxy.BackendRef{
+					{URL: "http://other.default.svc.cluster.local:8080", Weight: 1},
+				},
+			},
+		},
+	}
+
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "headless", 8080, []proxy.ResolvedEndpoint{
+		{Host: "10.0.0.1", Port: 3000},
+	})
+
+	assert.Equal(t, []string{"http://other.default.svc.cluster.local:8080"}, backendURLs(cfg.Rules[0].Backends))
+	assert.Equal(t, int32(1), cfg.Rules[0].Backends[0].Weight, "non-matching weight untouched")
+}
+
+// TestExpandHeadlessBackend_SkipsMarkedBackend proves an already-marked backend
+// (500/503) matching the host is not expanded — the marking carries its traffic
+// fraction and must survive.
+func TestExpandHeadlessBackend_SkipsMarkedBackend(t *testing.T) {
+	t.Parallel()
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Backends: []proxy.BackendRef{
+					{
+						URL:               "http://headless.default.svc.cluster.local:8080",
+						Weight:            1,
+						UnavailableStatus: http.StatusInternalServerError,
+					},
+				},
+			},
+		},
+	}
+
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "headless", 8080, []proxy.ResolvedEndpoint{
+		{Host: "10.0.0.1", Port: 3000},
+	})
+
+	require.Len(t, cfg.Rules[0].Backends, 1)
+	assert.Equal(t, "http://headless.default.svc.cluster.local:8080", cfg.Rules[0].Backends[0].URL)
+	assert.Equal(t, http.StatusInternalServerError, cfg.Rules[0].Backends[0].UnavailableStatus)
+}
+
+// TestExpandHeadlessBackend_WeightZeroNotExpanded proves a weight-0 headless
+// backendRef is left as the FQDN backend (it carries no traffic, and expanding it
+// would needlessly perturb sibling weights).
+func TestExpandHeadlessBackend_WeightZeroNotExpanded(t *testing.T) {
+	t.Parallel()
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{
+				Backends: []proxy.BackendRef{
+					{URL: "http://headless.default.svc.cluster.local:8080", Weight: 0},
+					{URL: "http://clusterip.default.svc.cluster.local:80", Weight: 1},
+				},
+			},
+		},
+	}
+
+	proxy.ExpandHeadlessBackend(cfg, "cluster.local", "default", "headless", 8080, []proxy.ResolvedEndpoint{
+		{Host: "10.0.0.1", Port: 3000},
+		{Host: "10.0.0.2", Port: 3000},
+	})
+
+	assert.Equal(t, []string{
+		"http://headless.default.svc.cluster.local:8080",
+		"http://clusterip.default.svc.cluster.local:80",
+	}, backendURLs(cfg.Rules[0].Backends), "weight-0 headless untouched; sibling not scaled")
+	assert.Equal(t, int32(1), cfg.Rules[0].Backends[1].Weight)
+}

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -237,22 +237,6 @@ func conformanceSkipTests() []string {
 		// Tunnel doesn't expose multiple ports.
 		"HTTPRouteListenerPortMatching",
 
-		// HTTPRouteServiceTypes routes to three backends: a normal ClusterIP
-		// Service with manual EndpointSlices (passes), and two headless
-		// Services (clusterIP: None) — one with a selector, one with manual
-		// EndpointSlices (both 502). The proxy builds upstreams as the Service
-		// FQDN at the Service port (converter.go buildServiceURL) and relies on
-		// kube-proxy to translate the Service VIP port to the endpoint
-		// targetPort. A headless Service has no VIP, so the FQDN resolves to the
-		// endpoint IPs and the proxy dials them at the Service port (8080) while
-		// the endpoints listen on the targetPort (3000) -> connection fails.
-		// Headless backend support is tracked in #426; until then the whole test
-		// is skipped (the suite cannot skip individual sub-cases). The
-		// manual-endpointslices sub-case already passes, so the earlier "only
-		// ClusterIP backends" reason was inaccurate — non-headless Services with
-		// hand-managed EndpointSlices route fine.
-		"HTTPRouteServiceTypes",
-
 		// Mesh: not supported — tunnel architecture, no service mesh.
 		"MeshBasic",
 		"MeshConsumerRoute",


### PR DESCRIPTION
## Summary

Route to **headless** `Service` backends (`spec.clusterIP: None`). A `backendRef` targeting a headless Service previously returned HTTP 502: the in-process L7 proxy dialed the Service FQDN at the Service port, but a headless Service has no VIP — its FQDN resolves straight to the pod IPs, so the proxy reached a pod listening on the `targetPort` while dialing the Service port, and the connection failed.

This adds a post-conversion pass that resolves a headless Service's `EndpointSlices` and expands the backend into one entry per ready endpoint, dialing the resolved endpoint `targetPort`. Normal ClusterIP Services keep routing through their VIP unchanged.

## Changes

- `internal/proxy/expand_headless.go` — pure config helper `ExpandHeadlessBackend`: replaces a matched Service-FQDN backend with one backend per resolved endpoint, preserving the Gateway API traffic proportion (endpoints split the `backendRef` weight equally; sibling weights scaled by the endpoint count, then GCD-reduced).
- `internal/controller/headless_backends.go` — controller pass `expandHeadlessBackends`: reads the Service and its `EndpointSlices`, resolves the endpoint port by Service-port name, collects ready endpoint addresses (IPv4/IPv6), and hands them to the helper. Runs after the 500 invalid-ref marking and before the 503 zero-endpoint marking. A headless Service with ready endpoints whose named `targetPort` cannot be resolved fails closed (503) rather than dialing the Service port.
- `internal/controller/service_backend_visit.go` — extract the shared authorized-backend visitor used by both the zero-endpoint 503 pass and the new headless pass, keeping cross-namespace `ReferenceGrant` authorization symmetric.
- Cross-namespace resolution keeps honouring `ReferenceGrant`; RBAC already grants `get/list/watch` on `services` and `endpointslices`, and `EndpointSlice` changes already re-trigger a route reconcile, so scaling a headless backend up/down refreshes the config.
- `test/conformance/conformance_test.go` — remove `HTTPRouteServiceTypes` from the skip list.
- `docs/gateway-api/limitations.md` — remove the "headless returns 502" limitation; describe the supported per-endpoint behaviour.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [x] Manual testing completed (if applicable) — official Gateway API conformance `HTTPRouteServiceTypes` (all three sub-cases: ClusterIP manual EndpointSlices, headless with selector, headless with manual EndpointSlices) run against a live Cloudflare Tunnel; custom e2e suite

## Documentation

- [ ] README updated (if needed) — not needed; README never claimed headless was unsupported
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed) — not needed

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced (if any)

## Additional Notes

Reviewed by Opus across two consecutive rounds before opening. The proxy data plane is unchanged — headless endpoints map onto the existing weighted multi-backend selection.

Closes #426
