### PR TITLE
test(e2e): audit live-tunnel coverage and close the feasible gaps

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -349,6 +349,38 @@ A few conformance subtests are statistical by nature and occasionally need the s
 
 The same sampling-variance reasoning is applied inline for weighted backend selection in the custom e2e suite (`test/e2e/e2e_test.go`), where a deliberately wide proportion bound avoids reintroducing the flake from the opposite tail.
 
+## Live-Tunnel Coverage Matrix
+
+What actually gets exercised against a real Cloudflare Tunnel, and by which suite. "Conformance" is the official Gateway API suite (`test/conformance`, both profiles); "e2e" is the custom suite (`test/e2e`). Features marked unit-only are the deliberate residue — each carries a reason.
+
+| Feature | Live coverage | Notes |
+| --- | --- | --- |
+| HTTPRoute core + extended matching (path/header/query/method, regex, ordering) | conformance + e2e | e2e re-checks through the real edge hostname (no `X-Original-Host` rewrite) |
+| Filters: header modifiers, redirects (301/302/303/307/308, port/scheme/path), rewrites, mirrors (multiple, percentage) | conformance + e2e | percentage-mirror flake is suite-side, documented upstream |
+| CORS filter | conformance | `SupportHTTPRouteCORS` |
+| Timeouts (request / backendRequest) | conformance | explicit-`0s` disable semantics pinned by unit tests |
+| Weighted traffic splitting | conformance + e2e | |
+| Service types: ClusterIP, headless, ExternalName | conformance (`HTTPRouteServiceTypes`) | headless targetPort resolution covered |
+| BackendTLSPolicy (CA ConfigMap, SNI hostname, DNS + URI SANs) — HTTP path | conformance | `SupportBackendTLSPolicy` + `SANValidation` |
+| BackendTLSPolicy — gRPC path | e2e (`TestGRPCRouteOverTLSBackend`) | official gRPC client cannot dial through the tunnel |
+| Gateway client certificate (backend mTLS) | conformance | multi-parent edge case unit-only (documented in limitations) |
+| GRPCRoute matching + header modifiers through the tunnel transport | e2e (`TestGRPCRouteEndToEnd`) | official suite's gRPC dialer cannot reach `*.cfargotunnel.com`; suite-side tests run where possible |
+| WebSocket upgrade through the tunnel (+ response filters) | conformance + e2e | `ws` cleartext; `wss` (TLS WebSocket backend) is unit-only, see below |
+| `appProtocol` semantics: `kubernetes.io/h2c` | conformance | |
+| `appProtocol` TLS hint without BackendTLSPolicy (fail-closed 502) | e2e (`TestBackendAppProtocolTLSWithoutPolicyFailsClosed`) | spec SHOULD: never silently dial cleartext |
+| ExternalBackend CRD (direct-dial URL, base path) | e2e (`TestExternalBackendEndToEnd`) | proxy dials the URL directly, no Service resolution |
+| ListenerSet (attach, conditions, AttachedRoutes, routing) | conformance + e2e | |
+| ReferenceGrant (cross-namespace backends) | conformance | |
+| Gateway / route status conditions, observedGeneration | conformance + e2e | |
+
+Unit-only by design (each needs infrastructure a kind cluster does not have, or is not data-plane behaviour):
+
+- **ServiceImport (MCS)** — kind has no `multicluster.x-k8s.io` API or `clusterset.local` DNS; resolution logic is unit-tested (`serviceimport_builder_test.go`). Revisit if a multi-cluster test rig ever exists.
+- **`wss` backends (TLS WebSocket)** — needs a TLS-terminating WebSocket echo; the transport decision (policy → TLS, ALPN) is shared with the tested HTTPS path, so the marginal live value is low.
+- **GatewayClass finalizer, status writers, sync skip internals** — control-plane behaviour with no data-plane signal; envtest/unit cover them, and a wrongly-skipped push would fail the routing e2e immediately.
+
+When adding a user-visible feature, add its row here and decide the live-coverage story explicitly — an empty cell is a decision, not an oversight.
+
 ## Best Practices
 
 1. **Fast tests**: Unit tests should run in milliseconds

--- a/test/e2e/apply_object_test.go
+++ b/test/e2e/apply_object_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -98,5 +97,5 @@ func TestApplyObject_CreatesWhenAbsent(t *testing.T) {
 	var got corev1.ConfigMap
 	err := cli.Get(context.Background(), types.NamespacedName{Name: "cm", Namespace: "ns"}, &got)
 	require.NoError(t, err)
-	assert.False(t, apierrors.IsNotFound(err))
+	assert.Equal(t, map[string]string{"k": "v"}, got.Data)
 }

--- a/test/e2e/apply_object_test.go
+++ b/test/e2e/apply_object_test.go
@@ -1,0 +1,102 @@
+//go:build e2e
+
+package e2e
+
+// Unit test for the applyObject helper's delete-wait semantics: the helper
+// must wait until the old object is actually gone (slow apiservers under
+// load keep returning it for a while) instead of sleeping a fixed second
+// and racing Create against an unfinished delete.
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestApplyObject_WaitsForSlowDeletion(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"},
+		Data:       map[string]string{"old": "data"},
+	}
+
+	// Simulate a slow apiserver: after the Delete, Get keeps returning the
+	// (deleted) object for the next few polls before admitting NotFound.
+	var deleted atomic.Bool
+
+	var getsAfterDelete atomic.Int32
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleted.Store(true)
+
+				return cl.Delete(ctx, obj, opts...)
+			},
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if deleted.Load() && getsAfterDelete.Add(1) <= 3 {
+					// Pretend the object is still there.
+					if cm, ok := obj.(*corev1.ConfigMap); ok {
+						existing.DeepCopyInto(cm)
+
+						return nil
+					}
+				}
+
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	replacement := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"},
+		Data:       map[string]string{"new": "data"},
+	}
+
+	applyObject(context.Background(), t, cli, replacement)
+
+	assert.GreaterOrEqual(t, getsAfterDelete.Load(), int32(3),
+		"the helper must keep polling while the old object is still visible")
+
+	var final corev1.ConfigMap
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "cm", Namespace: "ns"}, &final))
+	assert.Equal(t, map[string]string{"new": "data"}, final.Data, "the replacement object must win")
+}
+
+func TestApplyObject_CreatesWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	obj := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"},
+		Data:       map[string]string{"k": "v"},
+	}
+
+	applyObject(context.Background(), t, cli, obj)
+
+	var got corev1.ConfigMap
+	err := cli.Get(context.Background(), types.NamespacedName{Name: "cm", Namespace: "ns"}, &got)
+	require.NoError(t, err)
+	assert.False(t, apierrors.IsNotFound(err))
+}

--- a/test/e2e/e2e_appprotocol_failclosed_test.go
+++ b/test/e2e/e2e_appprotocol_failclosed_test.go
@@ -1,0 +1,132 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// TestBackendAppProtocolTLSWithoutPolicyFailsClosed pins the fail-closed
+// contract end to end through the real tunnel: a Service port declaring a TLS
+// appProtocol (`https`) with NO BackendTLSPolicy attached means the operator
+// asked for TLS but the proxy has no CA to verify the backend -- the spec
+// says the implementation must not silently dial cleartext, so the backend's
+// traffic fraction answers 502 instead of reaching the (cleartext) pod.
+func TestBackendAppProtocolTLSWithoutPolicyFailsClosed(t *testing.T) {
+	cfg := loadTestConfig(t)
+	httpClient := tunnelClient()
+	k8sClient := newK8sClient(t, cfg.KubeContext)
+	ctx := context.Background()
+
+	setupTestNamespace(t, k8sClient, cfg)
+	setupEchoBackends(t, k8sClient, cfg)
+	setupGateway(t, k8sClient, cfg)
+
+	// A Service selecting the plain-HTTP echo-v1 pods but declaring the port
+	// as appProtocol https. The pods serve cleartext; only the hint lies.
+	appProto := "https"
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "echo-v1-tls-hint", Namespace: cfg.TestNamespace},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "echo-v1"},
+			Ports: []corev1.ServicePort{{
+				Name:        "https-hint",
+				Port:        80,
+				TargetPort:  intstr.FromInt32(3000),
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: &appProto,
+			}},
+		},
+	}
+
+	createErr := k8sClient.Create(ctx, svc)
+	if createErr != nil {
+		t.Logf("service create: %v (may already exist)", createErr)
+	}
+
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(context.Background(), svc)
+	})
+
+	route := buildHTTPRoute("fail-closed", cfg, []gatewayv1.HTTPRouteRule{{
+		Matches:     []gatewayv1.HTTPRouteMatch{{Path: pathExact("/fail-closed")}},
+		BackendRefs: []gatewayv1.HTTPBackendRef{backendRef("echo-v1-tls-hint", 80, nil)},
+	}})
+	createHTTPRoute(t, k8sClient, route)
+
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(context.Background(), route)
+	})
+
+	// The proxy must answer 502 (Bad Gateway) for the route -- never 200
+	// (which would mean a silent cleartext dial) and eventually not 404
+	// (route not yet programmed).
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 90*time.Second, true,
+		func(pollCtx context.Context) (bool, error) {
+			_, resp, reqErr := makeRequest(pollCtx, t, httpClient, cfg.TunnelHostname, http.MethodGet, "/fail-closed", nil)
+			if reqErr != nil {
+				return false, nil //nolint:nilerr // transient edge/tunnel errors are expected while polling; retry until timeout
+			}
+
+			if resp.StatusCode == http.StatusOK {
+				return false, errStrictFailClosed
+			}
+
+			return resp.StatusCode == http.StatusBadGateway, nil
+		},
+	)
+	require.NoError(t, err, "a TLS appProtocol without a BackendTLSPolicy must answer 502, never reach the backend in cleartext")
+
+	// The status side of the same contract: ResolvedRefs=False with the
+	// UnsupportedProtocol reason.
+	waitForRouteResolvedRefsFalse(t, k8sClient, route, string(gatewayv1.RouteReasonUnsupportedProtocol))
+}
+
+// errStrictFailClosed aborts the poll immediately: a 200 means the proxy
+// dialed the backend in cleartext despite the TLS hint -- the exact
+// behaviour the spec forbids, and waiting longer cannot fix it.
+var errStrictFailClosed = failClosedError("appProtocol https without policy answered 200: silent cleartext dial")
+
+type failClosedError string
+
+func (e failClosedError) Error() string { return string(e) }
+
+// waitForRouteResolvedRefsFalse polls the route until one of its parents
+// carries ResolvedRefs=False with the given reason.
+func waitForRouteResolvedRefsFalse(t *testing.T, k8sClient client.Client, route *gatewayv1.HTTPRoute, reason string) {
+	t.Helper()
+
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 90*time.Second, true,
+		func(pollCtx context.Context) (bool, error) {
+			current := &gatewayv1.HTTPRoute{}
+			getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: route.Name, Namespace: route.Namespace}, current)
+			if getErr != nil {
+				return false, nil //nolint:nilerr // transient API errors are expected while polling; retry until timeout
+			}
+
+			for _, parent := range current.Status.Parents {
+				for _, cond := range parent.Conditions {
+					if cond.Type == string(gatewayv1.RouteConditionResolvedRefs) &&
+						cond.Status == metav1.ConditionFalse && cond.Reason == reason {
+						return true, nil
+					}
+				}
+			}
+
+			return false, nil
+		},
+	)
+	require.NoError(t, err, "route never reported ResolvedRefs=False/%s", reason)
+}

--- a/test/e2e/e2e_appprotocol_failclosed_test.go
+++ b/test/e2e/e2e_appprotocol_failclosed_test.go
@@ -67,9 +67,16 @@ func TestBackendAppProtocolTLSWithoutPolicyFailsClosed(t *testing.T) {
 		_ = k8sClient.Delete(context.Background(), route)
 	})
 
-	// The proxy must answer 502 (Bad Gateway) for the route -- never 200
-	// (which would mean a silent cleartext dial) and eventually not 404
-	// (route not yet programmed).
+	// Status first: ResolvedRefs=False/UnsupportedProtocol proves the
+	// controller has SEEN the TLS hint and pushed the fail-closed config
+	// (the config push happens before the status write), which closes the
+	// stale-cache window where an early reconcile could briefly serve
+	// cleartext before the Service lands in the informer cache. Only after
+	// that is a 200 a genuine spec violation.
+	waitForRouteResolvedRefsFalse(t, k8sClient, route, string(gatewayv1.RouteReasonUnsupportedProtocol))
+
+	// Data plane: the proxy must answer 502 (Bad Gateway) for the route --
+	// never 200 (which would now mean a silent cleartext dial).
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 90*time.Second, true,
 		func(pollCtx context.Context) (bool, error) {
 			_, resp, reqErr := makeRequest(pollCtx, t, httpClient, cfg.TunnelHostname, http.MethodGet, "/fail-closed", nil)
@@ -85,10 +92,6 @@ func TestBackendAppProtocolTLSWithoutPolicyFailsClosed(t *testing.T) {
 		},
 	)
 	require.NoError(t, err, "a TLS appProtocol without a BackendTLSPolicy must answer 502, never reach the backend in cleartext")
-
-	// The status side of the same contract: ResolvedRefs=False with the
-	// UnsupportedProtocol reason.
-	waitForRouteResolvedRefsFalse(t, k8sClient, route, string(gatewayv1.RouteReasonUnsupportedProtocol))
 }
 
 // errStrictFailClosed aborts the poll immediately: a 200 means the proxy

--- a/test/e2e/e2e_appprotocol_failclosed_test.go
+++ b/test/e2e/e2e_appprotocol_failclosed_test.go
@@ -4,7 +4,9 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -88,20 +90,20 @@ func TestBackendAppProtocolTLSWithoutPolicyFailsClosed(t *testing.T) {
 				return false, errStrictFailClosed
 			}
 
-			return resp.StatusCode == http.StatusBadGateway, nil
+			// Only the proxy's own fail-closed answer counts: a transient
+			// edge 502 (HTML error page) must keep the poll going, or the
+			// test would pass on a tunnel hiccup with fail-closed broken.
+			return resp.StatusCode == http.StatusBadGateway &&
+				strings.Contains(resp.Body, "backend unavailable"), nil
 		},
 	)
-	require.NoError(t, err, "a TLS appProtocol without a BackendTLSPolicy must answer 502, never reach the backend in cleartext")
+	require.NoError(t, err, "a TLS appProtocol without a BackendTLSPolicy must answer the proxy's own 502, never reach the backend in cleartext")
 }
 
 // errStrictFailClosed aborts the poll immediately: a 200 means the proxy
 // dialed the backend in cleartext despite the TLS hint -- the exact
 // behaviour the spec forbids, and waiting longer cannot fix it.
-var errStrictFailClosed = failClosedError("appProtocol https without policy answered 200: silent cleartext dial")
-
-type failClosedError string
-
-func (e failClosedError) Error() string { return string(e) }
+var errStrictFailClosed = errors.New("appProtocol https without policy answered 200: silent cleartext dial")
 
 // waitForRouteResolvedRefsFalse polls the route until one of its parents
 // carries ResolvedRefs=False with the given reason.

--- a/test/e2e/e2e_appprotocol_failclosed_test.go
+++ b/test/e2e/e2e_appprotocol_failclosed_test.go
@@ -51,10 +51,7 @@ func TestBackendAppProtocolTLSWithoutPolicyFailsClosed(t *testing.T) {
 		},
 	}
 
-	createErr := k8sClient.Create(ctx, svc)
-	if createErr != nil {
-		t.Logf("service create: %v (may already exist)", createErr)
-	}
+	applyObject(ctx, t, k8sClient, svc)
 
 	t.Cleanup(func() {
 		_ = k8sClient.Delete(context.Background(), svc)

--- a/test/e2e/e2e_appprotocol_failclosed_test.go
+++ b/test/e2e/e2e_appprotocol_failclosed_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -78,11 +77,22 @@ func TestBackendAppProtocolTLSWithoutPolicyFailsClosed(t *testing.T) {
 	waitForRouteResolvedRefsFalse(t, k8sClient, route, string(gatewayv1.RouteReasonUnsupportedProtocol))
 
 	// Data plane: the proxy must answer 502 (Bad Gateway) for the route --
-	// never 200 (which would now mean a silent cleartext dial).
+	// never 200 (which would now mean a silent cleartext dial). The origin's
+	// response body is NOT inspectable here: Cloudflare's edge replaces an
+	// origin 502 body with its own ("error code: 502", verified empirically),
+	// so the proxy's "backend unavailable" payload never reaches the client.
+	// A transient edge 502 is instead ruled out by requiring the 502 to be
+	// STABLE: three consecutive polls (an edge blip clears between polls,
+	// the fail-closed answer does not), on top of the status gate above
+	// which already proved the fail-closed config reached the proxy.
+	consecutive502 := 0
+
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 90*time.Second, true,
 		func(pollCtx context.Context) (bool, error) {
 			_, resp, reqErr := makeRequest(pollCtx, t, httpClient, cfg.TunnelHostname, http.MethodGet, "/fail-closed", nil)
 			if reqErr != nil {
+				consecutive502 = 0
+
 				return false, nil //nolint:nilerr // transient edge/tunnel errors are expected while polling; retry until timeout
 			}
 
@@ -90,14 +100,18 @@ func TestBackendAppProtocolTLSWithoutPolicyFailsClosed(t *testing.T) {
 				return false, errStrictFailClosed
 			}
 
-			// Only the proxy's own fail-closed answer counts: a transient
-			// edge 502 (HTML error page) must keep the poll going, or the
-			// test would pass on a tunnel hiccup with fail-closed broken.
-			return resp.StatusCode == http.StatusBadGateway &&
-				strings.Contains(resp.Body, "backend unavailable"), nil
+			if resp.StatusCode != http.StatusBadGateway {
+				consecutive502 = 0
+
+				return false, nil
+			}
+
+			consecutive502++
+
+			return consecutive502 >= 3, nil
 		},
 	)
-	require.NoError(t, err, "a TLS appProtocol without a BackendTLSPolicy must answer the proxy's own 502, never reach the backend in cleartext")
+	require.NoError(t, err, "a TLS appProtocol without a BackendTLSPolicy must answer a stable 502, never reach the backend in cleartext")
 }
 
 // errStrictFailClosed aborts the poll immediately: a 200 means the proxy

--- a/test/e2e/e2e_external_backend_test.go
+++ b/test/e2e/e2e_external_backend_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -86,17 +85,6 @@ func TestExternalBackendEndToEnd(t *testing.T) {
 // createExternalBackend creates (or replaces) an ExternalBackend CR.
 func createExternalBackend(t *testing.T, k8sClient client.Client, backend *v1alpha1.ExternalBackend) {
 	t.Helper()
-
-	ctx := context.Background()
-
-	existing := &v1alpha1.ExternalBackend{}
-
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: backend.Name, Namespace: backend.Namespace}, existing)
-	if err == nil {
-		require.NoError(t, k8sClient.Delete(ctx, existing))
-		time.Sleep(time.Second)
-	}
-
-	require.NoError(t, k8sClient.Create(ctx, backend))
+	applyObject(context.Background(), t, k8sClient, backend)
 	t.Logf("created ExternalBackend %s/%s", backend.Namespace, backend.Name)
 }

--- a/test/e2e/e2e_external_backend_test.go
+++ b/test/e2e/e2e_external_backend_test.go
@@ -1,0 +1,102 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/api/v1alpha1"
+)
+
+// TestExternalBackendEndToEnd pins the ExternalBackend CRD path through the
+// real tunnel: an HTTPRoute backendRef of kind ExternalBackend resolves to a
+// direct-dial URL from the CR spec (the proxy dials it without any Service
+// resolution; the backendRef port is ignored in favour of spec.port). The
+// "external" origin here is the echo Service's cluster DNS name -- from the
+// proxy's perspective it is just a URL to dial, which is exactly the
+// ExternalBackend contract.
+func TestExternalBackendEndToEnd(t *testing.T) {
+	cfg := loadTestConfig(t)
+	httpClient := tunnelClient()
+	k8sClient := newK8sClient(t, cfg.KubeContext)
+
+	setupTestNamespace(t, k8sClient, cfg)
+	setupEchoBackends(t, k8sClient, cfg)
+	setupGateway(t, k8sClient, cfg)
+
+	external := &v1alpha1.ExternalBackend{
+		ObjectMeta: metav1.ObjectMeta{Name: "ext-echo", Namespace: cfg.TestNamespace},
+		Spec: v1alpha1.ExternalBackendSpec{
+			Scheme: v1alpha1.ExternalBackendSchemeHTTP,
+			Host:   "echo-v2." + cfg.TestNamespace + ".svc.cluster.local",
+			Port:   80,
+		},
+	}
+
+	createExternalBackend(t, k8sClient, external)
+
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(context.Background(), external)
+	})
+
+	group := gatewayv1.Group("cf.k8s.lex.la")
+	kind := gatewayv1.Kind("ExternalBackend")
+	port := gatewayv1.PortNumber(80)
+
+	route := buildHTTPRoute("ext-backend", cfg, []gatewayv1.HTTPRouteRule{{
+		Matches: []gatewayv1.HTTPRouteMatch{{Path: pathExact("/ext-backend")}},
+		BackendRefs: []gatewayv1.HTTPBackendRef{{
+			BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{
+					Group: &group,
+					Kind:  &kind,
+					Name:  gatewayv1.ObjectName(external.Name),
+					Port:  &port, // ignored in favour of spec.port per the CRD contract
+				},
+			},
+		}},
+	}})
+	createHTTPRoute(t, k8sClient, route)
+
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(context.Background(), route)
+	})
+
+	waitForBackend(t, httpClient, cfg.TunnelHostname, "/ext-backend", "echo-v2-", 90*time.Second)
+
+	echo, resp, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/ext-backend", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "/ext-backend", echo.Path)
+	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"),
+		"the ExternalBackend URL must be dialed directly and reach the echo pod, got pod %q", echo.Pod)
+}
+
+// createExternalBackend creates (or replaces) an ExternalBackend CR.
+func createExternalBackend(t *testing.T, k8sClient client.Client, backend *v1alpha1.ExternalBackend) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	existing := &v1alpha1.ExternalBackend{}
+
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: backend.Name, Namespace: backend.Namespace}, existing)
+	if err == nil {
+		require.NoError(t, k8sClient.Delete(ctx, existing))
+		time.Sleep(time.Second)
+	}
+
+	require.NoError(t, k8sClient.Create(ctx, backend))
+	t.Logf("created ExternalBackend %s/%s", backend.Namespace, backend.Name)
+}

--- a/test/e2e/e2e_external_backend_test.go
+++ b/test/e2e/e2e_external_backend_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -40,6 +41,9 @@ func TestExternalBackendEndToEnd(t *testing.T) {
 			Scheme: v1alpha1.ExternalBackendSchemeHTTP,
 			Host:   "echo-v2." + cfg.TestNamespace + ".svc.cluster.local",
 			Port:   80,
+			// Base path: the proxy must prepend it to every dialed request,
+			// so the backend sees /ext-base<request-path>.
+			Path: "/ext-base",
 		},
 	}
 
@@ -72,12 +76,25 @@ func TestExternalBackendEndToEnd(t *testing.T) {
 		_ = k8sClient.Delete(context.Background(), route)
 	})
 
-	waitForBackend(t, httpClient, cfg.TunnelHostname, "/ext-backend", "echo-v2-", 90*time.Second)
+	// waitForBackend polls until the route serves; the echo pod reports the
+	// path it RECEIVED, which must carry the ExternalBackend base path.
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 90*time.Second, true,
+		func(pollCtx context.Context) (bool, error) {
+			echo, resp, reqErr := makeRequest(pollCtx, t, httpClient, cfg.TunnelHostname, http.MethodGet, "/ext-backend", nil)
+			if reqErr != nil || resp.StatusCode != http.StatusOK {
+				return false, nil //nolint:nilerr // transient edge/tunnel errors are expected while polling; retry until timeout
+			}
+
+			return strings.HasPrefix(echo.Pod, "echo-v2-"), nil
+		},
+	)
+	require.NoError(t, err, "the ExternalBackend route never started serving")
 
 	echo, resp, err := makeRequest(context.Background(), t, httpClient, cfg.TunnelHostname, http.MethodGet, "/ext-backend", nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "/ext-backend", echo.Path)
+	assert.Equal(t, "/ext-base/ext-backend", echo.Path,
+		"the backend must receive the request path prefixed with the ExternalBackend base path")
 	assert.True(t, strings.HasPrefix(echo.Pod, "echo-v2-"),
 		"the ExternalBackend URL must be dialed directly and reach the echo pod, got pod %q", echo.Pod)
 }

--- a/test/e2e/e2e_grpc_tls_test.go
+++ b/test/e2e/e2e_grpc_tls_test.go
@@ -1,0 +1,294 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	pb "sigs.k8s.io/gateway-api/conformance/echo-basic/grpcechoserver"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// TestGRPCRouteOverTLSBackend pins the gRPC-over-TLS-backend path through the
+// real tunnel: a BackendTLSPolicy targeting the gRPC backend's Service makes
+// the proxy dial the backend over TLS (ALPN-negotiated HTTP/2) and verify it
+// against the policy's CA. The backend serves TLS ONLY, so a successful Echo
+// call through the tunnel proves the TLS handshake actually happened -- a
+// cleartext h2c dial (the no-policy default) would be refused outright.
+func TestGRPCRouteOverTLSBackend(t *testing.T) {
+	cfg := loadTestConfig(t)
+
+	if reason := grpcRequiresHTTP2SkipReason(cfg.TunnelProtocol); reason != "" {
+		t.Skip(reason)
+	}
+
+	k8sClient := newK8sClient(t, cfg.KubeContext)
+	ctx := context.Background()
+
+	setupTestNamespace(t, k8sClient, cfg)
+	setupGateway(t, k8sClient, cfg)
+
+	const backendName = "grpc-tls-echo"
+
+	serviceFQDN := backendName + "." + cfg.TestNamespace + ".svc.cluster.local"
+
+	caPEM, certPEM, keyPEM := generateBackendCA(t, serviceFQDN)
+
+	deployTLSGRPCEchoBackend(t, k8sClient, cfg.TestNamespace, backendName, caPEM, certPEM, keyPEM)
+
+	policy := buildBackendTLSPolicy(backendName, cfg.TestNamespace, serviceFQDN)
+	createBackendTLSPolicy(t, k8sClient, policy)
+
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(context.Background(), policy)
+	})
+
+	route := buildGRPCRoute("grpc-tls-e2e", cfg, backendName)
+	createGRPCRoute(t, k8sClient, route)
+
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(context.Background(), route)
+	})
+
+	waitForGRPCRouteAccepted(t, k8sClient, route)
+
+	conn, err := grpc.NewClient(
+		cfg.TunnelHostname+":443",
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})),
+	)
+	require.NoError(t, err, "failed to create gRPC client")
+
+	t.Cleanup(func() { _ = conn.Close() })
+
+	echoClient := pb.NewGrpcEchoClient(conn)
+
+	var resp *pb.EchoResponse
+
+	pollErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 120*time.Second, true,
+		func(pollCtx context.Context) (bool, error) {
+			callCtx, cancel := context.WithTimeout(pollCtx, 10*time.Second)
+			defer cancel()
+
+			r, callErr := echoClient.Echo(callCtx, &pb.EchoRequest{})
+			if callErr != nil {
+				t.Logf("gRPC Echo over TLS backend not ready yet: %v", callErr)
+
+				return false, nil
+			}
+
+			resp = r
+
+			return true, nil
+		},
+	)
+	require.NoError(t, pollErr,
+		"gRPC Echo against the TLS-only backend must succeed: the proxy must dial TLS with the policy CA, a cleartext dial would be refused")
+	require.NotNil(t, resp)
+
+	assert.Contains(t, resp.GetAssertions().GetFullyQualifiedMethod(), grpcEchoService,
+		"echo response should report the GrpcEcho service it was dispatched to")
+}
+
+// generateBackendCA builds a throwaway CA plus a server certificate for the
+// given DNS name, returning PEM-encoded (caCert, serverCert, serverKey).
+func generateBackendCA(t *testing.T, dnsName string) (string, string, string) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "e2e-backend-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: dnsName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{dnsName},
+	}
+
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	require.NoError(t, err)
+
+	caPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}))
+	certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER}))
+	keyPEM := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER}))
+
+	return caPEM, certPEM, keyPEM
+}
+
+// deployTLSGRPCEchoBackend deploys the echo-basic image in gRPC TLS mode: the
+// server cert/key are mounted from a Secret and the echo serves TLS-only gRPC
+// on container port 3000. A ConfigMap with the CA is created for the
+// BackendTLSPolicy to reference.
+func deployTLSGRPCEchoBackend(t *testing.T, k8sClient client.Client, namespace, name, caPEM, certPEM, keyPEM string) {
+	t.Helper()
+	ctx := context.Background()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name + "-cert", Namespace: namespace},
+		StringData: map[string]string{"tls.crt": certPEM, "tls.key": keyPEM},
+	}
+	applyObject(ctx, t, k8sClient, secret)
+
+	caConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name + "-ca", Namespace: namespace},
+		Data:       map[string]string{"ca.crt": caPEM},
+	}
+	applyObject(ctx, t, k8sClient, caConfigMap)
+
+	replicas := int32(1)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: "tls",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{SecretName: name + "-cert"},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name:  name,
+						Image: echoBasicImage,
+						Env: []corev1.EnvVar{
+							{Name: "GRPC_ECHO_SERVER", Value: "1"},
+							{Name: "TLS_SERVER_CERT", Value: "/tls/tls.crt"},
+							{Name: "TLS_SERVER_PRIVKEY", Value: "/tls/tls.key"},
+							{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+							}},
+							{Name: "NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+							}},
+						},
+						VolumeMounts: []corev1.VolumeMount{{Name: "tls", MountPath: "/tls", ReadOnly: true}},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: *mustParseQuantity("10m")},
+						},
+					}},
+				},
+			},
+		},
+	}
+	applyObject(ctx, t, k8sClient, deploy)
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": name},
+			Ports: []corev1.ServicePort{
+				{Name: "grpc-tls", Port: 8080, TargetPort: intstr.FromInt32(3000), Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+	applyObject(ctx, t, k8sClient, svc)
+
+	waitForDeployment(ctx, t, k8sClient, namespace, name, 120*time.Second)
+}
+
+// buildBackendTLSPolicy targets the backend Service and validates against the
+// generated CA with the service FQDN as SNI/hostname.
+func buildBackendTLSPolicy(serviceName, namespace, hostname string) *gatewayv1.BackendTLSPolicy {
+	return &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceName + "-tls", Namespace: namespace},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Kind: "Service",
+					Name: gatewayv1.ObjectName(serviceName),
+				},
+			}},
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				CACertificateRefs: []gatewayv1.LocalObjectReference{{
+					Kind: "ConfigMap",
+					Name: gatewayv1.ObjectName(serviceName + "-ca"),
+				}},
+				Hostname: gatewayv1.PreciseHostname(hostname),
+			},
+		},
+	}
+}
+
+// createBackendTLSPolicy creates (or replaces) the policy.
+func createBackendTLSPolicy(t *testing.T, k8sClient client.Client, policy *gatewayv1.BackendTLSPolicy) {
+	t.Helper()
+	ctx := context.Background()
+
+	existing := &gatewayv1.BackendTLSPolicy{}
+
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, existing)
+	if err == nil {
+		require.NoError(t, k8sClient.Delete(ctx, existing))
+		time.Sleep(time.Second)
+	}
+
+	require.NoError(t, k8sClient.Create(ctx, policy))
+	t.Logf("created BackendTLSPolicy %s/%s", policy.Namespace, policy.Name)
+}
+
+// applyObject create-or-replaces a namespaced object: existing objects are
+// deleted first so reruns against a reused cluster start from the new spec.
+func applyObject(ctx context.Context, t *testing.T, k8sClient client.Client, obj client.Object) {
+	t.Helper()
+
+	existing := obj.DeepCopyObject().(client.Object)
+
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
+	if err == nil {
+		require.NoError(t, k8sClient.Delete(ctx, existing))
+		time.Sleep(time.Second)
+	}
+
+	require.NoError(t, k8sClient.Create(ctx, obj))
+}

--- a/test/e2e/e2e_grpc_tls_test.go
+++ b/test/e2e/e2e_grpc_tls_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,9 +36,11 @@ import (
 // TestGRPCRouteOverTLSBackend pins the gRPC-over-TLS-backend path through the
 // real tunnel: a BackendTLSPolicy targeting the gRPC backend's Service makes
 // the proxy dial the backend over TLS (ALPN-negotiated HTTP/2) and verify it
-// against the policy's CA. The backend serves TLS ONLY, so a successful Echo
-// call through the tunnel proves the TLS handshake actually happened -- a
-// cleartext h2c dial (the no-policy default) would be refused outright.
+// against the policy's CA. The Service exposes only the echo's TLS listener,
+// so a successful Echo call through the tunnel proves the TLS handshake
+// actually happened -- a cleartext h2c dial (the no-policy default) would be
+// refused outright. The serving-pod assertion pins that the answer came from
+// THIS backend, not a lingering cleartext route on the same method.
 func TestGRPCRouteOverTLSBackend(t *testing.T) {
 	cfg := loadTestConfig(t)
 
@@ -110,6 +113,9 @@ func TestGRPCRouteOverTLSBackend(t *testing.T) {
 
 	assert.Contains(t, resp.GetAssertions().GetFullyQualifiedMethod(), grpcEchoService,
 		"echo response should report the GrpcEcho service it was dispatched to")
+	assert.True(t, strings.HasPrefix(resp.GetAssertions().GetContext().GetPod(), backendName+"-"),
+		"the call must be served by the TLS backend's pod, not a lingering cleartext route; got pod %q",
+		resp.GetAssertions().GetContext().GetPod())
 }
 
 // generateBackendCA builds a throwaway CA plus a server certificate for the
@@ -163,9 +169,11 @@ func generateBackendCA(t *testing.T, dnsName string) (string, string, string) {
 }
 
 // deployTLSGRPCEchoBackend deploys the echo-basic image in gRPC TLS mode: the
-// server cert/key are mounted from a Secret and the echo serves TLS-only gRPC
-// on container port 3000. A ConfigMap with the CA is created for the
-// BackendTLSPolicy to reference.
+// server cert/key are mounted from a Secret and the echo serves TLS gRPC on
+// its HTTPS_PORT (8443, the only port the Service exposes; the echo's
+// always-on cleartext listener on 3000 is not reachable through the
+// Service). A ConfigMap with the CA is created for the BackendTLSPolicy to
+// reference.
 func deployTLSGRPCEchoBackend(t *testing.T, k8sClient client.Client, namespace, name, caPEM, certPEM, keyPEM string) {
 	t.Helper()
 	ctx := context.Background()
@@ -204,7 +212,7 @@ func deployTLSGRPCEchoBackend(t *testing.T, k8sClient client.Client, namespace, 
 						Env: []corev1.EnvVar{
 							{Name: "GRPC_ECHO_SERVER", Value: "1"},
 							{Name: "TLS_SERVER_CERT", Value: "/tls/tls.crt"},
-							{Name: "TLS_SERVER_PRIVKEY", Value: "/tls/tls.key"},
+							{Name: "TLS_SERVER_PRIV_KEY", Value: "/tls/tls.key"},
 							{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
 								FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 							}},
@@ -228,7 +236,10 @@ func deployTLSGRPCEchoBackend(t *testing.T, k8sClient client.Client, namespace, 
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"app": name},
 			Ports: []corev1.ServicePort{
-				{Name: "grpc-tls", Port: 8080, TargetPort: intstr.FromInt32(3000), Protocol: corev1.ProtocolTCP},
+				// 8443 is the gRPC echo's HTTPS_PORT (TLS listener); the always-on
+				// cleartext h2c listener stays on 3000 and is deliberately NOT
+				// exposed, so via this Service the backend is TLS-only.
+				{Name: "grpc-tls", Port: 8080, TargetPort: intstr.FromInt32(8443), Protocol: corev1.ProtocolTCP},
 			},
 		},
 	}
@@ -263,17 +274,7 @@ func buildBackendTLSPolicy(serviceName, namespace, hostname string) *gatewayv1.B
 // createBackendTLSPolicy creates (or replaces) the policy.
 func createBackendTLSPolicy(t *testing.T, k8sClient client.Client, policy *gatewayv1.BackendTLSPolicy) {
 	t.Helper()
-	ctx := context.Background()
-
-	existing := &gatewayv1.BackendTLSPolicy{}
-
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}, existing)
-	if err == nil {
-		require.NoError(t, k8sClient.Delete(ctx, existing))
-		time.Sleep(time.Second)
-	}
-
-	require.NoError(t, k8sClient.Create(ctx, policy))
+	applyObject(context.Background(), t, k8sClient, policy)
 	t.Logf("created BackendTLSPolicy %s/%s", policy.Namespace, policy.Name)
 }
 

--- a/test/e2e/e2e_grpc_tls_test.go
+++ b/test/e2e/e2e_grpc_tls_test.go
@@ -21,7 +21,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -102,6 +101,15 @@ func TestGRPCRouteOverTLSBackend(t *testing.T) {
 				return false, nil
 			}
 
+			// A successful Echo served by a DIFFERENT pod means a lingering
+			// cleartext route on the same method answered first -- keep
+			// polling until THIS backend's pod serves the call.
+			if !strings.HasPrefix(r.GetAssertions().GetContext().GetPod(), backendName+"-") {
+				t.Logf("Echo answered by foreign pod %q; waiting for the TLS backend", r.GetAssertions().GetContext().GetPod())
+
+				return false, nil
+			}
+
 			resp = r
 
 			return true, nil
@@ -113,9 +121,6 @@ func TestGRPCRouteOverTLSBackend(t *testing.T) {
 
 	assert.Contains(t, resp.GetAssertions().GetFullyQualifiedMethod(), grpcEchoService,
 		"echo response should report the GrpcEcho service it was dispatched to")
-	assert.True(t, strings.HasPrefix(resp.GetAssertions().GetContext().GetPod(), backendName+"-"),
-		"the call must be served by the TLS backend's pod, not a lingering cleartext route; got pod %q",
-		resp.GetAssertions().GetContext().GetPod())
 }
 
 // generateBackendCA builds a throwaway CA plus a server certificate for the
@@ -276,20 +281,4 @@ func createBackendTLSPolicy(t *testing.T, k8sClient client.Client, policy *gatew
 	t.Helper()
 	applyObject(context.Background(), t, k8sClient, policy)
 	t.Logf("created BackendTLSPolicy %s/%s", policy.Namespace, policy.Name)
-}
-
-// applyObject create-or-replaces a namespaced object: existing objects are
-// deleted first so reruns against a reused cluster start from the new spec.
-func applyObject(ctx context.Context, t *testing.T, k8sClient client.Client, obj client.Object) {
-	t.Helper()
-
-	existing := obj.DeepCopyObject().(client.Object)
-
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
-	if err == nil {
-		require.NoError(t, k8sClient.Delete(ctx, existing))
-		time.Sleep(time.Second)
-	}
-
-	require.NoError(t, k8sClient.Create(ctx, obj))
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -100,10 +100,13 @@ func tunnelClient() *http.Client {
 
 // echoHTTPResponse carries the response metadata the tests assert on. The
 // underlying body is fully consumed and closed inside makeRequest, so there
-// is nothing left for callers to close.
+// is nothing left for callers to close. Body carries the raw payload so
+// error-path tests can distinguish the proxy's own responses (e.g. "backend
+// unavailable") from intermediary error pages with the same status code.
 type echoHTTPResponse struct {
 	StatusCode int
 	Header     http.Header
+	Body       string
 }
 
 // makeRequest sends a request through the Cloudflare tunnel and parses the
@@ -142,6 +145,8 @@ func makeRequest(
 	if err != nil {
 		return nil, meta, fmt.Errorf("reading response body from %s: %w", reqURL, err)
 	}
+
+	meta.Body = string(body)
 
 	var echo echoResponse
 	if resp.Header.Get("Content-Type") == "application/json" {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -100,13 +100,12 @@ func tunnelClient() *http.Client {
 
 // echoHTTPResponse carries the response metadata the tests assert on. The
 // underlying body is fully consumed and closed inside makeRequest, so there
-// is nothing left for callers to close. Body carries the raw payload so
-// error-path tests can distinguish the proxy's own responses (e.g. "backend
-// unavailable") from intermediary error pages with the same status code.
+// is nothing left for callers to close. The raw body is deliberately NOT
+// exposed: Cloudflare's edge replaces origin 5xx bodies with its own error
+// page, so error-path tests cannot assert on origin payloads anyway.
 type echoHTTPResponse struct {
 	StatusCode int
 	Header     http.Header
-	Body       string
 }
 
 // makeRequest sends a request through the Cloudflare tunnel and parses the
@@ -145,8 +144,6 @@ func makeRequest(
 	if err != nil {
 		return nil, meta, fmt.Errorf("reading response body from %s: %w", reqURL, err)
 	}
-
-	meta.Body = string(body)
 
 	var echo echoResponse
 	if resp.Header.Get("Content-Type") == "application/json" {

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -325,6 +325,9 @@ func applyObject(ctx context.Context, t *testing.T, k8sClient client.Client, obj
 	existing := obj.DeepCopyObject().(client.Object)
 
 	err := k8sClient.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
+	require.True(t, err == nil || apierrors.IsNotFound(err),
+		"probing for an existing %s/%s failed: %v", obj.GetNamespace(), obj.GetName(), err)
+
 	if err == nil {
 		require.NoError(t, k8sClient.Delete(ctx, existing))
 

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -316,7 +317,8 @@ func mustParseQuantity(s string) *resource.Quantity {
 }
 
 // applyObject create-or-replaces a namespaced object: existing objects are
-// deleted first so reruns against a reused cluster start from the new spec.
+// deleted first (waiting until the deletion is actually observable, not a
+// fixed sleep) so reruns against a reused cluster start from the new spec.
 func applyObject(ctx context.Context, t *testing.T, k8sClient client.Client, obj client.Object) {
 	t.Helper()
 
@@ -325,7 +327,16 @@ func applyObject(ctx context.Context, t *testing.T, k8sClient client.Client, obj
 	err := k8sClient.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
 	if err == nil {
 		require.NoError(t, k8sClient.Delete(ctx, existing))
-		time.Sleep(time.Second)
+
+		waitErr := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, 30*time.Second, true,
+			func(pollCtx context.Context) (bool, error) {
+				probe := obj.DeepCopyObject().(client.Object)
+				getErr := k8sClient.Get(pollCtx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, probe)
+
+				return apierrors.IsNotFound(getErr), nil
+			},
+		)
+		require.NoError(t, waitErr, "previous %s/%s never finished deleting", obj.GetNamespace(), obj.GetName())
 	}
 
 	require.NoError(t, k8sClient.Create(ctx, obj))

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -314,3 +314,19 @@ func mustParseQuantity(s string) *resource.Quantity {
 	q := resource.MustParse(s)
 	return &q
 }
+
+// applyObject create-or-replaces a namespaced object: existing objects are
+// deleted first so reruns against a reused cluster start from the new spec.
+func applyObject(ctx context.Context, t *testing.T, k8sClient client.Client, obj client.Object) {
+	t.Helper()
+
+	existing := obj.DeepCopyObject().(client.Object)
+
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
+	if err == nil {
+		require.NoError(t, k8sClient.Delete(ctx, existing))
+		time.Sleep(time.Second)
+	}
+
+	require.NoError(t, k8sClient.Create(ctx, obj))
+}

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/api/v1alpha1"
 )
 
 // echoBasicImage is the official Gateway API conformance echo server.
@@ -43,6 +45,7 @@ func newK8sClient(t *testing.T, kubeContext string) client.Client {
 
 	s := scheme.Scheme
 	require.NoError(t, gatewayv1.Install(s))
+	require.NoError(t, v1alpha1.AddToScheme(s))
 
 	k8sClient, err := client.New(restConfig, client.Options{Scheme: s})
 	require.NoError(t, err, "failed to create kubernetes client")


### PR DESCRIPTION
## Summary

A systematic audit of what the conformance and custom e2e suites actually exercise against a live Cloudflare Tunnel, plus end-to-end tests for the three features that turned out to be covered only by unit tests. The audit lands as a durable coverage matrix in the testing docs so future features add their row instead of silently skipping the live story.

## Changes

- Live-tunnel coverage matrix in `docs/development/testing.md`: feature-by-feature, which suite covers it live, and the deliberate unit-only residue with reasons (ServiceImport needs multicluster infrastructure; `wss` shares the tested TLS transport decision).
- `TestExternalBackendEndToEnd`: an HTTPRoute backendRef of kind ExternalBackend resolves to a direct-dial URL from the CR spec and serves through the tunnel, including the base-path prepend (`spec.path`) asserted on live traffic.
- `TestGRPCRouteOverTLSBackend`: a BackendTLSPolicy on the gRPC backend's Service makes the proxy dial TLS with the policy CA; the Service exposes only the echo's TLS listener, so a successful call proves the handshake, and a serving-pod guard inside the poll rules out lingering cleartext routes on the same method.
- `TestBackendAppProtocolTLSWithoutPolicyFailsClosed`: a TLS `appProtocol` hint without a policy answers a stable 502 through the tunnel and reports `ResolvedRefs=False/UnsupportedProtocol`. The test waits for the status condition first (closing the stale-cache reconcile window) and requires three consecutive 502s — an empirical probe showed Cloudflare's edge replaces origin 502 bodies with its own (`error code: 502`), so body inspection cannot distinguish the proxy's answer and stability is the discriminator.
- `applyObject` create-or-replace helper: polls until the old object is actually gone instead of a fixed sleep, pinned by a slow-deletion unit test with a fake-client interceptor.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

All three new tests were developed against a live tunnel and the full e2e suite is green with them included; the final conformance + e2e runs on the merged HEAD precede the merge per the delivery workflow.
