### PR TITLE
ci: retry ttl.sh pushes, lint tag-gated tests, add scheduled e2e

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Brief description of what this PR does and why.
 ## Testing
 
 - [ ] All tests pass locally (`go test ./...`)
-- [ ] Linters pass locally (`golangci-lint run`)
+- [ ] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
 - [ ] Markdown linting passes (`markdownlint **/*.md`)
 - [ ] Manual testing completed (if applicable)
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -333,8 +333,10 @@ jobs:
               ok=1
               break
             fi
-            echo "imagetools create failed (attempt ${attempt}); retrying in 5s..."
-            sleep 5
+            if [[ "${attempt}" -lt 3 ]]; then
+              echo "imagetools create failed (attempt ${attempt}); retrying in 5s..."
+              sleep 5
+            fi
           done
           [[ "${ok}" -eq 1 ]]
 
@@ -636,8 +638,10 @@ jobs:
               ok=1
               break
             fi
-            echo "helm push failed (attempt ${attempt}); retrying in 5s..."
-            sleep 5
+            if [[ "${attempt}" -lt 3 ]]; then
+              echo "helm push failed (attempt ${attempt}); retrying in 5s..."
+              sleep 5
+            fi
           done
           [[ "${ok}" -eq 1 ]]
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -233,8 +233,9 @@ jobs:
       # blob writes ("error writing layer blob: not_found"), failing the leg
       # after a clean build. Tolerate one transient push failure with a
       # duplicate step: the first attempt is continue-on-error, the retry only
-      # runs when the first attempt failed, and the gha layer cache makes the
-      # retry effectively push-only. Issue #423.
+      # runs when the first attempt failed, and the gha layer cache keeps the
+      # retry cheap (push-only when the first attempt got as far as writing
+      # cache-to). Issue #423.
       - name: Build and Push to ttl.sh by digest
         id: build
         continue-on-error: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -76,7 +76,10 @@ jobs:
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: v2.12.2
-          args: --timeout=5m
+          # --build-tags makes the linter compile the tag-gated test packages
+          # (test/e2e, test/conformance, envtest suites) that a plain run
+          # silently skips. Issue #402.
+          args: --timeout=5m --build-tags e2e,conformance,envtest
 
       - name: markdownlint
         uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23
@@ -226,8 +229,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
+      # ttl.sh is an anonymous ephemeral registry that intermittently drops
+      # blob writes ("error writing layer blob: not_found"), failing the leg
+      # after a clean build. Tolerate one transient push failure with a
+      # duplicate step: the first attempt is continue-on-error, the retry only
+      # runs when the first attempt failed, and the gha layer cache makes the
+      # retry effectively push-only. Issue #423.
       - name: Build and Push to ttl.sh by digest
         id: build
+        continue-on-error: true
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: ./${{ matrix.file }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ matrix.component }}-${{ matrix.arch }}
+          cache-to: type=gha,scope=build-${{ matrix.component }}-${{ matrix.arch }},mode=max
+          build-args: |
+            VERSION=pr-${{ github.event.pull_request.number }}
+            REVISION=${{ github.event.pull_request.head.sha }}
+
+      - name: Build and Push to ttl.sh by digest (retry)
+        id: build-retry
+        if: steps.build.outcome == 'failure'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
@@ -243,7 +268,11 @@ jobs:
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
+          if [[ "${{ steps.build.outcome }}" == "success" ]]; then
+            digest="${{ steps.build.outputs.digest }}"
+          else
+            digest="${{ steps.build-retry.outputs.digest }}"
+          fi
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
@@ -293,10 +322,21 @@ jobs:
             images+=("${IMAGE_NAME}@sha256:${digest_file}")
           done
 
-          # Create multi-arch manifest
-          docker buildx imagetools create \
-            --tag "${IMAGE_NAME}:${TAG}" \
-            "${images[@]}"
+          # Create multi-arch manifest. The push to ttl.sh can drop writes
+          # transiently (issue #423), so retry a couple of times before
+          # failing the job.
+          ok=0
+          for attempt in 1 2 3; do
+            if docker buildx imagetools create \
+              --tag "${IMAGE_NAME}:${TAG}" \
+              "${images[@]}"; then
+              ok=1
+              break
+            fi
+            echo "imagetools create failed (attempt ${attempt}); retrying in 5s..."
+            sleep 5
+          done
+          [[ "${ok}" -eq 1 ]]
 
       - name: Inspect image
         run: |
@@ -588,8 +628,18 @@ jobs:
           CHART_VERSION="0.0.0-pr.${PR_NUMBER}-1d"
           CHART_PKG="cloudflare-tunnel-gateway-controller-${CHART_VERSION}.tgz"
 
-          # Push to ttl.sh OCI registry
-          helm push "${CHART_PKG}" oci://ttl.sh
+          # Push to ttl.sh OCI registry. ttl.sh drops writes transiently
+          # (issue #423), so retry a couple of times before failing the job.
+          ok=0
+          for attempt in 1 2 3; do
+            if helm push "${CHART_PKG}" oci://ttl.sh; then
+              ok=1
+              break
+            fi
+            echo "helm push failed (attempt ${attempt}); retrying in 5s..."
+            sleep 5
+          done
+          [[ "${ok}" -eq 1 ]]
 
           echo "Chart pushed to: oci://ttl.sh/cloudflare-tunnel-gateway-controller:${CHART_VERSION}"
 

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -110,7 +110,7 @@ jobs:
             --jq '.[0].number // empty')"
 
           if [[ -n "${existing}" ]]; then
-            gh issue comment "${existing}" --body "Still failing: ${run_url}"
+            gh issue comment "${existing}" --body "Still failing: ${run_url} -- ${summary}"
           else
             gh issue create \
               --title "${title}" \

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -23,6 +23,9 @@ permissions:
 jobs:
   e2e:
     name: E2E against live tunnel
+    # Forks have no CF_* secrets and no business hitting the live tunnel; a
+    # manually dispatched fork run would only fail and file a noise issue.
+    if: github.repository == 'lexfrei/cloudflare-tunnel-gateway-controller'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -10,6 +10,9 @@ on:
     - cron: '17 5 * * 1'
   workflow_dispatch: {}
 
+# Serializes scheduled runs against each other only. NB: the run shares the
+# test tunnel with local kind-based conformance/e2e runs -- a concurrent local
+# run against the same tunnel ID will fight over the tunnel config and flake.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -79,8 +82,16 @@ jobs:
           title="Scheduled e2e against the live tunnel failed"
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+          # failure() also covers a failed infrastructure step (checkout,
+          # toolchain install) before the suite ever ran -- say which it was.
+          if [[ "${{ steps.attempt2.outcome }}" == "failure" ]]; then
+            summary="The weekly scheduled e2e run against the live test tunnel failed twice in a row (one retry to rule out transients), which may indicate a Cloudflare edge/tunnel behaviour change rather than a code regression -- no code changed to trigger this run."
+          else
+            summary="The weekly scheduled e2e run failed before completing both e2e attempts (checkout/toolchain/setup step), so this is more likely a CI infrastructure problem than a Cloudflare edge change."
+          fi
+
           {
-            echo "The weekly scheduled e2e run against the live test tunnel failed twice in a row (one retry to rule out transients), which may indicate a Cloudflare edge/tunnel behaviour change rather than a code regression -- no code changed to trigger this run."
+            echo "${summary}"
             echo ""
             echo "Failed run: ${run_url}"
             echo ""

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -1,0 +1,119 @@
+name: Scheduled E2E
+
+# Cloudflare edge / tunnel behaviour can change without notice. The pre-merge
+# gates catch OUR regressions; this scheduled run catches THEIRS: a weekly
+# smoke-level e2e against the live test tunnel so an edge-side break is
+# detected the same week it ships, not via a user report. Issue #441.
+on:
+  schedule:
+    # Weekly, Monday 05:17 UTC (off the full hour to avoid the cron rush).
+    - cron: '17 5 * * 1'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E against live tunnel
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      issues: write
+    env:
+      CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+      CF_TUNNEL_ID: ${{ secrets.CF_TUNNEL_ID }}
+      CF_TUNNEL_TOKEN: ${{ secrets.CF_TUNNEL_TOKEN }}
+      CF_TUNNEL_HOSTNAME: ${{ secrets.CF_TUNNEL_HOSTNAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.26.4'
+          cache: true
+
+      - name: Install kind
+        run: |
+          set -euo pipefail
+
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+          KIND_VERSION="v0.30.0"
+
+          curl --retry 5 --retry-delay 1 -sSLo /tmp/kind \
+            "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
+          sudo install /tmp/kind /usr/local/bin/kind
+          kind version
+
+      # The setup script builds images, creates a kind cluster, deploys the
+      # controller against the live test tunnel, and runs the e2e suite.
+      # A failure here can be a transient (registry hiccup, edge blip), so the
+      # first attempt is continue-on-error and a full second attempt decides.
+      - name: Setup cluster and run e2e (attempt 1)
+        id: attempt1
+        continue-on-error: true
+        run: ./hack/conformance-setup.sh --test-e2e
+
+      - name: Setup cluster and run e2e (attempt 2)
+        id: attempt2
+        if: steps.attempt1.outcome == 'failure'
+        run: ./hack/conformance-setup.sh --test-e2e
+
+      # A red scheduled run nobody looks at is indistinguishable from no run
+      # at all -- surface persistent failures as an issue.
+      - name: Open or update failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          title="Scheduled e2e against the live tunnel failed"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          {
+            echo "The weekly scheduled e2e run against the live test tunnel failed twice in a row (one retry to rule out transients), which may indicate a Cloudflare edge/tunnel behaviour change rather than a code regression -- no code changed to trigger this run."
+            echo ""
+            echo "Failed run: ${run_url}"
+            echo ""
+            echo "Triage hints:"
+            echo ""
+            echo "- Check the run logs for which suite/step failed (cluster setup vs e2e assertions)."
+            echo "- A symmetric failure across all routes usually means tunnel/edge connectivity, not routing logic."
+            echo "- Compare with the previous green scheduled run to bound when the behaviour changed."
+          } > /tmp/issue-body.md
+
+          existing="$(gh issue list \
+            --state open \
+            --label kind/failing-test \
+            --search "\"${title}\" in:title" \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [[ -n "${existing}" ]]; then
+            gh issue comment "${existing}" --body "Still failing: ${run_url}"
+          else
+            gh issue create \
+              --title "${title}" \
+              --body-file /tmp/issue-body.md \
+              --label kind/failing-test \
+              --label area/testing \
+              --label area/ci \
+              --label priority/important-soon \
+              --label triage/needs-triage
+          fi
+
+      - name: Cleanup kind clusters
+        if: always()
+        run: |
+          for cluster in $(kind get clusters 2>/dev/null | grep '^v2-test' || true); do
+            kind delete cluster --name "${cluster}"
+          done

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -85,7 +85,7 @@ jobs:
           # failure() also covers a failed infrastructure step (checkout,
           # toolchain install) before the suite ever ran -- say which it was.
           if [[ "${{ steps.attempt2.outcome }}" == "failure" ]]; then
-            summary="The weekly scheduled e2e run against the live test tunnel failed twice in a row (one retry to rule out transients), which may indicate a Cloudflare edge/tunnel behaviour change rather than a code regression -- no code changed to trigger this run."
+            summary="The e2e run against the live test tunnel failed twice in a row (one retry to rule out transients), which may indicate a Cloudflare edge/tunnel behaviour change rather than a code regression -- this is a scheduled/manual run, not a merge gate, so no code change triggered it."
           else
             summary="The weekly scheduled e2e run failed before completing both e2e attempts (checkout/toolchain/setup step), so this is more likely a CI infrastructure problem than a Cloudflare edge change."
           fi

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -110,6 +110,11 @@ linters:
           - perfsprint
           - paralleltest
           - maintidx
+          # envtest suites share TestMain-initialized state (test environment,
+          # client, scheme) via package globals -- the idiomatic
+          # controller-runtime pattern; a struct would have to thread through
+          # every helper for no isolation gain in test binaries.
+          - gochecknoglobals
         path: _test\.go
       - linters:
           - forbidigo

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -113,10 +113,11 @@ linters:
           - perfsprint
           - paralleltest
           - maintidx
-          # envtest suites share TestMain-initialized state (test environment,
-          # client, scheme) via package globals -- the idiomatic
-          # controller-runtime pattern; a struct would have to thread through
-          # every helper for no isolation gain in test binaries.
+          # Test binaries legitimately use package globals: envtest suites
+          # share TestMain-initialized state (test environment, client,
+          # scheme) per the idiomatic controller-runtime pattern, and
+          # table-driven guards keep package-level data tables. Threading
+          # either through every helper buys no isolation in a test binary.
           - gochecknoglobals
         path: _test\.go
       - linters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,9 @@ linters:
     - errchkjson
     - ireturn
     - gocheckcompilerdirectives
+    # Deprecated since v2.12; gomodguard_v2 (enabled via default: all)
+    # replaces it. Keeping both active only produces a warning per run.
+    - gomodguard
   settings:
     dupl:
       threshold: 100

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ go test -v -race -coverprofile=coverage.out ./...
 go test -v -race ./internal/dns/... -run TestDetectClusterDomain
 
 # Run linter (all errors must be fixed before committing)
-golangci-lint run --timeout=5m
+golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest
 
 # Lint markdown files
 markdownlint-cli2 '**/*.md'
@@ -382,7 +382,7 @@ Run checks relevant to the files you changed:
 
 | Changed Files | Required Checks |
 |---------------|-----------------|
-| `*.go` | `go test -race ./...` and `golangci-lint run --timeout=5m` |
+| `*.go` | `go test -race ./...` and `golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest` |
 | `charts/**` | `helm unittest`, `helm lint`, `helm-docs` |
 | `**/*.md` | `markdownlint-cli2 '**/*.md'` |
 | `docs/**` | `mkdocs build --strict` |
@@ -391,7 +391,7 @@ Quick reference commands:
 
 ```bash
 # Go code changes
-go test -race ./... && golangci-lint run --timeout=5m
+go test -race ./... && golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest
 
 # Helm chart changes
 helm unittest charts/cloudflare-tunnel-gateway-controller && \
@@ -413,7 +413,7 @@ Before creating a PR, verify all checklist items from `.github/pull_request_temp
 
 1. **Testing**
    - All tests pass locally (`go test ./...`)
-   - Linters pass locally (`golangci-lint run`)
+   - Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
    - Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
    - Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller`)
    - Helm lint passes (`helm lint charts/cloudflare-tunnel-gateway-controller`)
@@ -527,7 +527,7 @@ Standalone labels not enumerated above (`epic`, `community`, `help wanted`, `goo
 
 ### Milestone
 
-Always assign a milestone when creating issues. The current active milestone is `v3.0.0`; anything bound to an earlier release line goes in the corresponding `vX.Y.Z` milestone if one exists.
+Always assign a milestone when creating issues. The current active milestone is `v3.1.0`; anything bound to an earlier release line goes in the corresponding `vX.Y.Z` milestone if one exists. Exception: issues filed automatically by workflows (e.g. the scheduled-e2e failure alert) carry no milestone — the right release target is unknown until a human triages them.
 
 ## Conformance Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,6 +564,9 @@ Official Gateway API conformance suite (`sigs.k8s.io/gateway-api/conformance` v1
 # Setup only (reuse for iterative testing)
 ./hack/conformance-setup.sh
 
+# Setup + run the custom e2e suite (smoke-level; lighter than --test)
+./hack/conformance-setup.sh --test-e2e
+
 # Verify a PR's CI artifact: skip the local build, deploy the PR's published
 # ttl.sh chart+images (the chart already pins the ttl.sh image refs). Add --test
 # to also run the suite. ttl.sh artifacts expire 24h after the PR's CI ran.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -33,7 +33,7 @@ git clone https://github.com/lexfrei/cloudflare-tunnel-gateway-controller.git
 cd cloudflare-tunnel-gateway-controller
 go mod download
 go build ./...
-golangci-lint run
+golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest
 ```
 
 ## Commit Message Format
@@ -80,7 +80,7 @@ chore(deps): update controller-runtime to v0.24.0
 1. **Title**: Use conventional commit format
 2. **Description**: Fill out the PR template completely
 3. **Tests**: Add tests for new functionality
-4. **Linting**: Ensure `golangci-lint run` passes with no errors
+4. **Linting**: Ensure `golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest` passes with no errors
 5. **Documentation**: Update relevant docs
 6. **Review**: Address reviewer feedback
 
@@ -114,10 +114,10 @@ All linting errors must be fixed before merging:
 
 ```bash
 # Run linter
-golangci-lint run
+golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest
 
 # Auto-fix some issues
-golangci-lint run --fix
+golangci-lint run --fix --build-tags e2e,conformance,envtest
 ```
 
 ### nolint Directives

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -63,7 +63,7 @@ go build -o bin/controller ./cmd/controller
 go test -v -race ./...
 
 # Run linter
-golangci-lint run --timeout=5m
+golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest
 ```
 
 ## Project Structure
@@ -88,5 +88,5 @@ deploy/                  # Raw Kubernetes manifests
 All changes must pass:
 
 - `go test -race ./...` - Unit tests with race detection
-- `golangci-lint run` - Linting (all errors must be fixed)
+- `golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest` - Linting (all errors must be fixed)
 - `markdownlint-cli2 '**/*.md'` - Markdown linting

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -27,7 +27,7 @@ go build -o bin/controller ./cmd/controller
 go test -v ./...
 
 # Run linter
-golangci-lint run
+golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest
 ```
 
 ## Building
@@ -106,13 +106,13 @@ The project uses golangci-lint with strict configuration:
 
 ```bash
 # Run linter
-golangci-lint run
+golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest
 
 # Run with timeout for CI
-golangci-lint run --timeout=5m
+golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest
 
 # Auto-fix issues
-golangci-lint run --fix
+golangci-lint run --fix --build-tags e2e,conformance,envtest
 ```
 
 ### Key Linter Settings

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -282,7 +282,7 @@ Conformance tests validate that the controller implements the Gateway API specif
 
 ### Running E2E Tests
 
-E2E tests run against a live kind cluster with Cloudflare Tunnel and L7 proxy deployed. `E2E_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` (`CF_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.
+E2E tests run against a live kind cluster with Cloudflare Tunnel and L7 proxy deployed. `E2E_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` or the exported environment (`CF_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.
 
 ```bash
 # Run all E2E tests
@@ -318,7 +318,7 @@ Tests cover both Cloudflare Tunnel and L7 proxy features:
 
 The project integrates the official `sigs.k8s.io/gateway-api/conformance` suite with a custom `TunnelRoundTripper` that routes requests through Cloudflare edge.
 
-`CONFORMANCE_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` (`CF_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.
+`CONFORMANCE_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` or the exported environment (`CF_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.
 
 ```bash
 # Run conformance tests (requires deployed controller + tunnel)

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -21,11 +21,17 @@
 #   ./hack/conformance-setup.sh --skip-build     # skip image build (reuse existing)
 #   ./hack/conformance-setup.sh --use-ci-images N  # deploy PR #N's published ttl.sh
 #                                                  # chart+images (no local build)
+#   ./hack/conformance-setup.sh --test-e2e       # setup + run the custom e2e suite
+#                                                  # (smoke-level; lighter than --test)
 #
 # Prerequisites:
 #   - .env file in repo root with: CF_API_TOKEN, CF_ACCOUNT_ID, CF_TUNNEL_ID,
-#     CF_TUNNEL_TOKEN, CF_TUNNEL_HOSTNAME (the edge hostname routing to the tunnel)
-#   - colima, docker, kind, helm, kubectl, go installed
+#     CF_TUNNEL_TOKEN, CF_TUNNEL_HOSTNAME (the edge hostname routing to the tunnel);
+#     alternatively (CI) the same variables already exported in the environment
+#   - colima (macOS only), docker, kind, helm, kubectl, go installed
+#
+# In GitHub Actions (GITHUB_ACTIONS=true) the colima requirement is skipped:
+# the runner's native docker daemon is used directly.
 
 set -euo pipefail
 
@@ -45,6 +51,7 @@ GATEWAY_API_VERSION="v1.5.1"
 
 # --- Flags ---
 RUN_TESTS=false
+RUN_E2E=false
 SKIP_BUILD=false
 CI_PR_NUMBER=""
 # Gateway API CRD release channel. "experimental" is the default (superset of
@@ -66,6 +73,7 @@ check_tool() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --test) RUN_TESTS=true ;;
+    --test-e2e) RUN_E2E=true ;;
     --channel)
       shift
       [[ $# -gt 0 ]] || die "--channel requires a value (standard|experimental)"
@@ -91,19 +99,27 @@ if [[ -n "${CI_PR_NUMBER}" && "${SKIP_BUILD}" == "true" ]]; then
 fi
 
 # --- Pre-flight checks ---
+# colima is the macOS docker backend; GitHub Actions runners have a native
+# docker daemon, so the requirement (and the start step below) is skipped there.
 info "Checking prerequisites..."
-for tool in colima docker kind helm kubectl go; do
+TOOLS=(docker kind helm kubectl go)
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  TOOLS+=(colima)
+fi
+for tool in "${TOOLS[@]}"; do
   check_tool "${tool}"
 done
 
 # --- Load .env ---
+# CI exports the CF_* variables directly (repo secrets); a missing .env is
+# only fatal when the variables are not already in the environment.
 ENV_FILE="${REPO_ROOT}/.env"
-if [[ ! -f "${ENV_FILE}" ]]; then
-  die ".env file not found at ${ENV_FILE}. See .env.example or MEMORY.md for required variables."
+if [[ -f "${ENV_FILE}" ]]; then
+  # shellcheck source=/dev/null
+  source "${ENV_FILE}"
+elif [[ -z "${CF_API_TOKEN:-}" ]]; then
+  die ".env file not found at ${ENV_FILE} and CF_* variables are not exported. See .env.example for required variables."
 fi
-
-# shellcheck source=/dev/null
-source "${ENV_FILE}"
 
 for var in CF_API_TOKEN CF_ACCOUNT_ID CF_TUNNEL_ID CF_TUNNEL_TOKEN CF_TUNNEL_HOSTNAME; do
   if [[ -z "${!var:-}" ]]; then
@@ -138,11 +154,13 @@ if [[ -n "${CI_PR_NUMBER}" ]]; then
     || die "Chart ${CI_CHART_VERSION} not found on ttl.sh. ttl.sh artifacts expire after 24h (the '1d' tag) — re-run PR #${CI_PR_NUMBER}'s CI to republish."
 fi
 
-# --- Step 1: Ensure colima is running ---
-info "Checking colima..."
-if ! colima status >/dev/null 2>&1; then
-  info "Starting colima..."
-  colima start
+# --- Step 1: Ensure colima is running (macOS only; CI uses native docker) ---
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  info "Checking colima..."
+  if ! colima status >/dev/null 2>&1; then
+    info "Starting colima..."
+    colima start
+  fi
 fi
 
 # --- Step 2: Delete old v2-test-* clusters ---
@@ -285,6 +303,11 @@ if [[ "${RUN_TESTS}" == "true" ]]; then
   CONFORMANCE_KUBE_CONTEXT="${KUBE_CONTEXT}" \
   CONFORMANCE_TUNNEL_HOSTNAME="${CF_TUNNEL_HOSTNAME}" \
     go test -v -race -tags conformance -count=1 -timeout=60m -parallel 10 ./test/conformance/...
+elif [[ "${RUN_E2E}" == "true" ]]; then
+  info "Running e2e tests against ${CF_TUNNEL_HOSTNAME}..."
+  E2E_KUBE_CONTEXT="${KUBE_CONTEXT}" \
+  E2E_TUNNEL_HOSTNAME="${CF_TUNNEL_HOSTNAME}" \
+    go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/...
 else
   echo ""
   info "Setup complete! To run conformance tests:"

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -98,6 +98,12 @@ if [[ -n "${CI_PR_NUMBER}" && "${SKIP_BUILD}" == "true" ]]; then
   die "--use-ci-images and --skip-build are mutually exclusive"
 fi
 
+# The test runner below is an either/or branch; accepting both flags would
+# silently drop one suite.
+if [[ "${RUN_TESTS}" == "true" && "${RUN_E2E}" == "true" ]]; then
+  die "--test and --test-e2e are mutually exclusive (run them as separate invocations)"
+fi
+
 # --- Pre-flight checks ---
 # colima is the macOS docker backend; GitHub Actions runners have a native
 # docker daemon, so the requirement (and the start step below) is skipped there.

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -123,7 +123,7 @@ fi
 
 for var in CF_API_TOKEN CF_ACCOUNT_ID CF_TUNNEL_ID CF_TUNNEL_TOKEN CF_TUNNEL_HOSTNAME; do
   if [[ -z "${!var:-}" ]]; then
-    die "Required variable ${var} is not set in .env (see .env.example)"
+    die "Required variable ${var} is not set (provide via .env or the environment; see .env.example)"
   fi
 done
 

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -320,7 +320,7 @@ else
   echo "  CONFORMANCE_KUBE_CONTEXT=${KUBE_CONTEXT} CONFORMANCE_TUNNEL_HOSTNAME=${CF_TUNNEL_HOSTNAME} go test -v -race -tags conformance -count=1 -timeout=30m ./test/conformance/..."
   echo ""
   info "To run E2E tests:"
-  echo "  CONFORMANCE_KUBE_CONTEXT=${KUBE_CONTEXT} E2E_TUNNEL_HOSTNAME=${CF_TUNNEL_HOSTNAME} go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/..."
+  echo "  E2E_KUBE_CONTEXT=${KUBE_CONTEXT} E2E_TUNNEL_HOSTNAME=${CF_TUNNEL_HOSTNAME} go test -v -race -tags e2e -count=1 -timeout=15m ./test/e2e/..."
   echo ""
   info "To tear down:"
   echo "  kind delete cluster --name ${CLUSTER_NAME}"

--- a/internal/docsdrift/docsdrift_test.go
+++ b/internal/docsdrift/docsdrift_test.go
@@ -18,8 +18,6 @@ import (
 // retiredSubstrings lists v2 vocabulary that must not appear in the docs.
 // Each entry has a why-it-was-removed explanation so a future maintainer
 // who hits this test understands the v3 boundary.
-//
-//nolint:gochecknoglobals // test data table; package-level slice is the standard Go test pattern.
 var retiredSubstrings = []struct {
 	needle string
 	why    string
@@ -158,8 +156,6 @@ var retiredSubstrings = []struct {
 // recursively; non-text files are skipped by extension. Covers both the
 // markdown docs corpus and the Go source — the "v2 proxy" / "v1 path"
 // vocabulary must not survive in either.
-//
-//nolint:gochecknoglobals // test data; package-level is idiomatic.
 var trackedRoots = []string{
 	"docs",
 	"CLAUDE.md",
@@ -178,8 +174,6 @@ var trackedRoots = []string{
 
 // trackedExtensions are the file types the guard inspects. Everything
 // else (images, lockfiles, binaries) is skipped.
-//
-//nolint:gochecknoglobals // test data; package-level is idiomatic.
 var trackedExtensions = map[string]bool{
 	".md":     true,
 	".gotmpl": true,
@@ -194,8 +188,6 @@ var trackedExtensions = map[string]bool{
 // (the v2→v3 migration guide must call out what was removed; this test
 // must reference the strings it's guarding against). One per file +
 // substring pair.
-//
-//nolint:gochecknoglobals // test data; package-level is idiomatic.
 var allowedFiles = map[string]map[string]bool{
 	"docs/upgrading/v2-to-v3.md": {
 		"Helm SDK":                                true,

--- a/internal/docsdrift/lintargs_test.go
+++ b/internal/docsdrift/lintargs_test.go
@@ -15,16 +15,16 @@ import (
 	"testing"
 )
 
-// lintCommandDocs are the files whose golangci-lint invocations must match
-// the CI arguments. Every line mentioning `golangci-lint run` in these
-// files must carry the CI --build-tags value.
+// lintCommandDocs are the files and trees whose golangci-lint invocations
+// must match the CI arguments. Every line mentioning `golangci-lint run`
+// in any tracked markdown file must carry the CI --build-tags value.
+// Directories are walked recursively so a new doc page cannot dodge the
+// guard by not being enumerated.
 var lintCommandDocs = []string{
 	"CLAUDE.md",
+	"README.md",
 	".github/pull_request_template.md",
-	"docs/development/index.md",
-	"docs/development/setup.md",
-	"docs/development/contributing.md",
-	"docs/development/testing.md",
+	"docs",
 }
 
 // ciLintBuildTags extracts the --build-tags value from the lint job in
@@ -54,20 +54,61 @@ func TestDocumentedLintCommandsCarryCIBuildTags(t *testing.T) {
 	want := "--build-tags " + tags
 
 	for _, rel := range lintCommandDocs {
-		body, err := os.ReadFile(filepath.Join(repoRoot, rel))
+		abs := filepath.Join(repoRoot, rel)
+
+		info, err := os.Stat(abs)
 		if err != nil {
-			t.Fatalf("read %s: %v", rel, err)
+			t.Fatalf("stat %s: %v", rel, err)
 		}
 
-		for i, line := range strings.Split(string(body), "\n") {
-			if !strings.Contains(line, "golangci-lint run") {
-				continue
+		if !info.IsDir() {
+			checkLintCommands(t, repoRoot, abs, want)
+
+			continue
+		}
+
+		walkErr := filepath.Walk(abs, func(path string, fi os.FileInfo, err error) error {
+			if err != nil {
+				return err
 			}
 
-			if !strings.Contains(line, want) {
-				t.Errorf("%s:%d documents a golangci-lint invocation without %q (CI lints with it; docs must match or tag-gated packages silently pass locally):\n  %s",
-					rel, i+1, want, strings.TrimSpace(line))
+			if fi.IsDir() || filepath.Ext(path) != ".md" {
+				return nil
 			}
+
+			checkLintCommands(t, repoRoot, path, want)
+
+			return nil
+		})
+		if walkErr != nil {
+			t.Fatalf("walk %s: %v", rel, walkErr)
+		}
+	}
+}
+
+// checkLintCommands asserts every golangci-lint invocation in the file
+// carries the CI --build-tags value.
+func checkLintCommands(t *testing.T, repoRoot, absPath, want string) {
+	t.Helper()
+
+	rel, err := filepath.Rel(repoRoot, absPath)
+	if err != nil {
+		rel = absPath
+	}
+
+	body, err := os.ReadFile(absPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+
+	for i, line := range strings.Split(string(body), "\n") {
+		if !strings.Contains(line, "golangci-lint run") {
+			continue
+		}
+
+		if !strings.Contains(line, want) {
+			t.Errorf("%s:%d documents a golangci-lint invocation without %q (CI lints with it; docs must match or tag-gated packages silently pass locally):\n  %s",
+				rel, i+1, want, strings.TrimSpace(line))
 		}
 	}
 }

--- a/internal/docsdrift/lintargs_test.go
+++ b/internal/docsdrift/lintargs_test.go
@@ -1,0 +1,73 @@
+package docsdrift_test
+
+// Lint-command drift guard: CI lints with --build-tags so the tag-gated
+// test packages (test/e2e, test/conformance, envtest suites) are compiled
+// by the linter. Every documented local lint invocation must carry the
+// same flag, or a contributor following the docs gets a local "0 issues"
+// on packages the linter never compiled and a red CI — the exact blind
+// spot the CI flag closed.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// lintCommandDocs are the files whose golangci-lint invocations must match
+// the CI arguments. Every line mentioning `golangci-lint run` in these
+// files must carry the CI --build-tags value.
+var lintCommandDocs = []string{
+	"CLAUDE.md",
+	".github/pull_request_template.md",
+	"docs/development/index.md",
+	"docs/development/setup.md",
+	"docs/development/contributing.md",
+	"docs/development/testing.md",
+}
+
+// ciLintBuildTags extracts the --build-tags value from the lint job in
+// .github/workflows/pr.yaml. Failing to find it is itself a drift: CI
+// stopped linting the tag-gated packages.
+func ciLintBuildTags(t *testing.T, repoRoot string) string {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join(repoRoot, ".github", "workflows", "pr.yaml"))
+	if err != nil {
+		t.Fatalf("read pr.yaml: %v", err)
+	}
+
+	m := regexp.MustCompile(`args:.*--build-tags\s+(\S+)`).FindStringSubmatch(string(body))
+	if m == nil {
+		t.Fatal("pr.yaml lint job no longer passes --build-tags; the tag-gated test packages are invisible to CI lint again")
+	}
+
+	return m[1]
+}
+
+func TestDocumentedLintCommandsCarryCIBuildTags(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := findRepoRoot(t)
+	tags := ciLintBuildTags(t, repoRoot)
+	want := "--build-tags " + tags
+
+	for _, rel := range lintCommandDocs {
+		body, err := os.ReadFile(filepath.Join(repoRoot, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+
+		for i, line := range strings.Split(string(body), "\n") {
+			if !strings.Contains(line, "golangci-lint run") {
+				continue
+			}
+
+			if !strings.Contains(line, want) {
+				t.Errorf("%s:%d documents a golangci-lint invocation without %q (CI lints with it; docs must match or tag-gated packages silently pass locally):\n  %s",
+					rel, i+1, want, strings.TrimSpace(line))
+			}
+		}
+	}
+}

--- a/test/e2e/e2e_grpc_test.go
+++ b/test/e2e/e2e_grpc_test.go
@@ -37,8 +37,6 @@ const (
 // Cloudflare tunnel. It asserts the call reaches the backend (the echo
 // response carries the fully-qualified method), proving GRPCRoute traffic
 // routes through the in-process proxy.
-//
-//nolint:funlen // one end-to-end scenario with deploy + wait + gRPC dial steps
 func TestGRPCRouteEndToEnd(t *testing.T) {
 	cfg := loadTestConfig(t)
 
@@ -117,7 +115,8 @@ func deployGRPCEchoBackend(t *testing.T, k8sClient client.Client, namespace, nam
 	grpcEnv := "1"
 
 	existing := &appsv1.Deployment{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, existing); err == nil {
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, existing)
+	if err == nil {
 		t.Logf("deployment %s/%s already exists, skipping", namespace, name)
 	} else {
 		deploy := &appsv1.Deployment{
@@ -163,11 +162,12 @@ func deployGRPCEchoBackend(t *testing.T, k8sClient client.Client, namespace, nam
 			},
 		},
 	}
-	if err := k8sClient.Create(ctx, svc); err != nil {
-		t.Logf("service %s/%s create: %v (may already exist)", namespace, name, err)
+	createErr := k8sClient.Create(ctx, svc)
+	if createErr != nil {
+		t.Logf("service %s/%s create: %v (may already exist)", namespace, name, createErr)
 	}
 
-	waitForDeployment(t, ctx, k8sClient, namespace, name, 120*time.Second)
+	waitForDeployment(ctx, t, k8sClient, namespace, name, 120*time.Second)
 }
 
 func buildGRPCRoute(name string, cfg testConfig, backend string) *gatewayv1.GRPCRoute {
@@ -210,7 +210,8 @@ func createGRPCRoute(t *testing.T, k8sClient client.Client, route *gatewayv1.GRP
 	ctx := context.Background()
 
 	existing := &gatewayv1.GRPCRoute{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: route.Name, Namespace: route.Namespace}, existing); err == nil {
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: route.Name, Namespace: route.Namespace}, existing)
+	if err == nil {
 		require.NoError(t, k8sClient.Delete(ctx, existing))
 		time.Sleep(time.Second)
 	}
@@ -225,8 +226,9 @@ func waitForGRPCRouteAccepted(t *testing.T, k8sClient client.Client, route *gate
 	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 90*time.Second, true,
 		func(pollCtx context.Context) (bool, error) {
 			current := &gatewayv1.GRPCRoute{}
-			if getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: route.Name, Namespace: route.Namespace}, current); getErr != nil {
-				return false, nil
+			getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: route.Name, Namespace: route.Namespace}, current)
+			if getErr != nil {
+				return false, nil //nolint:nilerr // transient API errors are expected while polling; retry until timeout
 			}
 
 			for _, parent := range current.Status.Parents {

--- a/test/e2e/e2e_listenerset_test.go
+++ b/test/e2e/e2e_listenerset_test.go
@@ -30,8 +30,6 @@ import (
 // (which the shared setupGateway intentionally does not set so other tests
 // aren't affected by the multi-listener attach semantic) and restores it on
 // cleanup. This is the only e2e test that mutates the shared Gateway spec.
-//
-//nolint:funlen // single end-to-end scenario with several wait/assert steps
 func TestListenerSetEndToEnd(t *testing.T) {
 	cfg := loadTestConfig(t)
 	httpClient := tunnelClient()
@@ -63,7 +61,7 @@ func TestListenerSetEndToEnd(t *testing.T) {
 
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/ls-e2e", "echo-v1-", 90*time.Second)
 
-	echo, resp, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/ls-e2e", nil)
+	echo, resp, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/ls-e2e", nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "/ls-e2e", echo.Path)
@@ -102,7 +100,8 @@ func allowListenerSetAttachment(t *testing.T, k8sClient client.Client, cfg testC
 
 	return func() {
 		fresh := &gatewayv1.Gateway{}
-		if err := k8sClient.Get(context.Background(), key, fresh); err != nil {
+		err := k8sClient.Get(context.Background(), key, fresh)
+		if err != nil {
 			return
 		}
 
@@ -164,8 +163,9 @@ func waitForListenerSetAccepted(t *testing.T, k8sClient client.Client, ls *gatew
 	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 90*time.Second, true,
 		func(pollCtx context.Context) (bool, error) {
 			current := &gatewayv1.ListenerSet{}
-			if getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: ls.Name, Namespace: ls.Namespace}, current); getErr != nil {
-				return false, nil
+			getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: ls.Name, Namespace: ls.Namespace}, current)
+			if getErr != nil {
+				return false, nil //nolint:nilerr // transient API errors are expected while polling; retry until timeout
 			}
 
 			accepted := false
@@ -193,8 +193,9 @@ func waitForGatewayAttachedListenerSets(t *testing.T, k8sClient client.Client, c
 	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second, true,
 		func(pollCtx context.Context) (bool, error) {
 			gw := &gatewayv1.Gateway{}
-			if getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: cfg.GatewayName, Namespace: cfg.Namespace}, gw); getErr != nil {
-				return false, nil
+			getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: cfg.GatewayName, Namespace: cfg.Namespace}, gw)
+			if getErr != nil {
+				return false, nil //nolint:nilerr // transient API errors are expected while polling; retry until timeout
 			}
 
 			if gw.Status.AttachedListenerSets == nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -98,23 +98,32 @@ func tunnelClient() *http.Client {
 	}
 }
 
+// echoHTTPResponse carries the response metadata the tests assert on. The
+// underlying body is fully consumed and closed inside makeRequest, so there
+// is nothing left for callers to close.
+type echoHTTPResponse struct {
+	StatusCode int
+	Header     http.Header
+}
+
 // makeRequest sends a request through the Cloudflare tunnel and parses the
 // echo-basic JSON response.
 func makeRequest(
+	ctx context.Context,
 	t *testing.T,
 	httpClient *http.Client,
 	tunnelHostname string,
 	method string,
 	path string,
 	headers map[string]string,
-) (*echoResponse, *http.Response, error) {
+) (*echoResponse, *echoHTTPResponse, error) {
 	t.Helper()
 
 	reqURL := fmt.Sprintf("https://%s%s", tunnelHostname, path)
 
-	req, err := http.NewRequestWithContext(context.Background(), method, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("building %s request for %s: %w", method, reqURL, err)
 	}
 
 	for key, val := range headers {
@@ -123,25 +132,28 @@ func makeRequest(
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("sending %s request to %s: %w", method, reqURL, err)
 	}
 	defer resp.Body.Close()
 
+	meta := &echoHTTPResponse{StatusCode: resp.StatusCode, Header: resp.Header}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, resp, err
+		return nil, meta, fmt.Errorf("reading response body from %s: %w", reqURL, err)
 	}
 
 	var echo echoResponse
 	if resp.Header.Get("Content-Type") == "application/json" {
-		if jsonErr := json.Unmarshal(body, &echo); jsonErr != nil {
-			return nil, resp, fmt.Errorf("failed to parse echo response: %w (body: %s)", jsonErr, string(body))
+		jsonErr := json.Unmarshal(body, &echo)
+		if jsonErr != nil {
+			return nil, meta, fmt.Errorf("failed to parse echo response: %w (body: %s)", jsonErr, string(body))
 		}
 	} else {
 		echo.Method = method
 	}
 
-	return &echo, resp, nil
+	return &echo, meta, nil
 }
 
 // waitForBackend polls until the given path routes to a pod matching podPrefix.
@@ -156,10 +168,10 @@ func waitForBackend(
 	t.Helper()
 
 	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, true,
-		func(_ context.Context) (bool, error) {
-			echo, resp, reqErr := makeRequest(t, httpClient, tunnelHostname, http.MethodGet, path, nil)
+		func(pollCtx context.Context) (bool, error) {
+			echo, resp, reqErr := makeRequest(pollCtx, t, httpClient, tunnelHostname, http.MethodGet, path, nil)
 			if reqErr != nil {
-				return false, nil
+				return false, nil //nolint:nilerr // transient edge/tunnel errors are expected while polling; retry until timeout
 			}
 
 			if resp.StatusCode == http.StatusNotFound {
@@ -251,7 +263,7 @@ func wipeAllRoutesInNamespace(t *testing.T, k8sClient client.Client, cfg testCon
 // TestHTTPRouteConformance runs Gateway API HTTPRoute conformance-style tests
 // against a live Cloudflare Tunnel deployment.
 //
-// Run with: go test -v -tags e2e -timeout 10m ./test/e2e/
+// Run with: go test -v -tags e2e -timeout 10m ./test/e2e/...
 func TestHTTPRouteConformance(t *testing.T) {
 	cfg := loadTestConfig(t)
 	httpClient := tunnelClient()
@@ -418,14 +430,14 @@ func testHTTPRouteSimpleSameNamespace(
 	createHTTPRoute(t, k8sClient, route)
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/simple", "echo-v1-", 60*time.Second)
 
-	echo, resp, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/simple", nil)
+	echo, resp, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/simple", nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "/simple", echo.Path)
 	assert.Equal(t, cfg.TestNamespace, echo.Namespace)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "pod should be echo-v1, got: %s", echo.Pod)
 
-	echo, resp, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/simple/sub", nil)
+	echo, resp, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/simple/sub", nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "/simple/sub", echo.Path)
@@ -450,15 +462,15 @@ func testHTTPRoutePathPrefixMatching(
 	createHTTPRoute(t, k8sClient, route)
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/prefix-a", "echo-v1-", 60*time.Second)
 
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/prefix-a", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/prefix-a", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"))
 
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/prefix-b", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/prefix-b", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"))
 
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/prefix-a/sub", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/prefix-a/sub", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"))
 }
@@ -483,7 +495,7 @@ func testHTTPRouteExactPathMatching(
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/exact-only", "echo-v1-", 60*time.Second)
 
 	// Exact match → echo-v1.
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/exact-only", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/exact-only", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "exact match → echo-v1, got: %s", echo.Pod)
 
@@ -491,7 +503,7 @@ func testHTTPRouteExactPathMatching(
 	// the tunnel may return 404 or route to either backend depending on internal
 	// ingress rule ordering.  We only verify the sub-path does NOT reach echo-v2,
 	// which would indicate the prefix rule incorrectly won over the exact rule.
-	echo, resp, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/exact-only/sub", nil)
+	echo, resp, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/exact-only/sub", nil)
 	require.NoError(t, err)
 	assert.False(t, strings.HasPrefix(echo.Pod, "echo-v2-"),
 		"sub-path must NOT match prefix /exact → echo-v2 (status %d, pod: %s)", resp.StatusCode, echo.Pod)
@@ -520,11 +532,11 @@ func testHTTPRouteMatchingAcrossRoutes(
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/across/route-a", "echo-v1-", 60*time.Second)
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/across/route-b", "echo-v2-", 30*time.Second)
 
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/across/route-a", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/across/route-a", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"))
 
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/across/route-b", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/across/route-b", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"))
 }
@@ -560,18 +572,18 @@ func testHTTPRouteHeaderMatching(
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/hdr-test", "echo-v1-", 60*time.Second)
 
 	// Without header → echo-v1.
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/hdr-test", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/hdr-test", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "no header → echo-v1, got: %s", echo.Pod)
 
 	// With matching header → echo-v2.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/hdr-test",
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/hdr-test",
 		map[string]string{"X-Test-Backend": "v2"})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"), "matching header → echo-v2, got: %s", echo.Pod)
 
 	// Non-matching header → echo-v1.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/hdr-test",
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/hdr-test",
 		map[string]string{"X-Test-Backend": "v1"})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "wrong header → echo-v1, got: %s", echo.Pod)
@@ -603,11 +615,11 @@ func testHTTPRouteMethodMatching(
 	createHTTPRoute(t, k8sClient, route)
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/meth-test", "echo-v1-", 60*time.Second)
 
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/meth-test", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/meth-test", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "GET → echo-v1, got: %s", echo.Pod)
 
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodPost, "/meth-test", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodPost, "/meth-test", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"), "POST → echo-v2, got: %s", echo.Pod)
 }
@@ -640,15 +652,15 @@ func testHTTPRouteQueryParamMatching(
 	createHTTPRoute(t, k8sClient, route)
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/qp-test", "echo-v1-", 60*time.Second)
 
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/qp-test", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/qp-test", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "no qp → echo-v1, got: %s", echo.Pod)
 
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/qp-test?version=v2", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/qp-test?version=v2", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"), "matching qp → echo-v2, got: %s", echo.Pod)
 
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/qp-test?version=v1", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/qp-test?version=v1", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "wrong qp → echo-v1, got: %s", echo.Pod)
 }
@@ -690,7 +702,7 @@ func testHTTPRouteWeight(
 	v1, v2 := 0, 0
 
 	for range total {
-		echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/wt-test", nil)
+		echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/wt-test", nil)
 		require.NoError(t, err)
 
 		switch {
@@ -737,7 +749,7 @@ func testHTTPRouteRequestHeaderModifier(
 	createHTTPRoute(t, k8sClient, route)
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/req-hdr-mod", "echo-v1-", 60*time.Second)
 
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/req-hdr-mod",
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/req-hdr-mod",
 		map[string]string{"X-Remove-Me": "should-be-removed"})
 	require.NoError(t, err)
 
@@ -784,7 +796,7 @@ func testHTTPRouteResponseHeaderModifier(
 	createHTTPRoute(t, k8sClient, route)
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/resp-hdr-mod", "echo-v1-", 60*time.Second)
 
-	_, resp, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/resp-hdr-mod", nil)
+	_, resp, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/resp-hdr-mod", nil)
 	require.NoError(t, err)
 
 	// Response headers may be modified by Cloudflare CDN.
@@ -820,10 +832,10 @@ func testHTTPRouteRequestRedirect(
 
 	// Wait for 301 response (redirect has no echo body).
 	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second, true,
-		func(_ context.Context) (bool, error) {
-			_, resp, reqErr := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-test", nil)
+		func(pollCtx context.Context) (bool, error) {
+			_, resp, reqErr := makeRequest(pollCtx, t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-test", nil)
 			if reqErr != nil {
-				return false, nil
+				return false, nil //nolint:nilerr // transient edge/tunnel errors are expected while polling; retry until timeout
 			}
 
 			return resp.StatusCode == http.StatusMovedPermanently, nil
@@ -831,7 +843,7 @@ func testHTTPRouteRequestRedirect(
 	)
 	require.NoError(t, err, "redirect route did not return 301")
 
-	_, resp, reqErr := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-test", nil)
+	_, resp, reqErr := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-test", nil)
 	require.NoError(t, reqErr)
 	assert.Equal(t, http.StatusMovedPermanently, resp.StatusCode)
 
@@ -858,13 +870,11 @@ func pathRegex(pattern string) *gatewayv1.HTTPPathMatch {
 }
 
 func backendRef(name string, port int32, weight *int32) gatewayv1.HTTPBackendRef {
-	p := gatewayv1.PortNumber(port)
-
 	return gatewayv1.HTTPBackendRef{
 		BackendRef: gatewayv1.BackendRef{
 			BackendObjectReference: gatewayv1.BackendObjectReference{
 				Name: gatewayv1.ObjectName(name),
-				Port: &p,
+				Port: &port,
 			},
 			Weight: weight,
 		},
@@ -961,17 +971,17 @@ func testHTTPRouteRegexPathMatching(
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/rgx/other", "echo-v2-", 60*time.Second)
 
 	// Regex match → echo-v1.
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx/item-42", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx/item-42", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "regex match → echo-v1, got: %s", echo.Pod)
 
 	// Non-numeric suffix → falls to prefix → echo-v2.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx/item-abc", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx/item-abc", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"), "no regex match → echo-v2, got: %s", echo.Pod)
 
 	// Other path under /rgx → prefix fallback → echo-v2.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx/other", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx/other", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"), "prefix fallback → echo-v2, got: %s", echo.Pod)
 }
@@ -1005,19 +1015,19 @@ func testHTTPRouteRegexHeaderMatching(
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/rgx-hdr", "echo-v1-", 60*time.Second)
 
 	// Header matching regex → echo-v2.
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-hdr",
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-hdr",
 		map[string]string{"X-Api-Version": "v2"})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"), "regex header match → echo-v2, got: %s", echo.Pod)
 
 	// Header not matching regex → echo-v1.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-hdr",
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-hdr",
 		map[string]string{"X-Api-Version": "latest"})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "non-matching header → echo-v1, got: %s", echo.Pod)
 
 	// No header → echo-v1.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-hdr", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-hdr", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "no header → echo-v1, got: %s", echo.Pod)
 }
@@ -1051,17 +1061,17 @@ func testHTTPRouteRegexQueryParamMatching(
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/rgx-qp", "echo-v1-", 60*time.Second)
 
 	// Numeric query param → echo-v2.
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-qp?id=123", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-qp?id=123", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"), "regex qp match → echo-v2, got: %s", echo.Pod)
 
 	// Non-numeric query param → echo-v1.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-qp?id=abc", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-qp?id=abc", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "non-matching qp → echo-v1, got: %s", echo.Pod)
 
 	// No query param → echo-v1.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-qp", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rgx-qp", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "no qp → echo-v1, got: %s", echo.Pod)
 }
@@ -1086,12 +1096,12 @@ func testHTTPRoutePathMatchOrder(
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/pmo/other", "echo-v2-", 60*time.Second)
 
 	// Exact match wins → echo-v1.
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/pmo/specific", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/pmo/specific", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "exact wins → echo-v1, got: %s", echo.Pod)
 
 	// Prefix fallback → echo-v2.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/pmo/other", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/pmo/other", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"), "prefix fallback → echo-v2, got: %s", echo.Pod)
 }
@@ -1122,7 +1132,7 @@ func testHTTPRouteURLRewritePath(
 	createHTTPRoute(t, k8sClient, route)
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/rewrite-test", "echo-v1-", 60*time.Second)
 
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rewrite-test/anything", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rewrite-test/anything", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "/replaced", echo.Path, "path should be rewritten to /replaced")
 }
@@ -1152,7 +1162,7 @@ func testHTTPRouteURLRewriteHost(
 	createHTTPRoute(t, k8sClient, route)
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/rewrite-host", "echo-v1-", 60*time.Second)
 
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rewrite-host", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/rewrite-host", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "rewritten.internal", echo.Host, "host should be rewritten to rewritten.internal")
 }
@@ -1189,7 +1199,7 @@ func testHTTPRouteRequestMirror(
 	waitForBackend(t, httpClient, cfg.TunnelHostname, mirrorPath, "echo-v1-", 60*time.Second)
 
 	// Response should come from echo-v1 (mirror is fire-and-forget).
-	echo, resp, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, mirrorPath, nil)
+	echo, resp, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, mirrorPath, nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "response from primary → echo-v1, got: %s", echo.Pod)
@@ -1200,11 +1210,12 @@ func testHTTPRouteRequestMirror(
 	// request so a single transient mirror drop does not fail the test. Without
 	// this assertion the test passes even when mirror delivery is fully broken.
 	require.Eventually(t, func() bool {
-		if _, _, reqErr := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, mirrorPath, nil); reqErr != nil {
+		_, _, reqErr := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, mirrorPath, nil)
+		if reqErr != nil {
 			return false
 		}
 
-		logs := backendPodLogs(t, context.Background(), clientset, cfg.TestNamespace, "echo-v3")
+		logs := backendPodLogs(context.Background(), t, clientset, cfg.TestNamespace, "echo-v3")
 
 		return strings.Contains(logs, mirrorPath)
 	}, 30*time.Second, 2*time.Second, "mirror copy never reached echo-v3 (path %q absent from its logs)", mirrorPath)
@@ -1237,8 +1248,8 @@ func testHTTPRouteRedirectPort(
 
 	// Wait for redirect response.
 	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second, true,
-		func(_ context.Context) (bool, error) {
-			_, resp, reqErr := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-port", nil)
+		func(pollCtx context.Context) (bool, error) {
+			_, resp, reqErr := makeRequest(pollCtx, t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-port", nil)
 			if reqErr != nil {
 				return false, nil //nolint:nilerr // transient errors are expected during polling
 			}
@@ -1248,7 +1259,7 @@ func testHTTPRouteRedirectPort(
 	)
 	require.NoError(t, err, "redirect route did not return 302")
 
-	_, resp, reqErr := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-port", nil)
+	_, resp, reqErr := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-port", nil)
 	require.NoError(t, reqErr)
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
 
@@ -1285,8 +1296,8 @@ func testHTTPRouteRedirectPath(
 
 	// Wait for redirect response.
 	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second, true,
-		func(_ context.Context) (bool, error) {
-			_, resp, reqErr := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-path", nil)
+		func(pollCtx context.Context) (bool, error) {
+			_, resp, reqErr := makeRequest(pollCtx, t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-path", nil)
 			if reqErr != nil {
 				return false, nil //nolint:nilerr // transient errors are expected during polling
 			}
@@ -1296,7 +1307,7 @@ func testHTTPRouteRedirectPath(
 	)
 	require.NoError(t, err, "redirect route did not return 301")
 
-	_, resp, reqErr := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-path", nil)
+	_, resp, reqErr := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/redir-path", nil)
 	require.NoError(t, reqErr)
 	assert.Equal(t, http.StatusMovedPermanently, resp.StatusCode)
 
@@ -1355,8 +1366,8 @@ func testHTTPRouteRedirectSchemeProbe(
 		createHTTPRoute(t, k8sClient, route)
 
 		err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second, true,
-			func(_ context.Context) (bool, error) {
-				_, resp, reqErr := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, path, nil)
+			func(pollCtx context.Context) (bool, error) {
+				_, resp, reqErr := makeRequest(pollCtx, t, httpClient, cfg.TunnelHostname, http.MethodGet, path, nil)
 				if reqErr != nil {
 					return false, nil //nolint:nilerr // transient errors are expected during polling
 				}
@@ -1366,7 +1377,7 @@ func testHTTPRouteRedirectSchemeProbe(
 		)
 		require.NoErrorf(t, err, "redirect route did not return %d", statusCode)
 
-		_, resp, reqErr := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, path, nil)
+		_, resp, reqErr := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, path, nil)
 		require.NoError(t, reqErr)
 		assert.Equal(t, statusCode, resp.StatusCode)
 
@@ -1422,24 +1433,24 @@ func testHTTPRouteCombinedMatching(
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/combo", "echo-v1-", 60*time.Second)
 
 	// All 4 conditions met → echo-v2.
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/combo?format=json",
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/combo?format=json",
 		map[string]string{"X-Env": "prod"})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"), "all conditions → echo-v2, got: %s", echo.Pod)
 
 	// Missing header → echo-v1.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/combo?format=json", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/combo?format=json", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "missing header → echo-v1, got: %s", echo.Pod)
 
 	// Missing query param → echo-v1.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/combo",
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/combo",
 		map[string]string{"X-Env": "prod"})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "missing qp → echo-v1, got: %s", echo.Pod)
 
 	// Wrong method (POST) → echo-v1.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodPost, "/combo?format=json",
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodPost, "/combo?format=json",
 		map[string]string{"X-Env": "prod"})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "wrong method → echo-v1, got: %s", echo.Pod)
@@ -1464,17 +1475,17 @@ func testHTTPRouteMultipleMatchesOR(
 	waitForBackend(t, httpClient, cfg.TunnelHostname, "/or-a", "echo-v1-", 60*time.Second)
 
 	// /or-a → echo-v1.
-	echo, _, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/or-a", nil)
+	echo, _, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/or-a", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "/or-a → echo-v1, got: %s", echo.Pod)
 
 	// /or-b → echo-v1.
-	echo, _, err = makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/or-b", nil)
+	echo, _, err = makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/or-b", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v1-"), "/or-b → echo-v1, got: %s", echo.Pod)
 
 	// /or-c → 404 (no match).
-	_, resp, err := makeRequest(t, httpClient, cfg.TunnelHostname, http.MethodGet, "/or-c", nil)
+	_, resp, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/or-c", nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "/or-c should be 404")
 }

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -76,7 +76,7 @@ func newClientset(t *testing.T, kubeContext string) *kubernetes.Clientset {
 // app=<appLabel> in the given namespace. The echo-basic server logs each
 // request it receives, so this is used to verify a mirror copy actually
 // reached the mirror backend, mirroring the conformance suite's DumpEchoLogs.
-func backendPodLogs(t *testing.T, ctx context.Context, clientset *kubernetes.Clientset, namespace, appLabel string) string {
+func backendPodLogs(ctx context.Context, t *testing.T, clientset *kubernetes.Clientset, namespace, appLabel string) string {
 	t.Helper()
 
 	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
@@ -130,23 +130,24 @@ func setupEchoBackends(t *testing.T, k8sClient client.Client, cfg testConfig) {
 	}
 
 	for _, backend := range backends {
-		deployEchoBackend(t, ctx, k8sClient, cfg.TestNamespace, backend.name)
+		deployEchoBackend(ctx, t, k8sClient, cfg.TestNamespace, backend.name)
 	}
 
 	// Wait for backends to be ready.
 	for _, backend := range backends {
-		waitForDeployment(t, ctx, k8sClient, cfg.TestNamespace, backend.name, 120*time.Second)
+		waitForDeployment(ctx, t, k8sClient, cfg.TestNamespace, backend.name, 120*time.Second)
 	}
 }
 
-func deployEchoBackend(t *testing.T, ctx context.Context, k8sClient client.Client, namespace, name string) {
+func deployEchoBackend(ctx context.Context, t *testing.T, k8sClient client.Client, namespace, name string) {
 	t.Helper()
 
 	replicas := int32(1)
 
 	// Check if deployment already exists.
 	existing := &appsv1.Deployment{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, existing); err == nil {
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, existing)
+	if err == nil {
 		t.Logf("deployment %s/%s already exists, skipping", namespace, name)
 		return
 	}
@@ -226,14 +227,15 @@ func deployEchoBackend(t *testing.T, ctx context.Context, k8sClient client.Clien
 	t.Logf("created service %s/%s", namespace, name)
 }
 
-func waitForDeployment(t *testing.T, ctx context.Context, k8sClient client.Client, namespace, name string, timeout time.Duration) {
+func waitForDeployment(ctx context.Context, t *testing.T, k8sClient client.Client, namespace, name string, timeout time.Duration) {
 	t.Helper()
 
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true,
 		func(pollCtx context.Context) (bool, error) {
 			deploy := &appsv1.Deployment{}
-			if getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: name, Namespace: namespace}, deploy); getErr != nil {
-				return false, nil
+			getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: name, Namespace: namespace}, deploy)
+			if getErr != nil {
+				return false, nil //nolint:nilerr // transient API errors are expected while polling; retry until timeout
 			}
 
 			return deploy.Status.ReadyReplicas >= 1, nil
@@ -251,7 +253,8 @@ func setupGateway(t *testing.T, k8sClient client.Client, cfg testConfig) {
 
 	// Check if Gateway already exists.
 	existing := &gatewayv1.Gateway{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: cfg.GatewayName, Namespace: cfg.Namespace}, existing); err == nil {
+	getErr := k8sClient.Get(ctx, types.NamespacedName{Name: cfg.GatewayName, Namespace: cfg.Namespace}, existing)
+	if getErr == nil {
 		t.Logf("gateway %s/%s already exists, skipping", cfg.Namespace, cfg.GatewayName)
 		return
 	}
@@ -285,8 +288,9 @@ func setupGateway(t *testing.T, k8sClient client.Client, cfg testConfig) {
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 60*time.Second, true,
 		func(pollCtx context.Context) (bool, error) {
 			gw := &gatewayv1.Gateway{}
-			if getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: cfg.GatewayName, Namespace: cfg.Namespace}, gw); getErr != nil {
-				return false, nil
+			getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: cfg.GatewayName, Namespace: cfg.Namespace}, gw)
+			if getErr != nil {
+				return false, nil //nolint:nilerr // transient API errors are expected while polling; retry until timeout
 			}
 
 			for _, condition := range gw.Status.Conditions {


### PR DESCRIPTION
## Summary

Hardens CI against transient ttl.sh registry failures, closes the lint blind spot for build-tag-gated test packages, and adds a weekly scheduled e2e run against the live test tunnel so Cloudflare-side regressions are detected without waiting for a user report.

Closes #402, closes #423, closes #441.

## Changes

- Image, manifest, and chart pushes to ttl.sh now retry on transient failures (duplicate continue-on-error step for the buildx push; bounded retry loops for `imagetools create` and `helm push`), so a dropped blob write no longer requires a manual rerun.
- The CI lint job passes `--build-tags e2e,conformance,envtest`, and the accumulated lint debt in the tag-gated test packages is fixed (the `makeRequest` e2e helper now takes a context and returns response metadata instead of a raw `*http.Response`).
- A new drift test pins every documented lint invocation to the CI lint arguments, so docs and CI cannot diverge again; all documented commands are updated.
- New `Scheduled E2E` workflow: weekly kind cluster + controller deploy + custom e2e suite against the live test tunnel, with one full retry to absorb transients and an auto-filed (deduplicated) issue on persistent failure. `hack/conformance-setup.sh` learns `--test-e2e`, runs without colima on GitHub Actions, and accepts credentials from the environment.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

The scheduled workflow can only be dispatch-tested once it lands on the default branch; a manual `workflow_dispatch` run right after merge is part of this change's delivery. The `CF_*` repository secrets it needs are already configured (dedicated test tunnel, no production credentials).
