### PR TITLE
refactor(routes): unify HTTPRoute/GRPCRoute logic behind shared generics

### DIFF
--- a/internal/ingress/generic_builder.go
+++ b/internal/ingress/generic_builder.go
@@ -16,9 +16,18 @@ import (
 
 // RouteAdapter defines the interface for adapting different route types
 // (HTTPRoute, GRPCRoute) to a common format for ingress rule generation.
+// Adapters are pure projections: they translate their typed rules into the
+// kind-neutral projectedRule shape, and every downstream step (filter
+// logging, backend resolution, entry assembly) runs through one shared
+// implementation so the route kinds cannot drift.
 type RouteAdapter[R any] interface {
-	// RouteKind returns the kind of route (e.g., "HTTPRoute", "GRPCRoute").
+	// RouteKind returns the short route kind used for metrics labeling
+	// (e.g., "http", "grpc").
 	RouteKind() string
+
+	// GatewayKind returns the Gateway API kind name used in ReferenceGrant
+	// checks and failed-ref reporting (e.g., "HTTPRoute", "GRPCRoute").
+	GatewayKind() string
 
 	// GetMeta returns route metadata (namespace, name).
 	GetMeta(route *R) (string, string)
@@ -27,13 +36,10 @@ type RouteAdapter[R any] interface {
 	// Returns ["*"] if no hostnames are specified.
 	GetHostnames(route *R) []gatewayv1.Hostname
 
-	// ExtractEntries extracts route entries from a single route.
-	// This includes processing all rules, matches, and backend refs.
-	ExtractEntries(
-		ctx context.Context,
-		route *R,
-		resolver *backendResolver,
-	) ([]routeEntry, []BackendRefError)
+	// ProjectRules translates the route's typed rules into the kind-neutral
+	// projection, logging any per-kind features the tunnel ingress cannot
+	// express along the way.
+	ProjectRules(route *R, resolver *backendResolver) []projectedRule
 
 	// AddCatchAll returns true if a catch-all rule should be added.
 	AddCatchAll() bool
@@ -104,7 +110,7 @@ func (b *GenericBuilder[R]) Build(ctx context.Context, routes []R) BuildResult {
 	var failedRefs []BackendRefError
 
 	for i := range routes {
-		routeEntries, routeFailedRefs := b.adapter.ExtractEntries(ctx, &routes[i], resolver)
+		routeEntries, routeFailedRefs := extractProjectedEntries(ctx, b.adapter, &routes[i], resolver)
 		entries = append(entries, routeEntries...)
 		failedRefs = append(failedRefs, routeFailedRefs...)
 	}

--- a/internal/ingress/generic_builder_test.go
+++ b/internal/ingress/generic_builder_test.go
@@ -1,7 +1,9 @@
 package ingress_test
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -262,4 +264,76 @@ func TestGenericBuilder_BackendResolutionEquivalentAcrossKinds(t *testing.T) {
 		"equivalent backendRefs must resolve identically through the shared path for both route kinds")
 	assert.Contains(t, httpResult.Rules[0].Service.Value, "svc-high.other.svc.cluster.local",
 		"the shared selection must pick the highest-weight backend")
+}
+
+// TestGenericBuilder_FailedRefsNotDuplicatedPerHostname pins that a route
+// listing N hostnames reports each invalid backendRef exactly once -- the
+// failed-ref set describes the route's backends, which do not vary by
+// hostname. Historically the resolution ran inside the hostname loop and a
+// 2-hostname route doubled every BackendRefError (inflating the failed-ref
+// metric and duplicating the ResolvedRefs message).
+func TestGenericBuilder_FailedRefsNotDuplicatedPerHostname(t *testing.T) {
+	t.Parallel()
+
+	badKind := gatewayv1.Kind("ConfigMap")
+	port := gatewayv1.PortNumber(8080)
+
+	builder := ingress.NewGenericBuilder[gatewayv1.HTTPRoute](
+		"cluster.local", nil, nil, nil, nil, ingress.HTTPRouteAdapter{},
+	)
+
+	routes := []gatewayv1.HTTPRoute{{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Hostnames: []gatewayv1.Hostname{"a.example.com", "b.example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: "bad", Kind: &badKind, Port: &port},
+					}},
+				},
+			}},
+		},
+	}}
+
+	result := builder.Build(context.Background(), routes)
+
+	assert.Len(t, result.FailedRefs, 1,
+		"one invalid backendRef on a two-hostname route must be reported exactly once")
+}
+
+// TestGenericBuilder_UnsupportedFeatureWarningsNotGatedOnBackends pins the
+// deliberate logging behaviour of the projection split: unsupported-feature
+// warnings describe the rule's matches, which are ignored by the tunnel
+// ingress regardless of backend resolvability, so they are emitted even for
+// a rule with no resolvable backend (historically they were silently skipped
+// exactly when an operator was debugging such a rule).
+func TestGenericBuilder_UnsupportedFeatureWarningsNotGatedOnBackends(t *testing.T) {
+	t.Parallel()
+
+	var logBuf bytes.Buffer
+
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	builder := ingress.NewGenericBuilder[gatewayv1.HTTPRoute](
+		"cluster.local", nil, nil, nil, logger, ingress.HTTPRouteAdapter{},
+	)
+
+	method := gatewayv1.HTTPMethodPost
+	routes := []gatewayv1.HTTPRoute{{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Hostnames: []gatewayv1.Hostname{"app.example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				// A method match the tunnel ingress cannot express, and NO
+				// backendRefs -- the rule can never resolve a backend.
+				Matches: []gatewayv1.HTTPRouteMatch{{Method: &method}},
+			}},
+		},
+	}}
+
+	builder.Build(context.Background(), routes)
+
+	assert.Contains(t, logBuf.String(), "method matching not supported by Cloudflare Tunnel",
+		"the unsupported-feature warning must be emitted even when the rule has no resolvable backend")
 }

--- a/internal/ingress/generic_builder_test.go
+++ b/internal/ingress/generic_builder_test.go
@@ -195,3 +195,71 @@ func TestGenericBuilder_EmptyRoutes(t *testing.T) {
 	require.Len(t, result.Rules, 1)
 	assert.Equal(t, ingress.CatchAllService, result.Rules[0].Service.Value)
 }
+
+// TestGenericBuilder_BackendResolutionEquivalentAcrossKinds pins #400's
+// single-source guarantee: HTTPRoute and GRPCRoute backendRefs flow through
+// ONE shared resolution path (projection to plain BackendRef + shared
+// selection/validation), so equivalent inputs must yield equivalent ingress
+// rules and identical failed-ref reporting modulo the route kind name.
+func TestGenericBuilder_BackendResolutionEquivalentAcrossKinds(t *testing.T) {
+	t.Parallel()
+
+	lowWeight := int32(10)
+	highWeight := int32(90)
+	port := gatewayv1.PortNumber(8080)
+	crossNS := gatewayv1.Namespace("other")
+
+	httpBuilder := ingress.NewGenericBuilder[gatewayv1.HTTPRoute](
+		"cluster.local", nil, nil, nil, nil, ingress.HTTPRouteAdapter{},
+	)
+	grpcBuilder := ingress.NewGenericBuilder[gatewayv1.GRPCRoute](
+		"cluster.local", nil, nil, nil, nil, ingress.GRPCRouteAdapter{},
+	)
+
+	// Two weighted backends (highest wins) plus a cross-namespace ref that is
+	// permitted (nil validator) — the same shape for both kinds.
+	httpRefs := []gatewayv1.HTTPBackendRef{
+		{BackendRef: gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-low", Port: &port},
+			Weight:                 &lowWeight,
+		}},
+		{BackendRef: gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-high", Port: &port, Namespace: &crossNS},
+			Weight:                 &highWeight,
+		}},
+	}
+	grpcRefs := []gatewayv1.GRPCBackendRef{
+		{BackendRef: httpRefs[0].BackendRef},
+		{BackendRef: httpRefs[1].BackendRef},
+	}
+
+	httpRoutes := []gatewayv1.HTTPRoute{{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Hostnames: []gatewayv1.Hostname{"app.example.com"},
+			Rules:     []gatewayv1.HTTPRouteRule{{BackendRefs: httpRefs}},
+		},
+	}}
+	grpcRoutes := []gatewayv1.GRPCRoute{{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec: gatewayv1.GRPCRouteSpec{
+			Hostnames: []gatewayv1.Hostname{"app.example.com"},
+			Rules:     []gatewayv1.GRPCRouteRule{{BackendRefs: grpcRefs}},
+		},
+	}}
+
+	httpResult := httpBuilder.Build(context.Background(), httpRoutes)
+	grpcResult := grpcBuilder.Build(context.Background(), grpcRoutes)
+
+	require.Empty(t, httpResult.FailedRefs)
+	require.Empty(t, grpcResult.FailedRefs)
+
+	// HTTP appends a catch-all rule; the route-derived rules before it must be
+	// identical to the gRPC ones (same highest-weight backend URL, same host).
+	require.NotEmpty(t, httpResult.Rules)
+	require.NotEmpty(t, grpcResult.Rules)
+	assert.Equal(t, grpcResult.Rules, httpResult.Rules[:len(httpResult.Rules)-1],
+		"equivalent backendRefs must resolve identically through the shared path for both route kinds")
+	assert.Contains(t, httpResult.Rules[0].Service.Value, "svc-high.other.svc.cluster.local",
+		"the shared selection must pick the highest-weight backend")
+}

--- a/internal/ingress/grpc_adapter.go
+++ b/internal/ingress/grpc_adapter.go
@@ -1,7 +1,6 @@
 package ingress
 
 import (
-	"context"
 	"fmt"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -13,6 +12,12 @@ type GRPCRouteAdapter struct{}
 // RouteKind returns "grpc" for metrics labeling.
 func (GRPCRouteAdapter) RouteKind() string {
 	return "grpc"
+}
+
+// GatewayKind returns the Gateway API kind for ReferenceGrant checks and
+// failed-ref reporting.
+func (GRPCRouteAdapter) GatewayKind() string {
+	return "GRPCRoute"
 }
 
 // GetMeta returns the namespace and name of the route.
@@ -35,67 +40,42 @@ func (GRPCRouteAdapter) AddCatchAll() bool {
 	return false
 }
 
-// ExtractEntries extracts route entries from a GRPCRoute.
+// ProjectRules translates GRPCRoute rules into the kind-neutral projection,
+// logging the gRPC-specific match features the tunnel ingress cannot express
+// (header matches) and mapping method matches onto HTTP paths.
 //
-//nolint:revive // routeEntry is intentionally unexported as internal implementation detail
-func (a GRPCRouteAdapter) ExtractEntries(
-	ctx context.Context,
-	route *gatewayv1.GRPCRoute,
-	resolver *backendResolver,
-) ([]routeEntry, []BackendRefError) {
-	var entries []routeEntry
+//nolint:revive // projectedRule is intentionally unexported as internal implementation detail
+func (a GRPCRouteAdapter) ProjectRules(route *gatewayv1.GRPCRoute, resolver *backendResolver) []projectedRule {
+	rules := make([]projectedRule, 0, len(route.Spec.Rules))
 
-	var failedRefs []BackendRefError
-
-	hostnames := a.GetHostnames(route)
-
-	for _, hostname := range hostnames {
-		for _, rule := range route.Spec.Rules {
-			a.logFilters(resolver, route.Namespace, route.Name, rule.Filters)
-
-			service, ruleFailedRefs := a.resolveBackendRef(ctx, resolver, route.Namespace, route.Name, rule.BackendRefs)
-			failedRefs = append(failedRefs, ruleFailedRefs...)
-
-			if service == "" {
-				continue
-			}
-
-			if len(rule.Matches) == 0 {
-				entries = append(entries, routeEntry{
-					hostname: string(hostname),
-					path:     "",
-					service:  service,
-					priority: 0,
-				})
-
-				continue
-			}
-
-			for _, match := range rule.Matches {
-				a.logUnsupportedHeaders(resolver, route.Namespace, route.Name, match.Headers)
-
-				path, priority := a.extractGRPCPath(match.Method)
-				entries = append(entries, routeEntry{
-					hostname: string(hostname),
-					path:     path,
-					service:  service,
-					priority: priority,
-				})
-			}
+	for _, rule := range route.Spec.Rules {
+		projected := projectedRule{
+			ignoredFilters: len(rule.Filters),
+			backendRefs:    grpcBackendRefs(rule.BackendRefs),
 		}
+
+		for _, match := range rule.Matches {
+			a.logUnsupportedHeaders(resolver, route.Namespace, route.Name, match.Headers)
+
+			path, priority := a.extractGRPCPath(match.Method)
+			projected.matches = append(projected.matches, projectedMatch{path: path, priority: priority})
+		}
+
+		rules = append(rules, projected)
 	}
 
-	return entries, failedRefs
+	return rules
 }
 
-func (GRPCRouteAdapter) logFilters(resolver *backendResolver, namespace, name string, filters []gatewayv1.GRPCRouteFilter) {
-	if len(filters) > 0 {
-		resolver.logger.Info("route configuration partially applied",
-			"route", fmt.Sprintf("%s/%s", namespace, name),
-			"reason", "filters not supported by Cloudflare Tunnel",
-			"ignored_filters", len(filters),
-		)
+// grpcBackendRefs projects GRPCBackendRefs to the embedded plain BackendRefs
+// (the per-backend filters are not expressible in tunnel ingress rules).
+func grpcBackendRefs(refs []gatewayv1.GRPCBackendRef) []gatewayv1.BackendRef {
+	out := make([]gatewayv1.BackendRef, len(refs))
+	for i := range refs {
+		out[i] = refs[i].BackendRef
 	}
+
+	return out
 }
 
 func (GRPCRouteAdapter) logUnsupportedHeaders(resolver *backendResolver, namespace, name string, headers []gatewayv1.GRPCHeaderMatch) {
@@ -142,87 +122,4 @@ func (GRPCRouteAdapter) extractGRPCPath(methodMatch *gatewayv1.GRPCMethodMatch) 
 
 	// Both service and method - exact match
 	return "/" + service + "/" + method, 1
-}
-
-// resolveBackendRef validates every traffic-receiving backend in the rule and
-// returns the highest-weight backend's URL plus a BackendRefError for each
-// invalid backend. Every backend with weight > 0 is validated (not just the
-// highest-weight one) so an invalid lower-weight backend is reported and the
-// proxy can return 500 for its traffic fraction per the Gateway API spec.
-// Weight-0 backends receive no traffic and are skipped.
-//
-//nolint:dupl // mirrored on purpose against HTTPRouteAdapter.resolveBackendRef — the concrete HTTPBackendRef/GRPCBackendRef element types prevent a clean generic.
-func (a GRPCRouteAdapter) resolveBackendRef(
-	ctx context.Context,
-	resolver *backendResolver,
-	namespace, routeName string,
-	refs []gatewayv1.GRPCBackendRef,
-) (string, []BackendRefError) {
-	if len(refs) == 0 {
-		return "", nil
-	}
-
-	a.logMultipleBackends(resolver, namespace, routeName, len(refs))
-	a.logBackendWeights(resolver, namespace, routeName, refs)
-
-	selectedIdx := SelectHighestWeightIndex(wrapGRPCBackendRefs(refs))
-	if selectedIdx == -1 {
-		return "", nil
-	}
-
-	var failedRefs []BackendRefError
-
-	serviceURL := ""
-
-	for i := range refs {
-		if grpcBackendWeight(&refs[i]) == 0 {
-			continue
-		}
-
-		url, failedRef := resolveValidatedBackend(ctx, resolver, refs[i].BackendRef, namespace, routeName, "GRPCRoute")
-		if failedRef != nil {
-			failedRefs = append(failedRefs, *failedRef)
-		}
-
-		if i == selectedIdx {
-			serviceURL = url
-		}
-	}
-
-	return serviceURL, failedRefs
-}
-
-// grpcBackendWeight returns the effective weight of a backend (default 1 when
-// unset), matching SelectHighestWeightIndex's weight semantics.
-func grpcBackendWeight(ref *gatewayv1.GRPCBackendRef) int32 {
-	if ref.Weight != nil {
-		return *ref.Weight
-	}
-
-	return DefaultBackendWeight
-}
-
-func (GRPCRouteAdapter) logMultipleBackends(resolver *backendResolver, namespace, routeName string, totalBackends int) {
-	if totalBackends > 1 {
-		resolver.logger.Info("route configuration partially applied",
-			"route", fmt.Sprintf("%s/%s", namespace, routeName),
-			"reason", "multiple backendRefs specified, using only highest weight",
-			"total_backends", totalBackends,
-			"ignored_backends", totalBackends-1,
-		)
-	}
-}
-
-func (GRPCRouteAdapter) logBackendWeights(resolver *backendResolver, namespace, routeName string, refs []gatewayv1.GRPCBackendRef) {
-	for i, backendRef := range refs {
-		if backendRef.Weight != nil && *backendRef.Weight != 1 {
-			resolver.logger.Info("route configuration partially applied",
-				"route", fmt.Sprintf("%s/%s", namespace, routeName),
-				"reason", "backendRef weight ignored, traffic splitting not supported",
-				"backend", string(backendRef.Name),
-				"backend_index", i,
-				"weight", *backendRef.Weight,
-			)
-		}
-	}
 }

--- a/internal/ingress/http_adapter.go
+++ b/internal/ingress/http_adapter.go
@@ -1,7 +1,6 @@
 package ingress
 
 import (
-	"context"
 	"fmt"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -13,6 +12,12 @@ type HTTPRouteAdapter struct{}
 // RouteKind returns "http" for metrics labeling.
 func (HTTPRouteAdapter) RouteKind() string {
 	return "http"
+}
+
+// GatewayKind returns the Gateway API kind for ReferenceGrant checks and
+// failed-ref reporting.
+func (HTTPRouteAdapter) GatewayKind() string {
+	return "HTTPRoute"
 }
 
 // GetMeta returns the namespace and name of the route.
@@ -34,67 +39,42 @@ func (HTTPRouteAdapter) AddCatchAll() bool {
 	return true
 }
 
-// ExtractEntries extracts route entries from an HTTPRoute.
+// ProjectRules translates HTTPRoute rules into the kind-neutral projection,
+// logging the HTTP-specific match features the tunnel ingress cannot express
+// (headers, query params, methods, regex paths).
 //
-//nolint:revive // routeEntry is intentionally unexported as internal implementation detail
-func (a HTTPRouteAdapter) ExtractEntries(
-	ctx context.Context,
-	route *gatewayv1.HTTPRoute,
-	resolver *backendResolver,
-) ([]routeEntry, []BackendRefError) {
-	var entries []routeEntry
+//nolint:revive // projectedRule is intentionally unexported as internal implementation detail
+func (a HTTPRouteAdapter) ProjectRules(route *gatewayv1.HTTPRoute, resolver *backendResolver) []projectedRule {
+	rules := make([]projectedRule, 0, len(route.Spec.Rules))
 
-	var failedRefs []BackendRefError
-
-	hostnames := a.GetHostnames(route)
-
-	for _, hostname := range hostnames {
-		for _, rule := range route.Spec.Rules {
-			a.logFilters(resolver, route.Namespace, route.Name, rule.Filters)
-
-			service, ruleFailedRefs := a.resolveBackendRef(ctx, resolver, route.Namespace, route.Name, rule.BackendRefs)
-			failedRefs = append(failedRefs, ruleFailedRefs...)
-
-			if service == "" {
-				continue
-			}
-
-			if len(rule.Matches) == 0 {
-				entries = append(entries, routeEntry{
-					hostname: string(hostname),
-					path:     "",
-					service:  service,
-					priority: 0,
-				})
-
-				continue
-			}
-
-			for _, match := range rule.Matches {
-				a.logUnsupportedFeatures(resolver, route.Namespace, route.Name, match)
-
-				path, priority := a.extractPath(resolver, route.Namespace, route.Name, match.Path)
-				entries = append(entries, routeEntry{
-					hostname: string(hostname),
-					path:     path,
-					service:  service,
-					priority: priority,
-				})
-			}
+	for _, rule := range route.Spec.Rules {
+		projected := projectedRule{
+			ignoredFilters: len(rule.Filters),
+			backendRefs:    httpBackendRefs(rule.BackendRefs),
 		}
+
+		for _, match := range rule.Matches {
+			a.logUnsupportedFeatures(resolver, route.Namespace, route.Name, match)
+
+			path, priority := a.extractPath(resolver, route.Namespace, route.Name, match.Path)
+			projected.matches = append(projected.matches, projectedMatch{path: path, priority: priority})
+		}
+
+		rules = append(rules, projected)
 	}
 
-	return entries, failedRefs
+	return rules
 }
 
-func (HTTPRouteAdapter) logFilters(resolver *backendResolver, namespace, name string, filters []gatewayv1.HTTPRouteFilter) {
-	if len(filters) > 0 {
-		resolver.logger.Info("route configuration partially applied",
-			"route", fmt.Sprintf("%s/%s", namespace, name),
-			"reason", "filters not supported by Cloudflare Tunnel",
-			"ignored_filters", len(filters),
-		)
+// httpBackendRefs projects HTTPBackendRefs to the embedded plain BackendRefs
+// (the per-backend filters are not expressible in tunnel ingress rules).
+func httpBackendRefs(refs []gatewayv1.HTTPBackendRef) []gatewayv1.BackendRef {
+	out := make([]gatewayv1.BackendRef, len(refs))
+	for i := range refs {
+		out[i] = refs[i].BackendRef
 	}
+
+	return out
 }
 
 func (HTTPRouteAdapter) logUnsupportedFeatures(resolver *backendResolver, namespace, name string, match gatewayv1.HTTPRouteMatch) {
@@ -156,89 +136,4 @@ func (HTTPRouteAdapter) extractPath(resolver *backendResolver, namespace, routeN
 	}
 
 	return path, 0
-}
-
-// resolveBackendRef validates every traffic-receiving backend in the rule and
-// returns the highest-weight backend's URL (for the single-backend Cloudflare
-// tunnel ingress entry) plus a BackendRefError for each invalid backend.
-//
-// Every backend with weight > 0 is validated — not just the highest-weight one
-// — so an invalid lower-weight backend is reported and the proxy can return 500
-// for its traffic fraction per the Gateway API spec. Weight-0
-// backends receive no traffic and are skipped.
-//
-//nolint:dupl // mirrored on purpose against GRPCRouteAdapter.resolveBackendRef — the concrete HTTPBackendRef/GRPCBackendRef element types prevent a clean generic.
-func (a HTTPRouteAdapter) resolveBackendRef(
-	ctx context.Context,
-	resolver *backendResolver,
-	namespace, routeName string,
-	refs []gatewayv1.HTTPBackendRef,
-) (string, []BackendRefError) {
-	if len(refs) == 0 {
-		return "", nil
-	}
-
-	a.logMultipleBackends(resolver, namespace, routeName, len(refs))
-	a.logBackendWeights(resolver, namespace, routeName, refs)
-
-	selectedIdx := SelectHighestWeightIndex(wrapHTTPBackendRefs(refs))
-	if selectedIdx == -1 {
-		return "", nil
-	}
-
-	var failedRefs []BackendRefError
-
-	serviceURL := ""
-
-	for i := range refs {
-		if httpBackendWeight(&refs[i]) == 0 {
-			continue
-		}
-
-		url, failedRef := resolveValidatedBackend(ctx, resolver, refs[i].BackendRef, namespace, routeName, "HTTPRoute")
-		if failedRef != nil {
-			failedRefs = append(failedRefs, *failedRef)
-		}
-
-		if i == selectedIdx {
-			serviceURL = url
-		}
-	}
-
-	return serviceURL, failedRefs
-}
-
-// httpBackendWeight returns the effective weight of a backend (default 1 when
-// unset), matching SelectHighestWeightIndex's weight semantics.
-func httpBackendWeight(ref *gatewayv1.HTTPBackendRef) int32 {
-	if ref.Weight != nil {
-		return *ref.Weight
-	}
-
-	return DefaultBackendWeight
-}
-
-func (HTTPRouteAdapter) logMultipleBackends(resolver *backendResolver, namespace, routeName string, totalBackends int) {
-	if totalBackends > 1 {
-		resolver.logger.Info("route configuration partially applied",
-			"route", fmt.Sprintf("%s/%s", namespace, routeName),
-			"reason", "multiple backendRefs specified, using only highest weight",
-			"total_backends", totalBackends,
-			"ignored_backends", totalBackends-1,
-		)
-	}
-}
-
-func (HTTPRouteAdapter) logBackendWeights(resolver *backendResolver, namespace, routeName string, refs []gatewayv1.HTTPBackendRef) {
-	for i, backendRef := range refs {
-		if backendRef.Weight != nil && *backendRef.Weight != 1 {
-			resolver.logger.Info("route configuration partially applied",
-				"route", fmt.Sprintf("%s/%s", namespace, routeName),
-				"reason", "backendRef weight ignored, traffic splitting not supported",
-				"backend", string(backendRef.Name),
-				"backend_index", i,
-				"weight", *backendRef.Weight,
-			)
-		}
-	}
 }

--- a/internal/ingress/route_projection.go
+++ b/internal/ingress/route_projection.go
@@ -26,9 +26,18 @@ type projectedRule struct {
 }
 
 // extractProjectedEntries is the shared rule-walking skeleton behind every
-// adapter's entry extraction. The per-hostname loop deliberately re-projects
-// and re-resolves per hostname, matching the historical behaviour (logging
-// and failed-ref accounting repeat per hostname).
+// adapter's entry extraction. Rules are projected and their backends
+// resolved exactly once per route — neither depends on the hostname — and
+// the hostname list only multiplies the resulting entries. (Historically
+// resolution ran inside the hostname loop, duplicating every
+// BackendRefError, its log lines, and the failed-ref metric N× for an
+// N-hostname route.)
+//
+// Unsupported-feature warnings are emitted during projection for every rule,
+// including rules whose backends do not resolve — the features are ignored
+// regardless of backend resolvability, so gating the warnings on a resolved
+// backend (as the historical per-kind code did) hid them exactly when an
+// operator was debugging a broken rule.
 func extractProjectedEntries[R any](
 	ctx context.Context,
 	adapter RouteAdapter[R],
@@ -42,19 +51,19 @@ func extractProjectedEntries[R any](
 	namespace, name := adapter.GetMeta(route)
 	hostnames := adapter.GetHostnames(route)
 
-	for _, hostname := range hostnames {
-		for _, rule := range adapter.ProjectRules(route, resolver) {
-			logIgnoredFilters(resolver, namespace, name, rule.ignoredFilters)
+	for _, rule := range adapter.ProjectRules(route, resolver) {
+		logIgnoredFilters(resolver, namespace, name, rule.ignoredFilters)
 
-			service, ruleFailedRefs := resolveRuleBackendRefs(
-				ctx, resolver, namespace, name, adapter.GatewayKind(), rule.backendRefs,
-			)
-			failedRefs = append(failedRefs, ruleFailedRefs...)
+		service, ruleFailedRefs := resolveRuleBackendRefs(
+			ctx, resolver, namespace, name, adapter.GatewayKind(), rule.backendRefs,
+		)
+		failedRefs = append(failedRefs, ruleFailedRefs...)
 
-			if service == "" {
-				continue
-			}
+		if service == "" {
+			continue
+		}
 
+		for _, hostname := range hostnames {
 			if len(rule.matches) == 0 {
 				entries = append(entries, routeEntry{
 					hostname: string(hostname),

--- a/internal/ingress/route_projection.go
+++ b/internal/ingress/route_projection.go
@@ -1,0 +1,177 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// projectedMatch is the kind-neutral form of a single route match: the
+// tunnel-ingress path it contributes plus its sorting priority (1 = exact,
+// 0 = prefix).
+type projectedMatch struct {
+	path     string
+	priority int
+}
+
+// projectedRule is the kind-neutral form of a single route rule. Adapters
+// project their typed rules (HTTPRouteRule / GRPCRouteRule) into this shape;
+// everything downstream — filter logging, backend resolution, entry
+// assembly — is shared and cannot diverge between route kinds.
+type projectedRule struct {
+	ignoredFilters int
+	backendRefs    []gatewayv1.BackendRef
+	matches        []projectedMatch
+}
+
+// extractProjectedEntries is the shared rule-walking skeleton behind every
+// adapter's entry extraction. The per-hostname loop deliberately re-projects
+// and re-resolves per hostname, matching the historical behaviour (logging
+// and failed-ref accounting repeat per hostname).
+func extractProjectedEntries[R any](
+	ctx context.Context,
+	adapter RouteAdapter[R],
+	route *R,
+	resolver *backendResolver,
+) ([]routeEntry, []BackendRefError) {
+	var entries []routeEntry
+
+	var failedRefs []BackendRefError
+
+	namespace, name := adapter.GetMeta(route)
+	hostnames := adapter.GetHostnames(route)
+
+	for _, hostname := range hostnames {
+		for _, rule := range adapter.ProjectRules(route, resolver) {
+			logIgnoredFilters(resolver, namespace, name, rule.ignoredFilters)
+
+			service, ruleFailedRefs := resolveRuleBackendRefs(
+				ctx, resolver, namespace, name, adapter.GatewayKind(), rule.backendRefs,
+			)
+			failedRefs = append(failedRefs, ruleFailedRefs...)
+
+			if service == "" {
+				continue
+			}
+
+			if len(rule.matches) == 0 {
+				entries = append(entries, routeEntry{
+					hostname: string(hostname),
+					path:     "",
+					service:  service,
+					priority: 0,
+				})
+
+				continue
+			}
+
+			for _, match := range rule.matches {
+				entries = append(entries, routeEntry{
+					hostname: string(hostname),
+					path:     match.path,
+					service:  service,
+					priority: match.priority,
+				})
+			}
+		}
+	}
+
+	return entries, failedRefs
+}
+
+// resolveRuleBackendRefs validates every traffic-receiving backend in the
+// rule and returns the highest-weight backend's URL (for the single-backend
+// Cloudflare tunnel ingress entry) plus a BackendRefError for each invalid
+// backend.
+//
+// Every backend with weight > 0 is validated — not just the highest-weight
+// one — so an invalid lower-weight backend is reported and the proxy can
+// return 500 for its traffic fraction per the Gateway API spec. Weight-0
+// backends receive no traffic and are skipped.
+func resolveRuleBackendRefs(
+	ctx context.Context,
+	resolver *backendResolver,
+	namespace, routeName, routeKind string,
+	refs []gatewayv1.BackendRef,
+) (string, []BackendRefError) {
+	if len(refs) == 0 {
+		return "", nil
+	}
+
+	logMultipleBackends(resolver, namespace, routeName, len(refs))
+	logBackendWeights(resolver, namespace, routeName, refs)
+
+	selectedIdx := SelectHighestWeightIndex(refs)
+	if selectedIdx == -1 {
+		return "", nil
+	}
+
+	var failedRefs []BackendRefError
+
+	serviceURL := ""
+
+	for i := range refs {
+		if effectiveBackendWeight(&refs[i]) == 0 {
+			continue
+		}
+
+		url, failedRef := resolveValidatedBackend(ctx, resolver, refs[i], namespace, routeName, routeKind)
+		if failedRef != nil {
+			failedRefs = append(failedRefs, *failedRef)
+		}
+
+		if i == selectedIdx {
+			serviceURL = url
+		}
+	}
+
+	return serviceURL, failedRefs
+}
+
+// effectiveBackendWeight returns the effective weight of a backend (default 1
+// when unset), matching SelectHighestWeightIndex's weight semantics.
+func effectiveBackendWeight(ref *gatewayv1.BackendRef) int32 {
+	if ref.Weight != nil {
+		return *ref.Weight
+	}
+
+	return DefaultBackendWeight
+}
+
+// logIgnoredFilters reports rule-level filters, which the Cloudflare tunnel
+// ingress path cannot express (the in-process proxy serves them instead).
+func logIgnoredFilters(resolver *backendResolver, namespace, name string, count int) {
+	if count > 0 {
+		resolver.logger.Info("route configuration partially applied",
+			"route", fmt.Sprintf("%s/%s", namespace, name),
+			"reason", "filters not supported by Cloudflare Tunnel",
+			"ignored_filters", count,
+		)
+	}
+}
+
+func logMultipleBackends(resolver *backendResolver, namespace, routeName string, totalBackends int) {
+	if totalBackends > 1 {
+		resolver.logger.Info("route configuration partially applied",
+			"route", fmt.Sprintf("%s/%s", namespace, routeName),
+			"reason", "multiple backendRefs specified, using only highest weight",
+			"total_backends", totalBackends,
+			"ignored_backends", totalBackends-1,
+		)
+	}
+}
+
+func logBackendWeights(resolver *backendResolver, namespace, routeName string, refs []gatewayv1.BackendRef) {
+	for i, backendRef := range refs {
+		if backendRef.Weight != nil && *backendRef.Weight != 1 {
+			resolver.logger.Info("route configuration partially applied",
+				"route", fmt.Sprintf("%s/%s", namespace, routeName),
+				"reason", "backendRef weight ignored, traffic splitting not supported",
+				"backend", string(backendRef.Name),
+				"backend_index", i,
+				"weight", *backendRef.Weight,
+			)
+		}
+	}
+}

--- a/internal/ingress/weight.go
+++ b/internal/ingress/weight.go
@@ -14,16 +14,15 @@ const (
 	MaxBackendWeight int32 = 1_000_000
 )
 
-// WeightedRef is an interface for backend references with optional weight.
-type WeightedRef interface {
-	GetWeight() *int32
-}
-
 // SelectHighestWeightIndex returns the index of the backend with highest weight.
 // Backends with weight=0 are skipped (disabled per Gateway API spec).
 // If weights are equal, returns the first one for deterministic behavior.
 // Returns -1 if slice is empty or all backends have weight=0.
-func SelectHighestWeightIndex[T WeightedRef](refs []T) int {
+//
+// Both route kinds project their refs to plain gatewayv1.BackendRef before
+// selection (HTTPBackendRef and GRPCBackendRef embed it), so one concrete
+// signature replaces the former per-kind wrapper types.
+func SelectHighestWeightIndex(refs []gatewayv1.BackendRef) int {
 	if len(refs) == 0 {
 		return -1
 	}
@@ -33,10 +32,7 @@ func SelectHighestWeightIndex[T WeightedRef](refs []T) int {
 	var highestWeight int32
 
 	for i := range refs {
-		weight := DefaultBackendWeight
-		if w := refs[i].GetWeight(); w != nil {
-			weight = *w
-		}
+		weight := effectiveBackendWeight(&refs[i])
 
 		// Skip backends with weight=0 (disabled per Gateway API spec)
 		if weight == 0 {
@@ -50,42 +46,4 @@ func SelectHighestWeightIndex[T WeightedRef](refs []T) int {
 	}
 
 	return selectedIdx
-}
-
-// httpBackendRefWrapper wraps HTTPBackendRef to implement WeightedRef.
-type httpBackendRefWrapper struct {
-	ref *gatewayv1.HTTPBackendRef
-}
-
-func (w httpBackendRefWrapper) GetWeight() *int32 {
-	return w.ref.Weight
-}
-
-// wrapHTTPBackendRefs wraps a slice of HTTPBackendRef for use with SelectHighestWeightIndex.
-func wrapHTTPBackendRefs(refs []gatewayv1.HTTPBackendRef) []httpBackendRefWrapper {
-	wrapped := make([]httpBackendRefWrapper, len(refs))
-	for i := range refs {
-		wrapped[i] = httpBackendRefWrapper{ref: &refs[i]}
-	}
-
-	return wrapped
-}
-
-// grpcBackendRefWrapper wraps GRPCBackendRef to implement WeightedRef.
-type grpcBackendRefWrapper struct {
-	ref *gatewayv1.GRPCBackendRef
-}
-
-func (w grpcBackendRefWrapper) GetWeight() *int32 {
-	return w.ref.Weight
-}
-
-// wrapGRPCBackendRefs wraps a slice of GRPCBackendRef for use with SelectHighestWeightIndex.
-func wrapGRPCBackendRefs(refs []gatewayv1.GRPCBackendRef) []grpcBackendRefWrapper {
-	wrapped := make([]grpcBackendRefWrapper, len(refs))
-	for i := range refs {
-		wrapped[i] = grpcBackendRefWrapper{ref: &refs[i]}
-	}
-
-	return wrapped
 }

--- a/internal/ingress/weight_test.go
+++ b/internal/ingress/weight_test.go
@@ -4,16 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
-
-// mockWeightedRef is a test implementation of WeightedRef.
-type mockWeightedRef struct {
-	weight *int32
-}
-
-func (m mockWeightedRef) GetWeight() *int32 {
-	return m.weight
-}
 
 func int32Ptr(i int32) *int32 {
 	return new(i)
@@ -98,9 +90,9 @@ func TestSelectHighestWeightIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			refs := make([]mockWeightedRef, len(tt.weights))
+			refs := make([]gatewayv1.BackendRef, len(tt.weights))
 			for i, w := range tt.weights {
-				refs[i] = mockWeightedRef{weight: w}
+				refs[i] = gatewayv1.BackendRef{Weight: w}
 			}
 
 			result := SelectHighestWeightIndex(refs)

--- a/internal/proxy/backendref_common.go
+++ b/internal/proxy/backendref_common.go
@@ -1,0 +1,184 @@
+package proxy
+
+import (
+	"context"
+	"log/slog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// backendRefOutcome tells the per-kind converter what the shared backendRef
+// resolution decided.
+type backendRefOutcome int
+
+const (
+	// backendRefResolved: the backend is valid; backend carries Weight and
+	// URL, and the per-kind transport/filter handling should run.
+	backendRefResolved backendRefOutcome = iota
+	// backendRefFinal: resolution finished early (invalid ref marked with its
+	// 500 fraction, or dropped at zero weight); return (backend, keep) as-is.
+	backendRefFinal
+	// backendRefDropped: skip the backend entirely (negative weight).
+	backendRefDropped
+	// backendRefExternal: the ref targets an ExternalBackend; delegate to the
+	// per-kind external path (URL comes from the CRD, port is ignored).
+	backendRefExternal
+)
+
+// resolvedBackendRef is the result of the shared backendRef resolution.
+type resolvedBackendRef struct {
+	outcome backendRefOutcome
+	backend BackendRef
+	keep    bool // meaningful for backendRefFinal
+	// Kind-agnostic identity for the per-kind transport steps.
+	serviceName  string
+	svcNamespace string
+	port         int32
+}
+
+// resolveCommonBackendRef performs the kind-agnostic half of backendRef
+// conversion shared by HTTPRoute and GRPCRoute: weight baseline, negative
+// weight drop, supported-kind / port / ReferenceGrant validation (each
+// marking the backend 500 for its traffic fraction per the Gateway API spec
+// rather than silently dropping it), ExternalBackend detection, and service
+// URL construction. Per-kind transport defaults and filters stay with the
+// callers.
+func resolveCommonBackendRef(
+	ctx context.Context,
+	ref *gatewayv1.BackendRef,
+	routeNamespace string,
+	clusterDomain string,
+	validator BackendRefValidator,
+) resolvedBackendRef {
+	result := BackendRef{Weight: 1}
+	if ref.Weight != nil {
+		result.Weight = *ref.Weight
+	}
+
+	if result.Weight < 0 {
+		slog.Warn("skipping backend with negative weight",
+			"name", string(ref.Name),
+			"weight", result.Weight,
+		)
+
+		return resolvedBackendRef{outcome: backendRefDropped}
+	}
+
+	serviceName := string(ref.Name)
+
+	port := int32(defaultServicePort)
+	if ref.Port != nil {
+		port = *ref.Port
+	}
+
+	svcNamespace := routeNamespace
+	if ref.Namespace != nil {
+		svcNamespace = string(*ref.Namespace)
+	}
+
+	resolved := resolvedBackendRef{
+		backend:      result,
+		serviceName:  serviceName,
+		svcNamespace: svcNamespace,
+		port:         port,
+	}
+
+	return validateCommonBackendRef(ctx, &resolved, ref.BackendObjectReference, routeNamespace, clusterDomain, validator)
+}
+
+// validateCommonBackendRef runs the shared validity gates over an
+// identity-resolved backendRef. An invalid backendRef MUST return 500 for its
+// traffic fraction per the Gateway API spec, not be silently dropped (which
+// would hand its share to the valid siblings): a weight>0 invalid ref stays
+// in the weighted pool marked 500, a weight-0 ref carries no traffic and is
+// dropped — markInvalidBackend enforces that.
+func validateCommonBackendRef(
+	ctx context.Context,
+	resolved *resolvedBackendRef,
+	objRef gatewayv1.BackendObjectReference,
+	routeNamespace string,
+	clusterDomain string,
+	validator BackendRefValidator,
+) resolvedBackendRef {
+	markInvalid := func(reason string) resolvedBackendRef {
+		resolved.outcome = backendRefFinal
+		resolved.backend, resolved.keep = markInvalidBackend(
+			resolved.backend.Weight, resolved.serviceName, resolved.svcNamespace, resolved.port, clusterDomain, reason)
+
+		return *resolved
+	}
+
+	if !IsSupportedBackendRef(objRef) {
+		return markInvalid("unsupported backend kind")
+	}
+
+	// An ExternalBackend's URL lives in its spec (resolved controller-side);
+	// its backendRef port is ignored in favour of spec.port, so skip port
+	// validation and let the per-kind external path take over.
+	if IsExternalBackendRef(objRef) {
+		resolved.outcome = backendRefExternal
+
+		return *resolved
+	}
+
+	if !validatePort(resolved.port) {
+		return markInvalid("invalid port")
+	}
+
+	if !validateCrossNamespace(ctx, resolved.svcNamespace, routeNamespace, resolved.serviceName, objRef, validator) {
+		return markInvalid("cross-namespace reference not permitted by ReferenceGrant")
+	}
+
+	resolved.outcome = backendRefResolved
+	resolved.backend.URL = buildServiceURL(
+		resolved.serviceName, resolved.svcNamespace, resolved.port, backendDomain(objRef, clusterDomain))
+
+	return *resolved
+}
+
+// routeKindView gives convertRoutesGeneric per-kind access to a route type:
+// its hostnames, its parentRefs (for the first-parent client-cert walk), and
+// the per-rule conversion. Everything else — precedence sorting, config
+// versioning, diagnostics sink wiring — is shared and cannot drift between
+// route kinds.
+type routeKindView[R metav1.Object] struct {
+	hostnames   func(route R) []gatewayv1.Hostname
+	parentRefs  func(route R) []gatewayv1.ParentReference
+	ruleCount   func(route R) int
+	convertRule func(ctx context.Context, route R, ruleIdx int, hostnames []string, clientCert *ClientCertConfig, sink *diagSink) RouteRule
+}
+
+// convertRoutesGeneric is the shared conversion shell behind ConvertHTTPRoutes
+// and ConvertGRPCRoutes: routes are flattened in spec precedence order (oldest
+// creationTimestamp, then namespace/name) so the router's stable ruleIndex
+// tiebreak resolves cross-Route ties exactly as the spec mandates, each
+// route's first managed parent contributes the backend mTLS client cert, and
+// every rule's diagnostics land in one sink.
+func convertRoutesGeneric[R metav1.Object](
+	ctx context.Context,
+	routes []R,
+	gatewayCertResolver GatewayClientCertResolver,
+	view routeKindView[R],
+) *Config {
+	cfg := &Config{
+		Version: configVersionCounter.Add(1),
+	}
+
+	sink := &diagSink{}
+
+	for _, route := range sortRoutesByPrecedence(routes) {
+		sink.route(route.GetNamespace(), route.GetName())
+		hostnames := convertHostnames(view.hostnames(route))
+		clientCert := resolveFirstParentClientCertFromRefs(ctx, view.parentRefs(route), route.GetNamespace(), gatewayCertResolver)
+
+		for ruleIdx := range view.ruleCount(route) {
+			sink.at(ruleIdx)
+			cfg.Rules = append(cfg.Rules, view.convertRule(ctx, route, ruleIdx, hostnames, clientCert, sink))
+		}
+	}
+
+	cfg.Diagnostics = sink.items
+
+	return cfg
+}

--- a/internal/proxy/backendref_common.go
+++ b/internal/proxy/backendref_common.go
@@ -50,6 +50,7 @@ func resolveCommonBackendRef(
 	routeNamespace string,
 	clusterDomain string,
 	validator BackendRefValidator,
+	routeKind string,
 ) resolvedBackendRef {
 	result := BackendRef{Weight: 1}
 	if ref.Weight != nil {
@@ -60,6 +61,7 @@ func resolveCommonBackendRef(
 		slog.Warn("skipping backend with negative weight",
 			"name", string(ref.Name),
 			"weight", result.Weight,
+			"route_kind", routeKind,
 		)
 
 		return resolvedBackendRef{outcome: backendRefDropped}

--- a/internal/proxy/converter.go
+++ b/internal/proxy/converter.go
@@ -132,6 +132,8 @@ func sortRoutesByPrecedence[T metav1.Object](routes []T) []T {
 //   - nil tlsResolver: no BackendTLSPolicy is applied; plaintext to backends.
 //   - nil gatewayCertResolver: no Gateway-level client certificate is attached
 //     to any backend TLS handshake (one-way TLS only).
+//
+//nolint:dupl // the two Convert*Routes wrappers are intentionally parallel lambda wiring into convertRoutesGeneric; the route types differ, so they cannot merge further.
 func ConvertHTTPRoutes(
 	ctx context.Context,
 	routes []*gatewayv1.HTTPRoute,
@@ -141,35 +143,22 @@ func ConvertHTTPRoutes(
 	tlsResolver BackendTLSResolver,
 	gatewayCertResolver GatewayClientCertResolver,
 ) *Config {
-	cfg := &Config{
-		Version: configVersionCounter.Add(1),
-	}
-
-	sink := &diagSink{}
-
-	for _, route := range sortRoutesByPrecedence(routes) {
-		sink.route(route.Namespace, route.Name)
-		hostnames := convertHostnames(route.Spec.Hostnames)
-		clientCert := resolveFirstParentClientCert(ctx, route, gatewayCertResolver)
-
-		for ruleIdx := range route.Spec.Rules {
-			sink.at(ruleIdx)
-			proxyRule := convertHTTPRouteRule(
+	// Rules with no backends and no redirect filter are kept — per Gateway API
+	// spec, unresolvable backend refs must return HTTP 500. The proxy handler
+	// returns 500 when no backend is available.
+	return convertRoutesGeneric(ctx, routes, gatewayCertResolver, routeKindView[*gatewayv1.HTTPRoute]{
+		hostnames:  func(route *gatewayv1.HTTPRoute) []gatewayv1.Hostname { return route.Spec.Hostnames },
+		parentRefs: func(route *gatewayv1.HTTPRoute) []gatewayv1.ParentReference { return route.Spec.ParentRefs },
+		ruleCount:  func(route *gatewayv1.HTTPRoute) int { return len(route.Spec.Rules) },
+		convertRule: func(ctx context.Context, route *gatewayv1.HTTPRoute, ruleIdx int,
+			hostnames []string, clientCert *ClientCertConfig, sink *diagSink,
+		) RouteRule {
+			return convertHTTPRouteRule(
 				ctx, &route.Spec.Rules[ruleIdx], hostnames,
 				route.Namespace, clusterDomain, validator, protocolResolver, tlsResolver, clientCert, sink,
 			)
-
-			// Rules with no backends and no redirect filter are kept —
-			// per Gateway API spec, unresolvable backend refs must return HTTP 500.
-			// The proxy handler returns 500 when no backend is available.
-
-			cfg.Rules = append(cfg.Rules, proxyRule)
-		}
-	}
-
-	cfg.Diagnostics = sink.items
-
-	return cfg
+		},
+	})
 }
 
 // kindGateway identifies the parentRef Kind we recognise when walking
@@ -178,19 +167,6 @@ func ConvertHTTPRoutes(
 // matched via gatewayv1.GroupName from the upstream package — no
 // proxy-side magic string.
 const kindGateway = "Gateway"
-
-// resolveFirstParentClientCert walks the HTTPRoute's parentRefs in declaration
-// order, asking gatewayCertResolver for each parent's client certificate, and
-// returns the first non-nil result. Multiple parents with conflicting certs
-// are a spec edge case the conformance suite does not exercise; this
-// "first-wins" rule is documented in docs/gateway-api/limitations.md.
-func resolveFirstParentClientCert(
-	ctx context.Context,
-	route *gatewayv1.HTTPRoute,
-	resolver GatewayClientCertResolver,
-) *ClientCertConfig {
-	return resolveFirstParentClientCertFromRefs(ctx, route.Spec.ParentRefs, route.Namespace, resolver)
-}
 
 // resolveFirstParentClientCertFromRefs is the route-type-agnostic core of the
 // parent-cert lookup: it walks ParentReferences directly so HTTPRoute and
@@ -460,6 +436,11 @@ func convertPathMatch(pathMatch *gatewayv1.HTTPPathMatch) *PathMatch {
 	return result
 }
 
+// convertHeaderMatch mirrors convertGRPCHeaderMatch (grpc_converter.go) by
+// design: the two Gateway API header-match types are structurally identical
+// but nominally distinct with no common underlying type, so a generic would
+// cost accessor indirection for a 10-line primitive. Deliberate per-kind
+// mirror, not drift.
 func convertHeaderMatch(header gatewayv1.HTTPHeaderMatch) HeaderMatch {
 	result := HeaderMatch{
 		Name:  string(header.Name),
@@ -1038,46 +1019,23 @@ func convertBackendRef(
 	clientCert *ClientCertConfig,
 	sink *diagSink,
 ) (BackendRef, bool) {
-	result, ok := initBackendRefBaseline(backend)
-	if !ok {
+	common := resolveCommonBackendRef(ctx, &backend.BackendRef, namespace, clusterDomain, validator)
+
+	switch common.outcome {
+	case backendRefDropped:
 		return BackendRef{}, false
+	case backendRefFinal:
+		return common.backend, common.keep
+	case backendRefExternal:
+		return convertExternalBackendRef(ctx, common.backend.Weight, backend, namespace, common.svcNamespace,
+			common.serviceName, clusterDomain, validator, tlsResolver, clientCert, sink)
+	case backendRefResolved:
 	}
 
-	serviceName := string(backend.Name)
-
-	port := int32(defaultServicePort)
-	if backend.Port != nil {
-		port = *backend.Port
-	}
-
-	svcNamespace := resolveBackendNamespace(backend, namespace)
-
-	// An invalid backendRef MUST return 500 for its traffic fraction per the
-	// Gateway API spec, not be silently dropped (which would hand its share to
-	// the valid siblings). A weight>0 invalid ref therefore stays in the
-	// weighted pool marked 500; a weight-0 ref carries no traffic and is
-	// dropped. markInvalidBackend enforces that.
-	if !IsSupportedBackendRef(backend.BackendObjectReference) {
-		return markInvalidBackend(result.Weight, serviceName, svcNamespace, port, clusterDomain, "unsupported backend kind")
-	}
-
-	// An ExternalBackend's URL lives in its spec (resolved controller-side); its
-	// backendRef port is ignored in favour of spec.port, so skip port validation.
-	if IsExternalBackendRef(backend.BackendObjectReference) {
-		return convertExternalBackendRef(ctx, result.Weight, backend, namespace, svcNamespace, serviceName,
-			clusterDomain, validator, tlsResolver, clientCert, sink)
-	}
-
-	if !validatePort(port) {
-		return markInvalidBackend(result.Weight, serviceName, svcNamespace, port, clusterDomain, "invalid port")
-	}
-
-	if !validateCrossNamespace(ctx, svcNamespace, namespace, serviceName, backend.BackendObjectReference, validator) {
-		return markInvalidBackend(result.Weight, serviceName, svcNamespace, port, clusterDomain,
-			"cross-namespace reference not permitted by ReferenceGrant")
-	}
-
-	result.URL = buildServiceURL(serviceName, svcNamespace, port, backendDomain(backend.BackendObjectReference, clusterDomain))
+	result := common.backend
+	serviceName := common.serviceName
+	svcNamespace := common.svcNamespace
+	port := common.port
 
 	// Resolve TLS first so the protocol resolver can know whether to silently
 	// pass through `appProtocol: https` (policy attached → suppressed) or warn
@@ -1189,27 +1147,6 @@ func markInvalidBackend(weight int32, name, svcNamespace string, port int32, clu
 		URL:               buildServiceURL(name, svcNamespace, urlPort, clusterDomain),
 		UnavailableStatus: http.StatusInternalServerError,
 	}, true
-}
-
-// initBackendRefBaseline validates a backend ref's weight, returning a
-// partially-initialised BackendRef when the weight is non-negative. Extracted
-// from convertBackendRef to keep that function under the funlen budget.
-func initBackendRefBaseline(backend *gatewayv1.HTTPBackendRef) (BackendRef, bool) {
-	result := BackendRef{Weight: 1}
-	if backend.Weight != nil {
-		result.Weight = *backend.Weight
-	}
-
-	if result.Weight < 0 {
-		slog.Warn("skipping backend with negative weight",
-			"name", string(backend.Name),
-			"weight", result.Weight,
-		)
-
-		return BackendRef{}, false
-	}
-
-	return result, true
 }
 
 // attachGatewayClientCert returns a backend TLS config that carries the
@@ -1501,14 +1438,6 @@ func convertBackendFilters(
 	}
 
 	return result, failClosed
-}
-
-func resolveBackendNamespace(backend *gatewayv1.HTTPBackendRef, fallback string) string {
-	if backend.Namespace != nil {
-		return string(*backend.Namespace)
-	}
-
-	return fallback
 }
 
 func validateCrossNamespace(

--- a/internal/proxy/converter.go
+++ b/internal/proxy/converter.go
@@ -1019,7 +1019,7 @@ func convertBackendRef(
 	clientCert *ClientCertConfig,
 	sink *diagSink,
 ) (BackendRef, bool) {
-	common := resolveCommonBackendRef(ctx, &backend.BackendRef, namespace, clusterDomain, validator)
+	common := resolveCommonBackendRef(ctx, &backend.BackendRef, namespace, clusterDomain, validator, "HTTPRoute")
 
 	switch common.outcome {
 	case backendRefDropped:

--- a/internal/proxy/grpc_converter.go
+++ b/internal/proxy/grpc_converter.go
@@ -50,6 +50,8 @@ const grpcSegmentPattern = "[^/]+"
 // Multiple backendRefs are weighted: every listed backend is emitted with its
 // weight, and the proxy's weighted-random selection splits traffic in
 // proportion to those weights (same as HTTPRoute).
+//
+//nolint:dupl // the two Convert*Routes wrappers are intentionally parallel lambda wiring into convertRoutesGeneric; the route types differ, so they cannot merge further.
 func ConvertGRPCRoutes(
 	ctx context.Context,
 	routes []*gatewayv1.GRPCRoute,
@@ -59,39 +61,19 @@ func ConvertGRPCRoutes(
 	tlsResolver BackendTLSResolver,
 	gatewayCertResolver GatewayClientCertResolver,
 ) *Config {
-	cfg := &Config{
-		Version: configVersionCounter.Add(1),
-	}
-
-	sink := &diagSink{}
-
-	for _, route := range sortRoutesByPrecedence(routes) {
-		sink.route(route.Namespace, route.Name)
-		hostnames := convertHostnames(route.Spec.Hostnames)
-		clientCert := resolveFirstParentClientCertForGRPCRoute(ctx, route, gatewayCertResolver)
-
-		for ruleIdx := range route.Spec.Rules {
-			sink.at(ruleIdx)
-			cfg.Rules = append(cfg.Rules, convertGRPCRouteRule(
+	return convertRoutesGeneric(ctx, routes, gatewayCertResolver, routeKindView[*gatewayv1.GRPCRoute]{
+		hostnames:  func(route *gatewayv1.GRPCRoute) []gatewayv1.Hostname { return route.Spec.Hostnames },
+		parentRefs: func(route *gatewayv1.GRPCRoute) []gatewayv1.ParentReference { return route.Spec.ParentRefs },
+		ruleCount:  func(route *gatewayv1.GRPCRoute) int { return len(route.Spec.Rules) },
+		convertRule: func(ctx context.Context, route *gatewayv1.GRPCRoute, ruleIdx int,
+			hostnames []string, clientCert *ClientCertConfig, sink *diagSink,
+		) RouteRule {
+			return convertGRPCRouteRule(
 				ctx, &route.Spec.Rules[ruleIdx], hostnames, route.Namespace, clusterDomain,
 				validator, protocolResolver, tlsResolver, clientCert, sink,
-			))
-		}
-	}
-
-	cfg.Diagnostics = sink.items
-
-	return cfg
-}
-
-// resolveFirstParentClientCertForGRPCRoute is the GRPCRoute entry point into
-// the shared parent-cert walker — same first-wins rule HTTPRoute uses.
-func resolveFirstParentClientCertForGRPCRoute(
-	ctx context.Context,
-	route *gatewayv1.GRPCRoute,
-	resolver GatewayClientCertResolver,
-) *ClientCertConfig {
-	return resolveFirstParentClientCertFromRefs(ctx, route.Spec.ParentRefs, route.Namespace, resolver)
+			)
+		},
+	})
 }
 
 func convertGRPCRouteRule(
@@ -320,58 +302,27 @@ func convertGRPCBackendRef(
 	clientCert *ClientCertConfig,
 	sink *diagSink,
 ) (BackendRef, bool) {
-	result := BackendRef{Weight: 1}
-	if backend.Weight != nil {
-		result.Weight = *backend.Weight
-	}
+	common := resolveCommonBackendRef(ctx, &backend.BackendRef, namespace, clusterDomain, validator)
 
-	if result.Weight < 0 {
-		slog.Warn("skipping gRPC backend with negative weight", "name", string(backend.Name), "weight", result.Weight)
-
+	switch common.outcome {
+	case backendRefDropped:
 		return BackendRef{}, false
+	case backendRefFinal:
+		return common.backend, common.keep
+	case backendRefExternal:
+		// ExternalBackend: URL comes from the CRD (resolved controller-side via
+		// a sentinel); the backendRef port is ignored in favour of spec.port.
+		return convertGRPCExternalBackendRef(ctx, common.backend.Weight, backend, namespace, common.svcNamespace,
+			common.serviceName, clusterDomain, validator, sink)
+	case backendRefResolved:
 	}
 
-	serviceName := string(backend.Name)
-
-	port := int32(defaultServicePort)
-	if backend.Port != nil {
-		port = *backend.Port
-	}
-
-	svcNamespace := namespace
-	if backend.Namespace != nil {
-		svcNamespace = string(*backend.Namespace)
-	}
-
-	// An invalid backendRef MUST return 500 for its traffic fraction per the
-	// Gateway API spec rather than be dropped (mirrors convertBackendRef): a
-	// weight>0 invalid ref stays in the weighted pool marked 500, a weight-0 ref
-	// is dropped.
-	if !IsSupportedBackendRef(backend.BackendObjectReference) {
-		return markInvalidBackend(result.Weight, serviceName, svcNamespace, port, clusterDomain, "unsupported backend kind")
-	}
-
-	// ExternalBackend: URL comes from the CRD (resolved controller-side via a
-	// sentinel); the backendRef port is ignored in favour of spec.port.
-	if IsExternalBackendRef(backend.BackendObjectReference) {
-		return convertGRPCExternalBackendRef(ctx, result.Weight, backend, namespace, svcNamespace, serviceName,
-			clusterDomain, validator, sink)
-	}
-
-	if !validatePort(port) {
-		return markInvalidBackend(result.Weight, serviceName, svcNamespace, port, clusterDomain, "invalid port")
-	}
-
-	if !validateCrossNamespace(ctx, svcNamespace, namespace, serviceName, backend.BackendObjectReference, validator) {
-		return markInvalidBackend(result.Weight, serviceName, svcNamespace, port, clusterDomain,
-			"cross-namespace reference not permitted by ReferenceGrant")
-	}
-
-	result.URL = buildServiceURL(serviceName, svcNamespace, port, backendDomain(backend.BackendObjectReference, clusterDomain))
+	result := common.backend
 
 	applyGRPCBackendFilters(&result, backend.Filters, sink)
 
-	applyGRPCBackendTransport(ctx, &result, protocolResolver, tlsResolver, clientCert, svcNamespace, serviceName, port, sink)
+	applyGRPCBackendTransport(ctx, &result, protocolResolver, tlsResolver, clientCert,
+		common.svcNamespace, common.serviceName, common.port, sink)
 
 	return result, true
 }

--- a/internal/proxy/grpc_converter.go
+++ b/internal/proxy/grpc_converter.go
@@ -302,7 +302,7 @@ func convertGRPCBackendRef(
 	clientCert *ClientCertConfig,
 	sink *diagSink,
 ) (BackendRef, bool) {
-	common := resolveCommonBackendRef(ctx, &backend.BackendRef, namespace, clusterDomain, validator)
+	common := resolveCommonBackendRef(ctx, &backend.BackendRef, namespace, clusterDomain, validator, "GRPCRoute")
 
 	switch common.outcome {
 	case backendRefDropped:

--- a/internal/proxy/grpc_converter_test.go
+++ b/internal/proxy/grpc_converter_test.go
@@ -1196,3 +1196,67 @@ func TestConvertRoutes_BackendTLSEquivalentAcrossRouteKinds(t *testing.T) {
 	assert.Equal(t, httpBackend.URL, grpcBackend.URL,
 		"the same Service backend must dial the same https URL from both route kinds")
 }
+
+// TestConvertRoutes_InvalidBackendOutcomesEquivalentAcrossRouteKinds is the
+// proxy-side counterpart of the ingress cross-kind equivalence pin: identical
+// invalid backendRefs (unsupported kind, out-of-range port, denied
+// cross-namespace ref) must produce identical outcomes through the shared
+// resolution path for HTTPRoute and GRPCRoute — same weight kept, same 500
+// marking, never silently dropped.
+func TestConvertRoutes_InvalidBackendOutcomesEquivalentAcrossRouteKinds(t *testing.T) {
+	t.Parallel()
+
+	badKind := gatewayv1.Kind("ConfigMap")
+	badPort := gatewayv1.PortNumber(70000)
+	deniedNS := gatewayv1.Namespace("denied")
+	okPort := gatewayv1.PortNumber(8080)
+	weight := int32(7)
+
+	denyAll := func(_ context.Context, _ string, _ gatewayv1.BackendObjectReference) bool { return false }
+
+	refs := []gatewayv1.BackendRef{
+		{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "bad-kind", Kind: &badKind, Port: &okPort}, Weight: &weight},
+		{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "bad-port", Port: &badPort}, Weight: &weight},
+		{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "denied", Port: &okPort, Namespace: &deniedNS}, Weight: &weight},
+	}
+
+	httpRefs := make([]gatewayv1.HTTPBackendRef, len(refs))
+	grpcRefs := make([]gatewayv1.GRPCBackendRef, len(refs))
+
+	for i, ref := range refs {
+		httpRefs[i] = gatewayv1.HTTPBackendRef{BackendRef: ref}
+		grpcRefs[i] = gatewayv1.GRPCBackendRef{BackendRef: ref}
+	}
+
+	httpRoutes := []*gatewayv1.HTTPRoute{{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec:       gatewayv1.HTTPRouteSpec{Rules: []gatewayv1.HTTPRouteRule{{BackendRefs: httpRefs}}},
+	}}
+	grpcRoutes := []*gatewayv1.GRPCRoute{{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec:       gatewayv1.GRPCRouteSpec{Rules: []gatewayv1.GRPCRouteRule{{BackendRefs: grpcRefs}}},
+	}}
+
+	httpCfg := proxy.ConvertHTTPRoutes(context.Background(), httpRoutes, "cluster.local", denyAll, nil, nil, nil)
+	grpcCfg := proxy.ConvertGRPCRoutes(context.Background(), grpcRoutes, "cluster.local", denyAll, nil, nil, nil)
+
+	require.Len(t, httpCfg.Rules, 1)
+	require.Len(t, grpcCfg.Rules, 1)
+	require.Len(t, httpCfg.Rules[0].Backends, len(refs),
+		"every weight>0 invalid backend must stay in the pool with its 500 marker")
+	require.Len(t, grpcCfg.Rules[0].Backends, len(refs))
+
+	for i := range refs {
+		httpBackend := httpCfg.Rules[0].Backends[i]
+		grpcBackend := grpcCfg.Rules[0].Backends[i]
+
+		assert.Equal(t, httpBackend.Weight, grpcBackend.Weight,
+			"backend %d: weight must survive identically on both kinds", i)
+		assert.Equal(t, httpBackend.UnavailableStatus, grpcBackend.UnavailableStatus,
+			"backend %d: the 500 invalid-ref marking must be identical on both kinds", i)
+		assert.Equal(t, http.StatusInternalServerError, httpBackend.UnavailableStatus,
+			"backend %d: an invalid ref must carry the 500 marker", i)
+		assert.Equal(t, httpBackend.URL, grpcBackend.URL,
+			"backend %d: the placeholder URL must be identical on both kinds", i)
+	}
+}


### PR DESCRIPTION
## Summary

Unifies the duplicated HTTPRoute/GRPCRoute logic behind shared generic implementations so a per-rule behaviour lands once and the two route families can no longer drift — the failure mode that had already produced real HTTP-vs-gRPC asymmetries. Along the way the restructure surfaced and fixes a real defect: failed backendRefs were reported once per hostname, inflating the failed-refs metric and duplicating ResolvedRefs messages on multi-hostname routes.

Closes #400.

## Changes

- Ingress adapters become pure projections into a kind-neutral rule shape; rule walking, ignored-feature logging, highest-weight selection, and failed-ref reporting are single-source. The per-kind `resolveBackendRef` twins, weight wrapper types, and log helpers are gone.
- Proxy converters share one backendRef resolution path (weight baseline, supported-kind/port/ReferenceGrant gates with the spec-mandated 500 traffic-fraction marking, ExternalBackend detection, URL build) and one conversion shell (precedence sort, config versioning, first-parent client cert, diagnostics sink).
- Failed backendRefs are now reported exactly once per route regardless of hostname count (previously duplicated N times for N hostnames).
- Cross-kind equivalence tests pin the guarantee on both layers: identical inputs must produce identical ingress rules and identical invalid-backend outcomes for both route kinds.
- Two deliberate per-kind mirrors remain and say so in comments (the nominally-distinct 10-line header-match primitives, and the thin `Convert*Routes` lambda wiring).
- One deliberate logging change, pinned by a log-capturing test: unsupported-match warnings are no longer suppressed for rules whose backends fail to resolve.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

No data-plane behavioural change: the full conformance + custom e2e suites were run against a live tunnel with images built from this branch before merge.
