### PR TITLE
fix(controller): route status spec compliance and opt-in rule-name uniqueness policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,12 @@ CF_API_TOKEN=
 CF_ACCOUNT_ID=
 
 # UUID of the Cloudflare Tunnel the in-process test proxy connects to.
-V2_TUNNEL_ID=
+CF_TUNNEL_ID=
 
 # Connector token for the tunnel above (GET cfd_tunnel/{id}/token).
-V2_TUNNEL_TOKEN=
+CF_TUNNEL_TOKEN=
 
 # Edge hostname whose DNS routes to the tunnel above. The conformance and e2e
 # suites send TLS SNI + Host to this name. There is no default — it must match
 # the deployed tunnel. e.g. your-tunnel-hostname.example.com
-V2_TUNNEL_HOSTNAME=
+CF_TUNNEL_HOSTNAME=

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ temp/
 
 # Secrets and credentials
 *credentials*.yaml
+# ...but vendored upstream code is never a secret. The pattern above otherwise
+# swallows the Gateway API conformance manifest
+# httproute-cors-allow-credentials-behavior.yaml, which makes that conformance
+# test fail with "route not found" on a fresh checkout.
+!vendor/**/*credentials*.yaml
 *.key
 *.pem
 .env

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ See [Backend mTLS](https://cf.k8s.lex.la/latest/gateway-api/limitations/#backend
 
 The proxy can emit a structured per-request access log (method, host, path, query, status, bytes_written, duration_ms, user_agent) via `proxy.accessLog.enabled: true` in Helm values. Off by default; sampling-rate knob keeps log volume manageable on busy gateways. See [Access Logging](https://cf.k8s.lex.la/latest/operations/access-logging/) for the full contract.
 
+Per Gateway API, `HTTPRouteRule.name` / `GRPCRouteRule.name` must be unique within a Route, but the Standard-channel CRDs do not enforce it (the uniqueness CEL is experimental-channel only) and rule names are cosmetic, so duplicates do not affect routing. To enforce uniqueness at admission, enable the opt-in `ruleNameUniquenessPolicy` Helm value, which installs a cluster-scoped `ValidatingAdmissionPolicy` (Kubernetes 1.30+). See [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/#route-rule-name-uniqueness-specrulesname) for the trade-offs.
+
 See [Gateway API documentation](https://cf.k8s.lex.la/latest/gateway-api/) for full details and examples.
 
 ## External-DNS Integration

--- a/charts/cloudflare-tunnel-gateway-controller/README.md
+++ b/charts/cloudflare-tunnel-gateway-controller/README.md
@@ -335,6 +335,8 @@ spec:
 | proxy.websocket.handshakeTimeout | string | `""` | 101-Switching-Protocols read deadline (Go duration). Empty preserves the 30s default. |
 | replicaCount | int | `1` | Number of controller replicas |
 | resources | object | See values.yaml for recommended production defaults | Container resource requests and limits When resources is empty ({}), the chart will use recommended defaults. Specify explicit values to override defaults. |
+| ruleNameUniquenessPolicy | object | `{"enabled":false}` | Optional ValidatingAdmissionPolicy that rejects HTTPRoutes/GRPCRoutes whose rules carry duplicate `name` values, enforcing the Gateway API uniqueness MUST at admission (the Standard-channel CRDs omit the experimental CEL that does this). Disabled by default because it is cluster-scoped and a deliberate operator choice: the policy matches ALL HTTPRoutes/GRPCRoutes in the cluster (a Route carries no controllerName at admission, so it cannot be limited to this controller's routes) and can block updates to routes that already have duplicate rule names. Requires a cluster with admissionregistration.k8s.io/v1 ValidatingAdmissionPolicy (Kubernetes >= 1.30). |
+| ruleNameUniquenessPolicy.enabled | bool | `false` | Install the rule-name uniqueness ValidatingAdmissionPolicy and its binding |
 | securityContext | object | See values.yaml | Container security context (secure defaults) |
 | service | object | `{"annotations":{},"healthPort":8081,"metricsPort":8080,"type":"ClusterIP"}` | Service configuration |
 | service.annotations | object | `{}` | Service annotations Example: Prometheus scraping annotations   prometheus.io/scrape: "true"   prometheus.io/port: "8080"   prometheus.io/path: "/metrics" |

--- a/charts/cloudflare-tunnel-gateway-controller/templates/validatingadmissionpolicy.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/templates/validatingadmissionpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ruleNameUniquenessPolicy.enabled }}
+# Enforces the Gateway API rule that HTTPRouteRule.name / GRPCRouteRule.name
+# MUST be unique within a Route. Upstream ships this check only in the
+# experimental-channel CRD CEL; the Standard channel omits it. This native
+# ValidatingAdmissionPolicy replicates the same admission rule without owning the
+# (upstream) Route CRDs and without a webhook server. It is cluster-scoped and
+# applies to every HTTPRoute/GRPCRoute — see values.yaml for the opt-in rationale.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ include "cf-tunnel-gw-ctrl.fullname" . }}-route-rule-name-unique
+  labels:
+    {{- include "cf-tunnel-gw-ctrl.labels" . | nindent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["gateway.networking.k8s.io"]
+        apiVersions: ["v1", "v1alpha2"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["httproutes", "grpcroutes"]
+  validations:
+    - expression: >-
+        !has(object.spec.rules) ||
+        object.spec.rules.all(l1, !has(l1.name) ||
+        object.spec.rules.exists_one(l2, has(l2.name) && l1.name == l2.name))
+      message: "Rule name must be unique within the route"
+      reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ include "cf-tunnel-gw-ctrl.fullname" . }}-route-rule-name-unique
+  labels:
+    {{- include "cf-tunnel-gw-ctrl.labels" . | nindent 4 }}
+spec:
+  policyName: {{ include "cf-tunnel-gw-ctrl.fullname" . }}-route-rule-name-unique
+  validationActions:
+    - Deny
+{{- end }}

--- a/charts/cloudflare-tunnel-gateway-controller/tests/validatingadmissionpolicy_test.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/tests/validatingadmissionpolicy_test.yaml
@@ -1,0 +1,64 @@
+suite: test validatingadmissionpolicy
+templates:
+  - validatingadmissionpolicy.yaml
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render both the policy and its binding when enabled
+    set:
+      ruleNameUniquenessPolicy:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should render a ValidatingAdmissionPolicy with the uniqueness CEL
+    set:
+      ruleNameUniquenessPolicy:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ValidatingAdmissionPolicy
+      - isAPIVersion:
+          of: admissionregistration.k8s.io/v1
+      - equal:
+          path: spec.failurePolicy
+          value: Fail
+      - equal:
+          path: spec.matchConstraints.resourceRules[0].resources
+          value:
+            - httproutes
+            - grpcroutes
+      - equal:
+          path: spec.matchConstraints.resourceRules[0].operations
+          value:
+            - CREATE
+            - UPDATE
+      - equal:
+          path: spec.validations[0].reason
+          value: Invalid
+      - matchRegex:
+          path: spec.validations[0].expression
+          pattern: exists_one
+
+  - it: should render a binding with Deny action referencing the policy
+    set:
+      ruleNameUniquenessPolicy:
+        enabled: true
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: ValidatingAdmissionPolicyBinding
+      - isAPIVersion:
+          of: admissionregistration.k8s.io/v1
+      - equal:
+          path: spec.validationActions
+          value:
+            - Deny
+      - matchRegex:
+          path: spec.policyName
+          pattern: route-rule-name-unique$

--- a/charts/cloudflare-tunnel-gateway-controller/values.schema.json
+++ b/charts/cloudflare-tunnel-gateway-controller/values.schema.json
@@ -541,6 +541,16 @@
         }
       }
     },
+    "ruleNameUniquenessPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Install the rule-name uniqueness ValidatingAdmissionPolicy and its binding",
+          "default": false
+        }
+      }
+    },
     "proxy": {
       "type": "object",
       "description": "L7 Proxy configuration (enhanced-cloudflared data plane). The chart always renders the proxy resources starting v3; the pre-v3 `proxy.enabled` toggle has been removed.",

--- a/charts/cloudflare-tunnel-gateway-controller/values.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/values.yaml
@@ -287,6 +287,19 @@ gatewayClass:
   # -- Create GatewayClass resource
   create: true
 
+# -- Optional ValidatingAdmissionPolicy that rejects HTTPRoutes/GRPCRoutes whose
+# rules carry duplicate `name` values, enforcing the Gateway API uniqueness MUST
+# at admission (the Standard-channel CRDs omit the experimental CEL that does
+# this). Disabled by default because it is cluster-scoped and a deliberate
+# operator choice: the policy matches ALL HTTPRoutes/GRPCRoutes in the cluster
+# (a Route carries no controllerName at admission, so it cannot be limited to
+# this controller's routes) and can block updates to routes that already have
+# duplicate rule names. Requires a cluster with admissionregistration.k8s.io/v1
+# ValidatingAdmissionPolicy (Kubernetes >= 1.30).
+ruleNameUniquenessPolicy:
+  # -- Install the rule-name uniqueness ValidatingAdmissionPolicy and its binding
+  enabled: false
+
 # -- L7 Proxy configuration (enhanced-cloudflared data plane).
 # Starting v3 the L7 proxy is the ONLY data plane; the chart always
 # renders the proxy Deployment + Service + (optional) NetworkPolicy

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -282,7 +282,7 @@ Conformance tests validate that the controller implements the Gateway API specif
 
 ### Running E2E Tests
 
-E2E tests run against a live kind cluster with Cloudflare Tunnel and L7 proxy deployed. `E2E_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` (`V2_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.
+E2E tests run against a live kind cluster with Cloudflare Tunnel and L7 proxy deployed. `E2E_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` (`CF_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.
 
 ```bash
 # Run all E2E tests
@@ -318,7 +318,7 @@ Tests cover both Cloudflare Tunnel and L7 proxy features:
 
 The project integrates the official `sigs.k8s.io/gateway-api/conformance` suite with a custom `TunnelRoundTripper` that routes requests through Cloudflare edge.
 
-`CONFORMANCE_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` (`V2_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.
+`CONFORMANCE_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` (`CF_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.
 
 ```bash
 # Run conformance tests (requires deployed controller + tunnel)

--- a/docs/gateway-api/limitations.md
+++ b/docs/gateway-api/limitations.md
@@ -320,6 +320,18 @@ Route B's `/api/v2` matches first (longer path), then Route A's `/api` matches r
 
 HTTP header match names are compared case-insensitively at request time (Go's `http.Header.Values` canonicalises the key), but the CRD enforces name uniqueness case-sensitively via its list-map key. Two header matches in one rule that differ only in case (for example `Foo` and `foo`) are therefore both admitted and both required to match, where the spec treats them as equivalent and says only the first should be considered. The effect is a single over-strict (never-matching) rule, not mis-routing; impact is negligible. Query-parameter match names are exact (case-sensitive) string matches per the spec, so `Foo` and `foo` are legitimately distinct parameters and are not affected.
 
+## Route rule name uniqueness (`spec.rules[].name`)
+
+Gateway API states that `HTTPRouteRule.name` / `GRPCRouteRule.name` MUST be unique within a Route when set. Upstream enforces this only through a CEL admission rule that ships in the **experimental**-channel CRDs; the **Standard**-channel CRDs this controller targets omit it, so by default the apiserver admits a Route whose rules share a `name`. Rule names are used only for status diagnostics, not for routing, so a duplicate does not affect traffic — but the normative MUST is unenforced.
+
+The controller does not add an equivalent runtime check: Gateway API defines no status condition for this violation, the `HTTPRoute`/`GRPCRoute` CRDs are owned upstream (the project cannot add the CEL to them), and flagging a working Route as `Accepted=False` would misreport reality.
+
+To enforce uniqueness at admission, enable the bundled opt-in `ValidatingAdmissionPolicy` (`ruleNameUniquenessPolicy.enabled=true` in the Helm chart). It replicates the upstream experimental CEL natively in the apiserver — no webhook server, no CRD ownership — and rejects a Route with duplicate rule names.
+
+### Why it is off by default
+
+The policy is cluster-scoped: it applies to every `HTTPRoute`/`GRPCRoute` in the cluster (a Route carries no `controllerName` at admission, so it cannot be limited to this controller's routes) and can block updates to routes that already have duplicate names. It also requires a cluster with `admissionregistration.k8s.io/v1` ValidatingAdmissionPolicy (Kubernetes 1.30+). Enable it deliberately when those trade-offs are acceptable.
+
 ## No Native Multi-Cluster Discovery
 
 The controller performs no direct peer-cluster discovery or mesh-style cross-cluster routing on its own. It does not connect clusters together or watch endpoints in remote clusters. Cross-cluster backends ARE reachable, however, through the Multi-Cluster Services (MCS) API: a `backendRef` targeting a `ServiceImport` (`multicluster.x-k8s.io`) resolves to the `clusterset.local` DNS plane, so the cluster's own MCS implementation routes to the imported remote endpoints (see [Non-Service backend kinds](#non-service-backend-kinds)).

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -23,8 +23,8 @@
 #                                                  # chart+images (no local build)
 #
 # Prerequisites:
-#   - .env file in repo root with: CF_API_TOKEN, CF_ACCOUNT_ID, V2_TUNNEL_ID,
-#     V2_TUNNEL_TOKEN, V2_TUNNEL_HOSTNAME (the edge hostname routing to the tunnel)
+#   - .env file in repo root with: CF_API_TOKEN, CF_ACCOUNT_ID, CF_TUNNEL_ID,
+#     CF_TUNNEL_TOKEN, CF_TUNNEL_HOSTNAME (the edge hostname routing to the tunnel)
 #   - colima, docker, kind, helm, kubectl, go installed
 
 set -euo pipefail
@@ -105,7 +105,7 @@ fi
 # shellcheck source=/dev/null
 source "${ENV_FILE}"
 
-for var in CF_API_TOKEN CF_ACCOUNT_ID V2_TUNNEL_ID V2_TUNNEL_TOKEN V2_TUNNEL_HOSTNAME; do
+for var in CF_API_TOKEN CF_ACCOUNT_ID CF_TUNNEL_ID CF_TUNNEL_TOKEN CF_TUNNEL_HOSTNAME; do
   if [[ -z "${!var:-}" ]]; then
     die "Required variable ${var} is not set in .env (see .env.example)"
   fi
@@ -120,13 +120,13 @@ done
 # (Account -> Cloudflare Tunnel -> Edit) lacks user-level token introspection, so
 # verify returns success:false / code 1000 for a working token. The
 # configurations endpoint is the authoritative signal.
-info "Validating Cloudflare API token against tunnel ${V2_TUNNEL_ID}..."
+info "Validating Cloudflare API token against tunnel ${CF_TUNNEL_ID}..."
 token_http_code="$(curl --silent --output /dev/null --write-out '%{http_code}' \
   --retry 3 --retry-delay 1 --max-time 15 \
   --header "Authorization: Bearer ${CF_API_TOKEN}" \
-  "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${V2_TUNNEL_ID}/configurations" || true)"
+  "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${CF_TUNNEL_ID}/configurations" || true)"
 if [[ "${token_http_code}" != "200" ]]; then
-  die "CF_API_TOKEN cannot read tunnel ${V2_TUNNEL_ID} (HTTP ${token_http_code:-no-response}). Refresh the token (Cloudflare dashboard -> account -> Cloudflare Tunnel -> Edit) before re-running."
+  die "CF_API_TOKEN cannot read tunnel ${CF_TUNNEL_ID} (HTTP ${token_http_code:-no-response}). Refresh the token (Cloudflare dashboard -> account -> Cloudflare Tunnel -> Edit) before re-running."
 fi
 
 # --- CI-images mode: fail fast if the PR chart is gone before building a cluster ---
@@ -212,7 +212,7 @@ kubectl --context "${KUBE_CONTEXT}" create secret generic cloudflare-credentials
 info "Creating tunnel token secret..."
 kubectl --context "${KUBE_CONTEXT}" create secret generic cloudflare-tunnel-token \
   --namespace "${NAMESPACE}" \
-  --from-literal=tunnel-token="${V2_TUNNEL_TOKEN}" \
+  --from-literal=tunnel-token="${CF_TUNNEL_TOKEN}" \
   --dry-run=client --output yaml \
   | kubectl --context "${KUBE_CONTEXT}" apply --filename -
 
@@ -248,7 +248,7 @@ helm upgrade --install "${RELEASE_NAME}" \
   --kube-context "${KUBE_CONTEXT}" \
   --namespace "${NAMESPACE}" \
   --set gatewayClassConfig.create=true \
-  --set gatewayClassConfig.tunnelID="${V2_TUNNEL_ID}" \
+  --set gatewayClassConfig.tunnelID="${CF_TUNNEL_ID}" \
   --set gatewayClassConfig.cloudflareCredentialsSecretRef.name=cloudflare-credentials \
   "${HELM_IMAGE_ARGS[@]+"${HELM_IMAGE_ARGS[@]}"}" \
   --set proxy.tunnelTokenSecretRef.name=cloudflare-tunnel-token \
@@ -281,17 +281,17 @@ echo ""
 
 # --- Step 11: Run tests (optional) ---
 if [[ "${RUN_TESTS}" == "true" ]]; then
-  info "Running conformance tests against ${V2_TUNNEL_HOSTNAME}..."
+  info "Running conformance tests against ${CF_TUNNEL_HOSTNAME}..."
   CONFORMANCE_KUBE_CONTEXT="${KUBE_CONTEXT}" \
-  CONFORMANCE_TUNNEL_HOSTNAME="${V2_TUNNEL_HOSTNAME}" \
+  CONFORMANCE_TUNNEL_HOSTNAME="${CF_TUNNEL_HOSTNAME}" \
     go test -v -race -tags conformance -count=1 -timeout=60m -parallel 10 ./test/conformance/...
 else
   echo ""
   info "Setup complete! To run conformance tests:"
-  echo "  CONFORMANCE_KUBE_CONTEXT=${KUBE_CONTEXT} CONFORMANCE_TUNNEL_HOSTNAME=${V2_TUNNEL_HOSTNAME} go test -v -race -tags conformance -count=1 -timeout=30m ./test/conformance/..."
+  echo "  CONFORMANCE_KUBE_CONTEXT=${KUBE_CONTEXT} CONFORMANCE_TUNNEL_HOSTNAME=${CF_TUNNEL_HOSTNAME} go test -v -race -tags conformance -count=1 -timeout=30m ./test/conformance/..."
   echo ""
   info "To run E2E tests:"
-  echo "  CONFORMANCE_KUBE_CONTEXT=${KUBE_CONTEXT} E2E_TUNNEL_HOSTNAME=${V2_TUNNEL_HOSTNAME} go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/..."
+  echo "  CONFORMANCE_KUBE_CONTEXT=${KUBE_CONTEXT} E2E_TUNNEL_HOSTNAME=${CF_TUNNEL_HOSTNAME} go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/..."
   echo ""
   info "To tear down:"
   echo "  kind delete cluster --name ${CLUSTER_NAME}"

--- a/internal/controller/backendtlspolicy_controller.go
+++ b/internal/controller/backendtlspolicy_controller.go
@@ -781,7 +781,9 @@ func (r *BackendTLSPolicyReconciler) partitionAncestors(
 		}
 
 		if statusGenerationStale(reconciledGen, ancestor.Conditions) {
-			return existing, others, true
+			// Stale: the caller skips the write, so the partial existing/others
+			// built so far is meaningless — return nil to make that explicit.
+			return nil, nil, true
 		}
 
 		key := ancestorRefKey(ancestor.AncestorRef, fresh.Namespace)

--- a/internal/controller/backendtlspolicy_controller.go
+++ b/internal/controller/backendtlspolicy_controller.go
@@ -247,7 +247,7 @@ func (r *BackendTLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		"gateways", len(gateways),
 	)
 
-	if err := r.updateStatus(ctx, req.NamespacedName, gateways, conditions); err != nil {
+	if err := r.updateStatus(ctx, req.NamespacedName, gateways, conditions, policy.Generation); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to update BackendTLSPolicy status")
 	}
 
@@ -701,6 +701,7 @@ func (r *BackendTLSPolicyReconciler) updateStatus(
 	policyKey client.ObjectKey,
 	gateways []gatewayv1.Gateway,
 	conditions []metav1.Condition,
+	reconciledGen int64,
 ) error {
 	//nolint:wrapcheck // retry wrapper handles errors internally
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -713,20 +714,12 @@ func (r *BackendTLSPolicyReconciler) updateStatus(
 			return err //nolint:wrapcheck // unwrapped to participate in retry
 		}
 
-		existing := map[client.ObjectKey][]metav1.Condition{}
-		otherControllerEntries := make([]gatewayv1.PolicyAncestorStatus, 0, len(fresh.Status.Ancestors))
-
-		for _, ancestor := range fresh.Status.Ancestors {
-			if string(ancestor.ControllerName) != r.ControllerName {
-				otherControllerEntries = append(otherControllerEntries, ancestor)
-
-				continue
-			}
-
-			// Remember our previous conditions per Gateway so SetStatusCondition
-			// can decide whether LastTransitionTime needs to flip.
-			key := ancestorRefKey(ancestor.AncestorRef, fresh.Namespace)
-			existing[key] = ancestor.Conditions
+		// Split current ancestors into our previous conditions (for merge) and
+		// other controllers' entries (preserved). stale=true means a newer
+		// reconcile already advanced our status, so we MUST NOT overwrite it.
+		existing, otherControllerEntries, stale := r.partitionAncestors(&fresh, reconciledGen)
+		if stale {
+			return nil
 		}
 
 		ourEntries := make([]gatewayv1.PolicyAncestorStatus, 0, len(gateways))
@@ -765,6 +758,37 @@ func (r *BackendTLSPolicyReconciler) updateStatus(
 
 		return r.Status().Update(ctx, &fresh) //nolint:wrapcheck // unwrapped to participate in retry
 	})
+}
+
+// partitionAncestors splits the policy's current ancestors into this
+// controller's previous conditions (keyed by Gateway, so SetStatusCondition can
+// preserve LastTransitionTime on merge) and the entries owned by other
+// controllers (preserved verbatim). stale is true when any of our entries was
+// already stamped with a generation newer than reconciledGen, in which case the
+// caller MUST NOT overwrite the status (observedGeneration regression guard).
+func (r *BackendTLSPolicyReconciler) partitionAncestors(
+	fresh *gatewayv1.BackendTLSPolicy,
+	reconciledGen int64,
+) (map[client.ObjectKey][]metav1.Condition, []gatewayv1.PolicyAncestorStatus, bool) {
+	existing := map[client.ObjectKey][]metav1.Condition{}
+	others := make([]gatewayv1.PolicyAncestorStatus, 0, len(fresh.Status.Ancestors))
+
+	for _, ancestor := range fresh.Status.Ancestors {
+		if string(ancestor.ControllerName) != r.ControllerName {
+			others = append(others, ancestor)
+
+			continue
+		}
+
+		if statusGenerationStale(reconciledGen, ancestor.Conditions) {
+			return existing, others, true
+		}
+
+		key := ancestorRefKey(ancestor.AncestorRef, fresh.Namespace)
+		existing[key] = ancestor.Conditions
+	}
+
+	return existing, others, false
 }
 
 // gatewayAncestorRef returns the ParentReference identifying the supplied

--- a/internal/controller/backendtlspolicy_controller_test.go
+++ b/internal/controller/backendtlspolicy_controller_test.go
@@ -1281,7 +1281,7 @@ func TestUpdateStatus_PreservesOtherControllers(t *testing.T) {
 	gateway := *gatewayFor("ns", "our-gw", "cf-class")
 	conditions := acceptedConditions(policy.Generation)
 
-	err := r.updateStatus(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, []gatewayv1.Gateway{gateway}, conditions)
+	err := r.updateStatus(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, []gatewayv1.Gateway{gateway}, conditions, policy.Generation)
 	require.NoError(t, err)
 
 	var refreshed gatewayv1.BackendTLSPolicy
@@ -1291,6 +1291,62 @@ func TestUpdateStatus_PreservesOtherControllers(t *testing.T) {
 	assert.Equal(t, gatewayv1.GatewayController("other-controller"), refreshed.Status.Ancestors[0].ControllerName)
 	assert.Equal(t, gatewayv1.GatewayController("test-controller"), refreshed.Status.Ancestors[1].ControllerName)
 	assert.Equal(t, gatewayv1.ObjectName("our-gw"), refreshed.Status.Ancestors[1].AncestorRef.Name)
+}
+
+// TestUpdateStatus_SkipsObservedGenerationRegression pins the Gateway API rule
+// that a reconcile MUST NOT overwrite an ancestor status condition already
+// stamped with an observedGeneration newer than the generation this reconcile
+// observed.
+func TestUpdateStatus_SkipsObservedGenerationRegression(t *testing.T) {
+	t.Parallel()
+
+	scheme := newBackendTLSPolicyScheme(t)
+
+	const newerGen = 5
+
+	// Our own ancestor entry, already stamped with a generation newer than the
+	// one this reconcile observed.
+	ours := gatewayv1.PolicyAncestorStatus{
+		AncestorRef:    gatewayv1.ParentReference{Name: "our-gw"},
+		ControllerName: gatewayv1.GatewayController("test-controller"),
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(gatewayv1.PolicyConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: newerGen,
+				Reason:             "Accepted",
+				Message:            "written by a newer reconcile",
+			},
+		},
+	}
+
+	policy := backendTLSPolicyFor("ns", "p", "svc", "cm", time.Time{})
+	policy.Status.Ancestors = []gatewayv1.PolicyAncestorStatus{ours}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(policy).
+		WithStatusSubresource(policy).
+		Build()
+	r := &BackendTLSPolicyReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test-controller"}
+
+	gateway := *gatewayFor("ns", "our-gw", "cf-class")
+
+	// reconciledGen 3 < stored 5 → the write is skipped.
+	require.NoError(t, r.updateStatus(context.Background(),
+		client.ObjectKey{Namespace: "ns", Name: "p"},
+		[]gatewayv1.Gateway{gateway},
+		acceptedConditions(3),
+		3,
+	))
+
+	var refreshed gatewayv1.BackendTLSPolicy
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, &refreshed))
+	require.Len(t, refreshed.Status.Ancestors, 1)
+	require.Len(t, refreshed.Status.Ancestors[0].Conditions, 1)
+	assert.Equal(t, int64(newerGen), refreshed.Status.Ancestors[0].Conditions[0].ObservedGeneration,
+		"stale reconcile must not overwrite a newer ancestor status")
+	assert.Equal(t, "written by a newer reconcile", refreshed.Status.Ancestors[0].Conditions[0].Message)
 }
 
 func TestUpdateStatus_PreservesOtherControllersUnderCap(t *testing.T) {
@@ -1338,6 +1394,7 @@ func TestUpdateStatus_PreservesOtherControllersUnderCap(t *testing.T) {
 		client.ObjectKey{Namespace: "ns", Name: "p"},
 		gateways,
 		acceptedConditions(policy.Generation),
+		policy.Generation,
 	))
 
 	var refreshed gatewayv1.BackendTLSPolicy
@@ -1384,7 +1441,7 @@ func TestUpdateStatus_CapsAncestorsAt16(t *testing.T) {
 
 	conditions := acceptedConditions(policy.Generation)
 
-	err := r.updateStatus(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, gateways, conditions)
+	err := r.updateStatus(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, gateways, conditions, policy.Generation)
 	require.NoError(t, err)
 
 	var refreshed gatewayv1.BackendTLSPolicy
@@ -1414,7 +1471,7 @@ func TestUpdateStatus_SetsLastTransitionTime(t *testing.T) {
 	gateway := *gatewayFor("ns", "gw", "cf-class")
 	conditions := acceptedConditions(policy.Generation)
 
-	require.NoError(t, r.updateStatus(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, []gatewayv1.Gateway{gateway}, conditions))
+	require.NoError(t, r.updateStatus(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, []gatewayv1.Gateway{gateway}, conditions, policy.Generation))
 
 	var refreshed gatewayv1.BackendTLSPolicy
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "p"}, &refreshed))
@@ -1677,6 +1734,7 @@ func TestUpdateStatus_ObservedGenerationMatchesPolicyGeneration(t *testing.T) {
 		client.ObjectKey{Namespace: "ns", Name: "p"},
 		[]gatewayv1.Gateway{gateway},
 		conditions,
+		policy.Generation,
 	))
 
 	var refreshed gatewayv1.BackendTLSPolicy

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -202,6 +202,13 @@ func (r *GatewayReconciler) updateStatus(
 			return errors.Wrap(err, "failed to get fresh gateway")
 		}
 
+		// Skip if a newer reconcile already advanced this Gateway's status past
+		// the generation we observed; Gateway API forbids regressing
+		// observedGeneration, and that reconcile will write the current view.
+		if gatewayStatusStale(gateway.Generation, &freshGateway) {
+			return nil
+		}
+
 		now := metav1.Now()
 
 		attachedRoutes := r.countAttachedRoutes(ctx, &freshGateway)
@@ -342,6 +349,31 @@ func (r *GatewayReconciler) updateStatus(
 	return errors.Wrap(err, "failed to update gateway status after retries")
 }
 
+// gatewayStatusStale reports whether the freshly-fetched Gateway already
+// carries status conditions (top-level or per-listener) stamped with a
+// generation newer than reconciledGen, in which case this reconcile MUST NOT
+// overwrite the status (Gateway API observedGeneration regression guard).
+//
+// Only this controller's own top-level conditions count: a foreign controller's
+// condition (e.g. special.io/...) carries an unrelated generation and MUST NOT
+// be touched. The per-listener status array, by contrast, is wholly owned here.
+func gatewayStatusStale(reconciledGen int64, gateway *gatewayv1.Gateway) bool {
+	if ownedConditionsStale(gateway.Status.Conditions, reconciledGen,
+		string(gatewayv1.GatewayConditionAccepted),
+		string(gatewayv1.GatewayConditionProgrammed),
+		string(gatewayv1.GatewayConditionResolvedRefs),
+	) {
+		return true
+	}
+
+	listenerConds := make([][]metav1.Condition, 0, len(gateway.Status.Listeners))
+	for i := range gateway.Status.Listeners {
+		listenerConds = append(listenerConds, gateway.Status.Listeners[i].Conditions)
+	}
+
+	return statusGenerationStale(reconciledGen, listenerConds...)
+}
+
 func (r *GatewayReconciler) setConfigErrorStatus(
 	ctx context.Context,
 	gateway *gatewayv1.Gateway,
@@ -354,6 +386,12 @@ func (r *GatewayReconciler) setConfigErrorStatus(
 		var freshGateway gatewayv1.Gateway
 		if err := r.Get(ctx, gatewayKey, &freshGateway); err != nil {
 			return errors.Wrap(err, "failed to get fresh gateway")
+		}
+
+		// Skip if a newer reconcile already advanced this Gateway's status past
+		// the generation we observed (observedGeneration regression guard).
+		if gatewayStatusStale(gateway.Generation, &freshGateway) {
+			return nil
 		}
 
 		now := metav1.Now()

--- a/internal/controller/gateway_controller_test.go
+++ b/internal/controller/gateway_controller_test.go
@@ -767,6 +767,88 @@ func TestGatewayReconciler_PreservesForeignStatusConditions(t *testing.T) {
 		string(gatewayv1.GatewayConditionProgrammed)))
 }
 
+// TestGatewayReconciler_UpdateStatus_SkipsObservedGenerationRegression pins the
+// Gateway API rule that a reconcile MUST NOT overwrite a status condition
+// already stamped with an observedGeneration newer than the generation this
+// reconcile observed.
+func TestGatewayReconciler_UpdateStatus_SkipsObservedGenerationRegression(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	const newerGen = 5
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "default", Generation: 3},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cloudflare-tunnel",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Port: 80, Protocol: "HTTP"},
+			},
+		},
+		Status: gatewayv1.GatewayStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(gatewayv1.GatewayConditionAccepted),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: newerGen,
+					LastTransitionTime: metav1.Now(),
+					Reason:             string(gatewayv1.GatewayReasonAccepted),
+					Message:            "written by a newer reconcile",
+				},
+			},
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cf-credentials", Namespace: "default"},
+		Data:       map[string][]byte{"api-token": []byte("test-token")},
+	}
+
+	gatewayClassConfig := &v1alpha1.GatewayClassConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
+		Spec: v1alpha1.GatewayClassConfigSpec{
+			CloudflareCredentialsSecretRef: v1alpha1.SecretReference{Name: "cf-credentials", Namespace: "default"},
+			TunnelID:                       "12345678-1234-1234-1234-123456789abc",
+		},
+	}
+
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-tunnel"},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "test-controller",
+			ParametersRef: &gatewayv1.ParametersReference{
+				Group: config.ParametersRefGroup,
+				Kind:  config.ParametersRefKind,
+				Name:  "test-config",
+			},
+		},
+	}
+
+	fakeClient := setupGatewayFakeClient(gateway, secret, gatewayClassConfig, gatewayClass)
+	reconciler := &GatewayReconciler{
+		Client:         fakeClient,
+		Scheme:         fakeClient.Scheme(),
+		ControllerName: "test-controller",
+		ConfigResolver: config.NewResolver(fakeClient, "default", cfmetrics.NewNoopCollector()),
+	}
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-gateway", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	var updated gatewayv1.Gateway
+	require.NoError(t, fakeClient.Get(ctx,
+		types.NamespacedName{Name: "test-gateway", Namespace: "default"}, &updated))
+
+	accepted := meta.FindStatusCondition(updated.Status.Conditions, string(gatewayv1.GatewayConditionAccepted))
+	require.NotNil(t, accepted)
+	assert.Equal(t, int64(newerGen), accepted.ObservedGeneration,
+		"stale reconcile must not overwrite a newer Gateway status")
+	assert.Equal(t, "written by a newer reconcile", accepted.Message)
+}
+
 // TestGatewayReconciler_ConflictedListenersSetListenersNotValid pins the Gateway
 // API requirement (gateway_types.go:187): when the Gateway contains conflicted
 // listeners, the implementation MUST set a ListenersNotValid condition. Two HTTP

--- a/internal/controller/gatewayclass_controller.go
+++ b/internal/controller/gatewayclass_controller.go
@@ -68,14 +68,18 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	logger.Info("reconciling GatewayClass", "name", gatewayClass.Name)
 
-	if err := r.updateStatus(ctx, req.NamespacedName); err != nil {
+	if err := r.updateStatus(ctx, req.NamespacedName, gatewayClass.Generation); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to update GatewayClass status")
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (r *GatewayClassReconciler) updateStatus(ctx context.Context, key types.NamespacedName) error {
+func (r *GatewayClassReconciler) updateStatus(
+	ctx context.Context,
+	key types.NamespacedName,
+	reconciledGen int64,
+) error {
 	//nolint:wrapcheck // retry wrapper handles errors internally
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var freshClass gatewayv1.GatewayClass
@@ -84,6 +88,17 @@ func (r *GatewayClassReconciler) updateStatus(ctx context.Context, key types.Nam
 		}
 
 		if string(freshClass.Spec.ControllerName) != r.ControllerName {
+			return nil
+		}
+
+		// Skip if a newer reconcile already advanced this GatewayClass's status
+		// past the generation we observed (observedGeneration regression guard).
+		// Only our own condition types count — a foreign condition's generation
+		// is unrelated and MUST NOT be touched.
+		if ownedConditionsStale(freshClass.Status.Conditions, reconciledGen,
+			string(gatewayv1.GatewayClassConditionStatusAccepted),
+			string(gatewayv1.GatewayClassConditionStatusSupportedVersion),
+		) {
 			return nil
 		}
 

--- a/internal/controller/gatewayclass_controller_test.go
+++ b/internal/controller/gatewayclass_controller_test.go
@@ -537,7 +537,7 @@ func TestGatewayClassReconciler_UpdateStatus_ControllerMismatch(t *testing.T) {
 	}
 
 	// updateStatus should silently return nil for non-matching controllers
-	err := r.updateStatus(context.Background(), types.NamespacedName{Name: "other-class"})
+	err := r.updateStatus(context.Background(), types.NamespacedName{Name: "other-class"}, 0)
 	assert.NoError(t, err)
 
 	// Verify no conditions were set
@@ -563,7 +563,7 @@ func TestGatewayClassReconciler_UpdateStatus_NotFound(t *testing.T) {
 		ControllerName: "test-controller",
 	}
 
-	err := r.updateStatus(context.Background(), types.NamespacedName{Name: "non-existent"})
+	err := r.updateStatus(context.Background(), types.NamespacedName{Name: "non-existent"}, 0)
 	assert.Error(t, err)
 }
 
@@ -616,6 +616,64 @@ func TestGatewayClassReconciler_Reconcile_IdempotentStatusUpdate(t *testing.T) {
 	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "cloudflare-tunnel"}, &updatedClass)
 	require.NoError(t, err)
 	assert.Len(t, updatedClass.Status.Conditions, 2)
+}
+
+// TestGatewayClassReconciler_UpdateStatus_SkipsObservedGenerationRegression pins
+// the Gateway API rule that a reconcile MUST NOT overwrite a status condition
+// already stamped with an observedGeneration newer than the generation this
+// reconcile observed.
+func TestGatewayClassReconciler_UpdateStatus_SkipsObservedGenerationRegression(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	const newerGen = 5
+
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-tunnel", Generation: 3},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "test-controller"},
+		Status: gatewayv1.GatewayClassStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: newerGen,
+					LastTransitionTime: metav1.Now(),
+					Reason:             string(gatewayv1.GatewayClassReasonAccepted),
+					Message:            "written by a newer reconcile",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gatewayClass).
+		WithStatusSubresource(gatewayClass).
+		Build()
+	require.NoError(t, fakeClient.Status().Update(context.Background(), gatewayClass))
+
+	r := &GatewayClassReconciler{Client: fakeClient, Scheme: scheme, ControllerName: "test-controller"}
+
+	// reconciledGen 3 < stored 5 → the write is skipped.
+	require.NoError(t, r.updateStatus(context.Background(), types.NamespacedName{Name: "cloudflare-tunnel"}, 3))
+
+	var updated gatewayv1.GatewayClass
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "cloudflare-tunnel"}, &updated))
+
+	var accepted *metav1.Condition
+
+	for i := range updated.Status.Conditions {
+		if updated.Status.Conditions[i].Type == string(gatewayv1.GatewayClassConditionStatusAccepted) {
+			accepted = &updated.Status.Conditions[i]
+		}
+	}
+
+	require.NotNil(t, accepted)
+	assert.Equal(t, int64(newerGen), accepted.ObservedGeneration,
+		"stale reconcile must not overwrite a newer GatewayClass status")
+	assert.Equal(t, "written by a newer reconcile", accepted.Message)
 }
 
 func TestGatewayClassReconciler_Reconcile_WrongType(t *testing.T) {

--- a/internal/controller/gatewayclassconfig_controller.go
+++ b/internal/controller/gatewayclassconfig_controller.go
@@ -67,6 +67,12 @@ func (r *GatewayClassConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return errors.Wrap(err, "failed to get fresh GatewayClassConfig")
 		}
 
+		// Skip if a newer reconcile already advanced this config's status past
+		// the generation we observed (observedGeneration regression guard).
+		if statusGenerationStale(config.Generation, freshConfig.Status.Conditions) {
+			return nil
+		}
+
 		// Validate secrets and collect conditions
 		conditions := r.validateConfig(ctx, &freshConfig)
 		freshConfig.Status.Conditions = conditions

--- a/internal/controller/gatewayclassconfig_controller_test.go
+++ b/internal/controller/gatewayclassconfig_controller_test.go
@@ -128,6 +128,63 @@ func TestGatewayClassConfigReconciler_Reconcile_Valid(t *testing.T) {
 	assert.Equal(t, "Valid", validCondition.Reason)
 }
 
+// TestGatewayClassConfigReconciler_Reconcile_SkipsObservedGenerationRegression
+// pins the Gateway API rule that a reconcile MUST NOT overwrite a status
+// condition already stamped with an observedGeneration newer than the one this
+// reconcile observed.
+func TestGatewayClassConfigReconciler_Reconcile_SkipsObservedGenerationRegression(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	const newerGen = 5
+
+	config := &v1alpha1.GatewayClassConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-config", Generation: 3},
+		Spec: v1alpha1.GatewayClassConfigSpec{
+			TunnelID: "test-tunnel-id",
+			CloudflareCredentialsSecretRef: v1alpha1.SecretReference{
+				Name:      "cf-credentials",
+				Namespace: "default",
+			},
+		},
+		Status: v1alpha1.GatewayClassConfigStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               ConditionTypeValid,
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: newerGen,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "Valid",
+					Message:            "written by a newer reconcile",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(config).
+		WithStatusSubresource(config).
+		Build()
+	require.NoError(t, fakeClient.Status().Update(context.Background(), config))
+
+	r := &GatewayClassConfigReconciler{Client: fakeClient, Scheme: scheme, DefaultNamespace: "default"}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-config"}})
+	require.NoError(t, err)
+
+	var updated v1alpha1.GatewayClassConfig
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-config"}, &updated))
+
+	require.Len(t, updated.Status.Conditions, 1)
+	assert.Equal(t, int64(newerGen), updated.Status.Conditions[0].ObservedGeneration,
+		"stale reconcile must not overwrite a newer GatewayClassConfig status")
+	assert.Equal(t, "written by a newer reconcile", updated.Status.Conditions[0].Message)
+}
+
 func TestGatewayClassConfigReconciler_Reconcile_MissingCredentialsSecret(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controller/grpcroute_controller.go
+++ b/internal/controller/grpcroute_controller.go
@@ -215,10 +215,11 @@ func (r *GRPCRouteReconciler) updateRouteStatus(
 ) error {
 	emitDiagnosticEvents(r.Recorder, route, diagnostics)
 
-	params := routeStatusUpdateParams{
-		k8sClient:      r.Client,
-		controllerName: r.ControllerName,
-		diagnostics:    diagnostics,
+	params := &routeStatusUpdateParams{
+		k8sClient:            r.Client,
+		controllerName:       r.ControllerName,
+		diagnostics:          diagnostics,
+		reconciledGeneration: route.Generation,
 	}
 
 	// gRPC over an explicit quic tunnel cannot be served (cloudflared drops HTTP

--- a/internal/controller/grpcroute_controller_test.go
+++ b/internal/controller/grpcroute_controller_test.go
@@ -899,6 +899,100 @@ func TestGRPCRouteReconciler_Start(t *testing.T) {
 	assert.True(t, r.startupComplete.Load())
 }
 
+// TestGRPCRouteReconciler_UpdateRouteStatus_SkipsObservedGenerationRegression
+// pins, for GRPCRoute, the Gateway API rule that a reconcile MUST NOT overwrite
+// a status condition already stamped with an observedGeneration newer than the
+// one this reconcile observed.
+func TestGRPCRouteReconciler_UpdateRouteStatus_SkipsObservedGenerationRegression(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-tunnel"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "test-controller"},
+	}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cloudflare-tunnel",
+			Listeners: []gatewayv1.Listener{
+				{Name: "grpc", Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+			},
+		},
+	}
+
+	const newerGen = 5
+
+	advanced := gatewayv1.RouteParentStatus{
+		ParentRef:      gatewayv1.ParentReference{Name: "test-gateway"},
+		ControllerName: "test-controller",
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(gatewayv1.RouteConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: newerGen,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(gatewayv1.RouteReasonAccepted),
+				Message:            "written by a newer reconcile",
+			},
+		},
+	}
+
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "stale-route", Namespace: "default", Generation: 3},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "test-gateway"}},
+			},
+		},
+		Status: gatewayv1.GRPCRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{Parents: []gatewayv1.RouteParentStatus{advanced}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gatewayClass, gateway, route).
+		WithStatusSubresource(route).
+		Build()
+	require.NoError(t, fakeClient.Status().Update(context.Background(), route))
+
+	configResolver := config.NewResolver(fakeClient, "default", cfmetrics.NewNoopCollector())
+	routeSyncer := NewRouteSyncer(fakeClient, scheme, "cluster.local", "test-controller", configResolver, cfmetrics.NewNoopCollector(), nil)
+
+	r := &GRPCRouteReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		RouteSyncer:    routeSyncer,
+	}
+
+	bindingInfo := routeBindingInfo{
+		bindingResults: map[int]routebinding.BindingResult{
+			0: {Accepted: true, Reason: gatewayv1.RouteReasonAccepted},
+		},
+	}
+
+	require.NoError(t, r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil))
+
+	var updated gatewayv1.GRPCRoute
+	require.NoError(t, fakeClient.Get(
+		context.Background(), client.ObjectKey{Name: "stale-route", Namespace: "default"}, &updated))
+
+	require.Len(t, updated.Status.Parents, 1)
+	require.Len(t, updated.Status.Parents[0].Conditions, 1)
+
+	accepted := updated.Status.Parents[0].Conditions[0]
+	assert.Equal(t, int64(newerGen), accepted.ObservedGeneration,
+		"stale reconcile must not overwrite a newer GRPCRoute status")
+	assert.Equal(t, "written by a newer reconcile", accepted.Message)
+}
+
 func TestGRPCRouteReconciler_UpdateRouteStatus_Integration(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -151,10 +151,11 @@ func (r *HTTPRouteReconciler) updateRouteStatus(
 
 	return updateRouteStatusGeneric(
 		ctx,
-		routeStatusUpdateParams{
-			k8sClient:      r.Client,
-			controllerName: r.ControllerName,
-			diagnostics:    diagnostics,
+		&routeStatusUpdateParams{
+			k8sClient:            r.Client,
+			controllerName:       r.ControllerName,
+			diagnostics:          diagnostics,
+			reconciledGeneration: route.Generation,
 		},
 		types.NamespacedName{Name: route.Name, Namespace: route.Namespace},
 		newHTTPRouteAccessor,

--- a/internal/controller/httproute_controller_test.go
+++ b/internal/controller/httproute_controller_test.go
@@ -1818,6 +1818,102 @@ func TestHTTPRouteReconciler_UpdateRouteStatus_PreservesForeignParentStatus(t *t
 	assert.Equal(t, "owned by another controller", foreign.Conditions[0].Message)
 }
 
+// TestHTTPRouteReconciler_UpdateRouteStatus_SkipsObservedGenerationRegression
+// pins the Gateway API rule that a reconcile MUST NOT overwrite a status
+// condition already stamped with an observedGeneration newer than the
+// generation this reconcile observed.
+func TestHTTPRouteReconciler_UpdateRouteStatus_SkipsObservedGenerationRegression(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-tunnel"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "test-controller"},
+	}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cloudflare-tunnel",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+
+	// Our own entry, already stamped with a newer generation than the one this
+	// reconcile observed — as if a later reconcile already wrote it.
+	const newerGen = 5
+
+	advanced := gatewayv1.RouteParentStatus{
+		ParentRef:      gatewayv1.ParentReference{Name: "test-gateway"},
+		ControllerName: "test-controller",
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(gatewayv1.RouteConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: newerGen,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(gatewayv1.RouteReasonAccepted),
+				Message:            "written by a newer reconcile",
+			},
+		},
+	}
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "stale-route", Namespace: "default", Generation: 3},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "test-gateway"}},
+			},
+		},
+		Status: gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{Parents: []gatewayv1.RouteParentStatus{advanced}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gatewayClass, gateway, route).
+		WithStatusSubresource(route).
+		Build()
+	require.NoError(t, fakeClient.Status().Update(context.Background(), route))
+
+	configResolver := config.NewResolver(fakeClient, "default", cfmetrics.NewNoopCollector())
+	routeSyncer := NewRouteSyncer(fakeClient, scheme, "cluster.local", "test-controller", configResolver, cfmetrics.NewNoopCollector(), nil)
+
+	r := &HTTPRouteReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		RouteSyncer:    routeSyncer,
+	}
+
+	bindingInfo := routeBindingInfo{
+		bindingResults: map[int]routebinding.BindingResult{
+			0: {Accepted: true, Reason: gatewayv1.RouteReasonAccepted},
+		},
+	}
+
+	// reconciledGeneration is route.Generation (3) < stored 5 → the write is skipped.
+	require.NoError(t, r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil))
+
+	var updated gatewayv1.HTTPRoute
+	require.NoError(t, fakeClient.Get(
+		context.Background(), client.ObjectKey{Name: "stale-route", Namespace: "default"}, &updated))
+
+	require.Len(t, updated.Status.Parents, 1)
+	require.Len(t, updated.Status.Parents[0].Conditions, 1)
+
+	accepted := updated.Status.Parents[0].Conditions[0]
+	assert.Equal(t, int64(newerGen), accepted.ObservedGeneration, "stale reconcile must not overwrite a newer status")
+	assert.Equal(t, "written by a newer reconcile", accepted.Message)
+}
+
 func TestHTTPRouteReconciler_UpdateRouteStatus_NonGatewayParentRef(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controller/httproute_controller_test.go
+++ b/internal/controller/httproute_controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1816,6 +1817,112 @@ func TestHTTPRouteReconciler_UpdateRouteStatus_PreservesForeignParentStatus(t *t
 	require.NotNil(t, foreign, "foreign controller's parent status must be preserved")
 	assert.Equal(t, gatewayv1.GatewayController("other.example.com/controller"), foreign.ControllerName)
 	assert.Equal(t, "owned by another controller", foreign.Conditions[0].Message)
+}
+
+// TestHTTPRouteReconciler_UpdateRouteStatus_TruncatesOwnEntriesNotForeign pins
+// the overflow rule for the RouteStatus.Parents 32-entry cap: when the combined
+// set of our managed entries plus other controllers' entries exceeds the cap,
+// only OUR entries are truncated — every foreign entry survives.
+func TestHTTPRouteReconciler_UpdateRouteStatus_TruncatesOwnEntriesNotForeign(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-tunnel"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "test-controller"},
+	}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cloudflare-tunnel",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+
+	// 28 foreign entries + 8 of our managed parentRefs = 36, over the 32 cap.
+	const (
+		foreignCount = 28
+		ourCount     = 8
+	)
+
+	foreign := make([]gatewayv1.RouteParentStatus, 0, foreignCount)
+	for i := range foreignCount {
+		foreign = append(foreign, gatewayv1.RouteParentStatus{
+			ParentRef:      gatewayv1.ParentReference{Name: gatewayv1.ObjectName("foreign-" + strconv.Itoa(i))},
+			ControllerName: "other.example.com/controller",
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(gatewayv1.RouteConditionAccepted),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(gatewayv1.RouteReasonAccepted),
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		})
+	}
+
+	parentRefs := make([]gatewayv1.ParentReference, 0, ourCount)
+	for i := range ourCount {
+		sectionName := gatewayv1.SectionName("http-" + strconv.Itoa(i))
+		parentRefs = append(parentRefs, gatewayv1.ParentReference{Name: "test-gateway", SectionName: &sectionName})
+	}
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "capped-route", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: parentRefs},
+		},
+		Status: gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{Parents: foreign},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gatewayClass, gateway, route).
+		WithStatusSubresource(route).
+		Build()
+	require.NoError(t, fakeClient.Status().Update(context.Background(), route))
+
+	configResolver := config.NewResolver(fakeClient, "default", cfmetrics.NewNoopCollector())
+	routeSyncer := NewRouteSyncer(fakeClient, scheme, "cluster.local", "test-controller", configResolver, cfmetrics.NewNoopCollector(), nil)
+
+	r := &HTTPRouteReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		RouteSyncer:    routeSyncer,
+	}
+
+	require.NoError(t, r.updateRouteStatus(context.Background(), route, routeBindingInfo{}, nil, nil, nil))
+
+	var updated gatewayv1.HTTPRoute
+	require.NoError(t, fakeClient.Get(
+		context.Background(), client.ObjectKey{Name: "capped-route", Namespace: "default"}, &updated))
+
+	require.Len(t, updated.Status.Parents, routeParentStatusMaxCount)
+
+	var foreignSurvivors, ourSurvivors int
+
+	for i := range updated.Status.Parents {
+		if string(updated.Status.Parents[i].ControllerName) == "test-controller" {
+			ourSurvivors++
+		} else {
+			foreignSurvivors++
+		}
+	}
+
+	assert.Equal(t, foreignCount, foreignSurvivors,
+		"all foreign controllers' entries MUST survive truncation")
+	assert.Equal(t, routeParentStatusMaxCount-foreignCount, ourSurvivors,
+		"only our entries are truncated to fit the cap")
 }
 
 // TestHTTPRouteReconciler_UpdateRouteStatus_SkipsObservedGenerationRegression

--- a/internal/controller/httproute_controller_test.go
+++ b/internal/controller/httproute_controller_test.go
@@ -1702,6 +1702,122 @@ func TestHTTPRouteReconciler_UpdateRouteStatus_MultipleParents(t *testing.T) {
 	assert.Equal(t, gatewayv1.ObjectName("test-gateway"), updatedRoute.Status.Parents[0].ParentRef.Name)
 }
 
+// TestHTTPRouteReconciler_UpdateRouteStatus_PreservesForeignParentStatus pins
+// the Gateway API rule that a controller MUST NOT remove or modify
+// RouteParentStatus entries owned by a different controllerName. A Route
+// co-managed by another implementation keeps that implementation's entry across
+// our reconcile.
+func TestHTTPRouteReconciler_UpdateRouteStatus_PreservesForeignParentStatus(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloudflare-tunnel"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "test-controller"},
+	}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cloudflare-tunnel",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+
+	// A RouteParentStatus written by a different controller for a parent we do
+	// not manage. Gateway API requires we leave it untouched.
+	foreignParent := gatewayv1.RouteParentStatus{
+		ParentRef:      gatewayv1.ParentReference{Name: "foreign-gateway"},
+		ControllerName: "other.example.com/controller",
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(gatewayv1.RouteConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(gatewayv1.RouteReasonAccepted),
+				Message:            "owned by another controller",
+			},
+		},
+	}
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-route", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: "test-gateway"},
+				},
+			},
+		},
+		Status: gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{foreignParent},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gatewayClass, gateway, route).
+		WithStatusSubresource(route).
+		Build()
+
+	// Seed the foreign entry through the status subresource so it is durably
+	// stored before our reconcile reads it back.
+	require.NoError(t, fakeClient.Status().Update(context.Background(), route))
+
+	configResolver := config.NewResolver(fakeClient, "default", cfmetrics.NewNoopCollector())
+	routeSyncer := NewRouteSyncer(fakeClient, scheme, "cluster.local", "test-controller", configResolver, cfmetrics.NewNoopCollector(), nil)
+
+	r := &HTTPRouteReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		ControllerName: "test-controller",
+		RouteSyncer:    routeSyncer,
+	}
+
+	bindingInfo := routeBindingInfo{
+		bindingResults: map[int]routebinding.BindingResult{
+			0: {Accepted: true, Reason: gatewayv1.RouteReasonAccepted},
+		},
+	}
+
+	err := r.updateRouteStatus(context.Background(), route, bindingInfo, nil, nil, nil)
+	require.NoError(t, err)
+
+	var updatedRoute gatewayv1.HTTPRoute
+	require.NoError(t, fakeClient.Get(
+		context.Background(), client.ObjectKey{Name: "shared-route", Namespace: "default"}, &updatedRoute))
+
+	// Our managed parent is (re)written and the foreign controller's entry survives.
+	require.Len(t, updatedRoute.Status.Parents, 2)
+
+	var ours, foreign *gatewayv1.RouteParentStatus
+
+	for i := range updatedRoute.Status.Parents {
+		switch updatedRoute.Status.Parents[i].ParentRef.Name {
+		case "test-gateway":
+			ours = &updatedRoute.Status.Parents[i]
+		case "foreign-gateway":
+			foreign = &updatedRoute.Status.Parents[i]
+		}
+	}
+
+	require.NotNil(t, ours, "our managed parent status must be present")
+	assert.Equal(t, gatewayv1.GatewayController("test-controller"), ours.ControllerName)
+
+	require.NotNil(t, foreign, "foreign controller's parent status must be preserved")
+	assert.Equal(t, gatewayv1.GatewayController("other.example.com/controller"), foreign.ControllerName)
+	assert.Equal(t, "owned by another controller", foreign.Conditions[0].Message)
+}
+
 func TestHTTPRouteReconciler_UpdateRouteStatus_NonGatewayParentRef(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controller/listenerset_controller.go
+++ b/internal/controller/listenerset_controller.go
@@ -133,6 +133,28 @@ func (r *ListenerSetReconciler) isManagedGateway(
 	return classes[string(gateway.Spec.GatewayClassName)], nil
 }
 
+// listenerSetStatusStale reports whether the freshly-fetched ListenerSet
+// already carries status conditions stamped with a generation newer than
+// reconciledGen, in which case this reconcile MUST NOT overwrite the status
+// (observedGeneration regression guard). Only our own top-level conditions
+// count — a foreign condition's generation is unrelated; the per-entry listener
+// status array is wholly owned here.
+func listenerSetStatusStale(reconciledGen int64, listenerSet *gatewayv1.ListenerSet) bool {
+	if ownedConditionsStale(listenerSet.Status.Conditions, reconciledGen,
+		string(gatewayv1.ListenerSetConditionAccepted),
+		string(gatewayv1.ListenerSetConditionProgrammed),
+	) {
+		return true
+	}
+
+	entryConds := make([][]metav1.Condition, 0, len(listenerSet.Status.Listeners))
+	for i := range listenerSet.Status.Listeners {
+		entryConds = append(entryConds, listenerSet.Status.Listeners[i].Conditions)
+	}
+
+	return statusGenerationStale(reconciledGen, entryConds...)
+}
+
 // reconcileStatus computes and writes the ListenerSet status (top-level
 // Accepted/Programmed plus per-entry listener conditions). It uses
 // retry.RetryOnConflict so a parallel reconcile cannot lose updates.
@@ -147,6 +169,12 @@ func (r *ListenerSetReconciler) reconcileStatus(
 		var fresh gatewayv1.ListenerSet
 		if err := r.Get(ctx, key, &fresh); err != nil {
 			return errors.Wrap(err, "failed to get fresh listenerset")
+		}
+
+		// Skip if a newer reconcile already advanced this ListenerSet's status
+		// past the generation we observed (observedGeneration regression guard).
+		if listenerSetStatusStale(listenerSet.Generation, &fresh) {
+			return nil
 		}
 
 		now := metav1.Now()

--- a/internal/controller/listenerset_controller_test.go
+++ b/internal/controller/listenerset_controller_test.go
@@ -479,6 +479,106 @@ func TestListenerSetReconciler_SkipsWhenParentNotManaged(t *testing.T) {
 	assert.Empty(t, updated.Status.Conditions, "controller should not touch ListenerSets attached to other-class Gateways")
 }
 
+// TestListenerSetReconciler_SkipsObservedGenerationRegression pins the Gateway
+// API rule that a reconcile MUST NOT overwrite a status condition already
+// stamped with an observedGeneration newer than the one this reconcile
+// observed. It covers both the top-level conditions and the wholly-owned
+// per-listener entry conditions.
+func TestListenerSetReconciler_SkipsObservedGenerationRegression(t *testing.T) {
+	t.Parallel()
+
+	const newerGen = 5
+
+	tests := []struct {
+		name  string
+		seed  func(ls *gatewayv1.ListenerSet)
+		check func(t *testing.T, updated *gatewayv1.ListenerSet)
+	}{
+		{
+			name: "newer generation on a top-level condition",
+			seed: func(ls *gatewayv1.ListenerSet) {
+				ls.Status.Conditions = []metav1.Condition{{
+					Type:               string(gatewayv1.ListenerSetConditionAccepted),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: newerGen,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "Accepted",
+					Message:            "written by a newer reconcile",
+				}}
+			},
+			check: func(t *testing.T, updated *gatewayv1.ListenerSet) {
+				t.Helper()
+
+				cond := findCondition(updated.Status.Conditions, string(gatewayv1.ListenerSetConditionAccepted))
+				require.NotNil(t, cond)
+				assert.Equal(t, int64(newerGen), cond.ObservedGeneration)
+				assert.Equal(t, "written by a newer reconcile", cond.Message)
+			},
+		},
+		{
+			name: "newer generation on a per-listener entry condition",
+			seed: func(ls *gatewayv1.ListenerSet) {
+				ls.Status.Listeners = []gatewayv1.ListenerEntryStatus{{
+					Name: gatewayv1.SectionName("ls-l1"),
+					Conditions: []metav1.Condition{{
+						Type:               "Programmed",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: newerGen,
+						LastTransitionTime: metav1.Now(),
+						Reason:             "Programmed",
+						Message:            "entry written by a newer reconcile",
+					}},
+				}}
+			},
+			check: func(t *testing.T, updated *gatewayv1.ListenerSet) {
+				t.Helper()
+
+				require.Len(t, updated.Status.Listeners, 1)
+				require.Len(t, updated.Status.Listeners[0].Conditions, 1)
+				assert.Equal(t, int64(newerGen), updated.Status.Listeners[0].Conditions[0].ObservedGeneration)
+				assert.Equal(t, "entry written by a newer reconcile", updated.Status.Listeners[0].Conditions[0].Message)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gc := managedGatewayClass()
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "infra"},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: gatewayv1.ObjectName(gc.Name),
+					Listeners: []gatewayv1.Listener{
+						{Name: "gw-l1", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+					},
+				},
+			}
+			ls := &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "infra", Generation: 3},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{Name: gatewayv1.ObjectName(gw.Name)},
+					Listeners: []gatewayv1.ListenerEntry{
+						{Name: "ls-l1", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+					},
+				},
+			}
+			tt.seed(ls)
+
+			r, cli := newListenerSetReconciler(t, gc, gw, ls)
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: ls.Name, Namespace: ls.Namespace},
+			})
+			require.NoError(t, err)
+
+			updated := getListenerSet(t, cli, ls.Name, ls.Namespace)
+			tt.check(t, updated)
+		})
+	}
+}
+
 func newListenerSetReconciler(
 	t *testing.T,
 	gc *gatewayv1.GatewayClass,

--- a/internal/controller/route_status.go
+++ b/internal/controller/route_status.go
@@ -62,6 +62,12 @@ type acceptedConditionOverride struct {
 	message string
 }
 
+// routeParentStatusMaxCount is the CRD cap on RouteStatus.Parents
+// (+kubebuilder:validation:MaxItems=32 in shared_types.go). Exceeding it makes
+// the Status().Update fail validation, so on overflow we truncate only our own
+// entries and never the ones owned by other controllers.
+const routeParentStatusMaxCount = 32
+
 // updateRouteStatusGeneric updates the status of a route with per-parent binding conditions.
 // It fetches a fresh copy, builds parent status entries, and writes the update with retry.
 func updateRouteStatusGeneric(
@@ -109,20 +115,45 @@ func updateRouteParentStatuses(
 
 	now := metav1.Now()
 	routeStatus := accessor.routeStatus()
-	routeStatus.Parents = nil
+
+	// Gateway API requires updating only RouteParentStatus entries whose
+	// controllerName matches ours, and MUST NOT touch entries owned by other
+	// controllers co-managing this Route. Keep foreign entries verbatim and
+	// rebuild only our own below. Mirrors the BackendTLSPolicy ancestor-status
+	// writer (backendtlspolicy_controller.go updateStatus).
+	foreignEntries := make([]gatewayv1.RouteParentStatus, 0, len(routeStatus.Parents))
+
+	for _, parent := range routeStatus.Parents {
+		if string(parent.ControllerName) != params.controllerName {
+			foreignEntries = append(foreignEntries, parent)
+		}
+	}
 
 	// ruleCount comes from the freshly-fetched spec so the diagnostic
 	// aggregation can tell "every rule unservable" from "some rules dropped".
 	params.ruleCount = accessor.ruleCount()
+
+	ours := make([]gatewayv1.RouteParentStatus, 0, len(accessor.parentRefs()))
 
 	for refIdx, ref := range accessor.parentRefs() {
 		parentStatus := resolveParentRefStatus(
 			ctx, params, accessor, ref, refIdx, classNames, now, bindingInfo, failedRefs, syncErr,
 		)
 		if parentStatus != nil {
-			routeStatus.Parents = append(routeStatus.Parents, *parentStatus)
+			ours = append(ours, *parentStatus)
 		}
 	}
+
+	// Reserve the foreign controllers' slots first and truncate only our own
+	// entries on overflow — other controllers' status MUST NOT be dropped.
+	available := max(routeParentStatusMaxCount-len(foreignEntries), 0)
+	if len(ours) > available {
+		ours = ours[:available]
+	}
+
+	combined := ours
+	combined = append(combined, foreignEntries...)
+	routeStatus.Parents = combined
 
 	if err := params.k8sClient.Status().Update(ctx, accessor.obj); err != nil {
 		return errors.Wrap(err, "failed to update route status")

--- a/internal/controller/route_status.go
+++ b/internal/controller/route_status.go
@@ -53,6 +53,12 @@ type routeStatusUpdateParams struct {
 	// writer tell "every rule is unservable" (Accepted=False) apart from "some
 	// rules dropped" (PartiallyInvalid=True).
 	ruleCount int
+	// reconciledGeneration is the route's metadata.generation at the time this
+	// reconcile read the spec and computed its conclusions. It is used to skip
+	// the write when a newer reconcile has already advanced our entries past it
+	// (see statusGenerationStale); the writer still stamps observedGeneration
+	// from the freshly-fetched generation.
+	reconciledGeneration int64
 }
 
 // acceptedConditionOverride carries the reason/message used to downgrade an
@@ -72,7 +78,7 @@ const routeParentStatusMaxCount = 32
 // It fetches a fresh copy, builds parent status entries, and writes the update with retry.
 func updateRouteStatusGeneric(
 	ctx context.Context,
-	params routeStatusUpdateParams,
+	params *routeStatusUpdateParams,
 	routeKey types.NamespacedName,
 	newAccessor func() routeAccessor,
 	bindingInfo routeBindingInfo,
@@ -101,7 +107,7 @@ func updateRouteStatusGeneric(
 // updateRouteParentStatuses fetches a fresh route, builds parent statuses, and writes the update.
 func updateRouteParentStatuses(
 	ctx context.Context,
-	params routeStatusUpdateParams,
+	params *routeStatusUpdateParams,
 	routeKey types.NamespacedName,
 	accessor routeAccessor,
 	classNames map[string]bool,
@@ -126,6 +132,16 @@ func updateRouteParentStatuses(
 	for _, parent := range routeStatus.Parents {
 		if string(parent.ControllerName) != params.controllerName {
 			foreignEntries = append(foreignEntries, parent)
+
+			continue
+		}
+
+		// A newer reconcile already advanced our entry past the generation we
+		// reconciled; skip the write and let that reconcile own the status
+		// (Gateway API MUST NOT overwrite a condition stamped with a newer
+		// observedGeneration).
+		if statusGenerationStale(params.reconciledGeneration, parent.Conditions) {
+			return nil
 		}
 	}
 
@@ -167,7 +183,7 @@ func updateRouteParentStatuses(
 // via a ListenerSet attached to one).
 func resolveParentRefStatus(
 	ctx context.Context,
-	params routeStatusUpdateParams,
+	params *routeStatusUpdateParams,
 	accessor routeAccessor,
 	ref gatewayv1.ParentReference,
 	refIdx int,

--- a/internal/controller/status_generation.go
+++ b/internal/controller/status_generation.go
@@ -1,0 +1,51 @@
+package controller
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// statusGenerationStale reports whether any stored condition already carries an
+// observedGeneration newer than reconciledGen — the generation this reconcile
+// observed and computed its status from.
+//
+// Gateway API requires that, in that case, the implementation MUST NOT perform
+// the status update and must wait for a future reconciliation of the newer
+// generation (shared_types.go: "If the observedGeneration of a Condition is
+// greater than the value the implementation knows about, then it MUST NOT
+// perform the update on that Condition, but must wait for a future
+// reconciliation and status update").
+//
+// The check is strictly greater-than: an equal generation is the normal
+// re-write case, so the next reconcile of the newer generation still corrects
+// any transient stale write. Callers pass every condition set they own (e.g.
+// the top-level conditions plus each nested listener/parent/ancestor slice).
+func statusGenerationStale(reconciledGen int64, conditionSets ...[]metav1.Condition) bool {
+	for _, set := range conditionSets {
+		for i := range set {
+			if set[i].ObservedGeneration > reconciledGen {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// ownedConditionsStale reports whether any of the listed owned condition types,
+// as currently stored, carries an observedGeneration newer than reconciledGen.
+//
+// Use this for objects whose status.conditions is a flat list that may also
+// hold entries written by OTHER controllers (e.g. a `special.io/...` condition
+// on a Gateway). Those foreign entries carry a generation unrelated to ours and
+// Gateway API forbids us from removing or modifying them, so the regression
+// guard must look only at the types this controller manages.
+func ownedConditionsStale(stored []metav1.Condition, reconciledGen int64, ownedTypes ...string) bool {
+	for _, condType := range ownedTypes {
+		if c := apimeta.FindStatusCondition(stored, condType); c != nil && c.ObservedGeneration > reconciledGen {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/controller/status_generation_test.go
+++ b/internal/controller/status_generation_test.go
@@ -1,0 +1,79 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func cond(observedGen int64) metav1.Condition {
+	return metav1.Condition{
+		Type:               "Accepted",
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: observedGen,
+	}
+}
+
+func TestStatusGenerationStale(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		reconciledGen int64
+		conditionSets [][]metav1.Condition
+		want          bool
+	}{
+		{
+			name:          "no conditions",
+			reconciledGen: 5,
+			conditionSets: nil,
+			want:          false,
+		},
+		{
+			name:          "all equal generation is a normal re-write",
+			reconciledGen: 5,
+			conditionSets: [][]metav1.Condition{{cond(5), cond(5)}},
+			want:          false,
+		},
+		{
+			name:          "older stored generation is overwritable",
+			reconciledGen: 5,
+			conditionSets: [][]metav1.Condition{{cond(3), cond(4)}},
+			want:          false,
+		},
+		{
+			name:          "newer stored generation in a single set is stale",
+			reconciledGen: 5,
+			conditionSets: [][]metav1.Condition{{cond(5), cond(6)}},
+			want:          true,
+		},
+		{
+			name:          "newer stored generation in a later set is stale",
+			reconciledGen: 5,
+			conditionSets: [][]metav1.Condition{{cond(5)}, {cond(4)}, {cond(7)}},
+			want:          true,
+		},
+		{
+			name:          "multiple sets all at or below is overwritable",
+			reconciledGen: 9,
+			conditionSets: [][]metav1.Condition{{cond(9)}, {cond(8)}, {cond(0)}},
+			want:          false,
+		},
+		{
+			name:          "empty inner sets are ignored",
+			reconciledGen: 1,
+			conditionSets: [][]metav1.Condition{{}, nil, {cond(1)}},
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := statusGenerationStale(tt.reconciledGen, tt.conditionSets...)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/controller/status_generation_test.go
+++ b/internal/controller/status_generation_test.go
@@ -77,3 +77,66 @@ func TestStatusGenerationStale(t *testing.T) {
 		})
 	}
 }
+
+func TestOwnedConditionsStale(t *testing.T) {
+	t.Parallel()
+
+	const ownedType = "Accepted"
+
+	stored := func(condType string, gen int64) []metav1.Condition {
+		return []metav1.Condition{{Type: condType, Status: metav1.ConditionTrue, ObservedGeneration: gen}}
+	}
+
+	tests := []struct {
+		name          string
+		stored        []metav1.Condition
+		reconciledGen int64
+		ownedTypes    []string
+		want          bool
+	}{
+		{
+			name:          "owned type at newer generation is stale",
+			stored:        stored(ownedType, 6),
+			reconciledGen: 5,
+			ownedTypes:    []string{ownedType},
+			want:          true,
+		},
+		{
+			name:          "owned type at equal generation is not stale",
+			stored:        stored(ownedType, 5),
+			reconciledGen: 5,
+			ownedTypes:    []string{ownedType},
+			want:          false,
+		},
+		{
+			name:          "owned type at older generation is not stale",
+			stored:        stored(ownedType, 3),
+			reconciledGen: 5,
+			ownedTypes:    []string{ownedType},
+			want:          false,
+		},
+		{
+			name:          "newer foreign condition type is ignored",
+			stored:        stored("special.io/SomeField", 9),
+			reconciledGen: 5,
+			ownedTypes:    []string{ownedType},
+			want:          false,
+		},
+		{
+			name:          "missing owned type is not stale",
+			stored:        nil,
+			reconciledGen: 5,
+			ownedTypes:    []string{ownedType},
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ownedConditionsStale(tt.stored, tt.reconciledGen, tt.ownedTypes...)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/test/internal/tunnelhost/tunnelhost.go
+++ b/test/internal/tunnelhost/tunnelhost.go
@@ -17,7 +17,7 @@ import (
 // set. Resolve wraps it with the specific keys it tried so the message names
 // what to export.
 var errUnset = errors.New(
-	"tunnel hostname not set; see .env.example (hack/conformance-setup.sh sources it from .env via V2_TUNNEL_HOSTNAME)")
+	"tunnel hostname not set; see .env.example (hack/conformance-setup.sh sources it from .env via CF_TUNNEL_HOSTNAME)")
 
 // Resolve returns the first non-empty value among the given env keys, checked
 // in order. It errors when none is set so callers can fail fast with a clear

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-cors-allow-credentials-behavior.yaml
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-cors-allow-credentials-behavior.yaml
@@ -1,0 +1,36 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cors-allow-credentials
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /cors-behavior-creds-false
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    filters:
+    - cors:
+        allowOrigins:
+        - https://app.example
+        allowCredentials: false
+      type: CORS
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /cors-behavior-creds-true
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    filters:
+    - cors:
+        allowOrigins:
+        - https://app.example
+        allowCredentials: true
+      type: CORS
+


### PR DESCRIPTION
## Summary

Three findings from the Gateway API v1.5.1 MUST-compliance audit (#389), none of which the conformance suite exercises. All are spec gaps in how the controller writes status, plus the unenforced rule-name uniqueness MUST.

Closes #434, closes #435, closes #436.

## Changes

- **#434 — preserve foreign-owned `RouteParentStatus`.** The route status writer rebuilt `status.parents` by clearing the slice and re-appending only this controller's entries, erasing `RouteParentStatus` written by other controllers co-managing a Route. It now keeps entries with a non-matching `controllerName` verbatim and rebuilds only its own, mirroring the BackendTLSPolicy ancestor-status writer. On overflow of the 32-entry cap, only our own entries are truncated — foreign status is never dropped.
- **#435 — guard against `observedGeneration` regressions.** Status writers stamped `observedGeneration` and persisted unconditionally. A shared guard now skips the write when a stored condition this controller owns already carries a generation newer than the one the reconcile observed (Gateway API MUST NOT). Wired into every status writer (Gateway, GatewayClass, GatewayClassConfig, BackendTLSPolicy, ListenerSet, HTTPRoute, GRPCRoute). For flat condition lists that may also hold other controllers' conditions, only this controller's own condition types are considered.
- **#436 — enforce route rule-name uniqueness via an opt-in policy.** `HTTPRouteRule.name` / `GRPCRouteRule.name` MUST be unique within a Route, but the uniqueness check ships only in the experimental-channel CRDs; the Standard channel omits it. A new opt-in `ValidatingAdmissionPolicy` (`ruleNameUniquenessPolicy.enabled`, default off) replicates the upstream CEL natively in the apiserver — no webhook, no ownership of the upstream Route CRDs. Off by default because it is cluster-scoped and can block updates to routes that already have duplicate names; documented in the limitations page and README.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [ ] Manual testing completed (if applicable) — kind conformance (HTTP+gRPC) + custom e2e + VAP admission smoke run before this leaves draft

`helm unittest` (243/243), `helm lint`, `helm-docs` (no drift), and `mkdocs build --strict` also pass.

## Documentation

- [x] README updated (if needed) — Known Limitations plus a `docs/gateway-api/limitations.md` rule-name uniqueness section
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed) — no workflow or standards change

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced (if any) — Closes #434, #435, #436

## Additional Notes

Reviewed by Opus before opening. The opt-in policy relies on `matchConstraints.matchPolicy: Equivalent` (the default) so it also matches requests made against the deprecated served versions of the Route CRDs.
