### PR TITLE
ci: bump helm to v4 and fix helm-unittest install/invocation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -383,7 +383,7 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           # renovate: datasource=github-releases depName=helm/helm
-          version: 'v3.21.1'
+          version: 'v4.2.0'
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -395,8 +395,13 @@ jobs:
 
       - name: Install tools
         run: |
-          # helm-unittest
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git
+          # helm-unittest. Helm 4 defaults --verify=true, but its git/VCS
+          # plugin installer cannot verify signatures (verification applies
+          # only to .tgz archives), so requesting it on a .git source
+          # hard-errors with "plugin source does not support verification".
+          # Disable it explicitly — the flag is needed for the source type,
+          # not because the plugin is unsigned.
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
 
           # JSON schema validator
           pip install check-jsonschema
@@ -429,7 +434,10 @@ jobs:
           CHART_DIR="charts/cloudflare-tunnel-gateway-controller"
           if [ -d "$CHART_DIR/tests" ]; then
             echo "Running unit tests..."
-            helm unittest "$CHART_DIR" --color --with-subchart=false
+            # No --color: Helm 4 added a global "--color string" flag that
+            # collides with helm-unittest's own boolean --color, so every
+            # --color form errors ("invalid color mode"). Output stays plain.
+            helm unittest "$CHART_DIR" --with-subchart=false
           else
             echo "No tests directory found, skipping unit tests"
           fi
@@ -517,7 +525,8 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
-          version: 'latest'
+          # renovate: datasource=github-releases depName=helm/helm
+          version: 'v4.2.0'
 
       - name: Modify Chart.yaml and values.yaml
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           # renovate: datasource=github-releases depName=helm/helm
-          version: 'v3.21.1'
+          version: 'v4.2.0'
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -41,8 +41,13 @@ jobs:
 
       - name: Install tools
         run: |
-          # helm-unittest
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git
+          # helm-unittest. Helm 4 defaults --verify=true, but its git/VCS
+          # plugin installer cannot verify signatures (verification applies
+          # only to .tgz archives), so requesting it on a .git source
+          # hard-errors with "plugin source does not support verification".
+          # Disable it explicitly — the flag is needed for the source type,
+          # not because the plugin is unsigned.
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
 
           # JSON schema validator
           pip install check-jsonschema
@@ -75,7 +80,10 @@ jobs:
           CHART_DIR="charts/cloudflare-tunnel-gateway-controller"
           if [ -d "$CHART_DIR/tests" ]; then
             echo "Running unit tests..."
-            helm unittest "$CHART_DIR" --color --with-subchart=false
+            # No --color: Helm 4 added a global "--color string" flag that
+            # collides with helm-unittest's own boolean --color, so every
+            # --color form errors ("invalid color mode"). Output stays plain.
+            helm unittest "$CHART_DIR" --with-subchart=false
           else
             echo "No tests directory found, skipping unit tests"
           fi
@@ -399,7 +407,8 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=helm/helm
+          version: 'v4.2.0'
 
       - name: Install oras
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ check-deps: ## Check all required tools are installed
 	@which mkdocs > /dev/null 2>&1 && echo "OK: mkdocs" || echo "MISSING: mkdocs        pip install -r requirements-docs.txt"
 	@which podman > /dev/null 2>&1 && echo "OK: podman" || echo "MISSING: podman        https://podman.io/getting-started/installation"
 	@which markdownlint-cli2 > /dev/null 2>&1 && echo "OK: markdownlint-cli2" || echo "MISSING: markdownlint-cli2  npm install -g markdownlint-cli2"
-	@helm plugin list 2>/dev/null | grep -q unittest && echo "OK: helm-unittest" || echo "MISSING: helm-unittest  helm plugin install https://github.com/helm-unittest/helm-unittest"
+	@helm plugin list 2>/dev/null | grep -q unittest && echo "OK: helm-unittest" || echo "MISSING: helm-unittest  helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false"
 	@which helm-docs > /dev/null 2>&1 && echo "OK: helm-docs" || echo "MISSING: helm-docs     https://github.com/norwoodj/helm-docs#installation"
 
 help: ## Print this help message

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -35,9 +35,16 @@ go tool cover -func=coverage.out
 
 ### Helm Chart Tests
 
+CI is pinned to Helm v4.2.0. The `helm-unittest` plugin install below uses Helm 4 syntax (`--verify=false`); the test run and chart install themselves work on Helm 3+ as well.
+
 ```bash
-# Install helm-unittest plugin
-helm plugin install https://github.com/helm-unittest/helm-unittest
+# Install helm-unittest plugin (matches CI).
+# helm-unittest installs from a .git source, which Helm 4's installer
+# cannot verify — signature verification only applies to .tgz archives.
+# Helm 4 defaults plugin install to --verify=true, so a .git source
+# hard-errors unless you opt out. Plugin verification (and the --verify
+# flag) did not exist before Helm 4.
+helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
 
 # Run chart tests
 helm unittest charts/cloudflare-tunnel-gateway-controller


### PR DESCRIPTION
## Summary

CI broke when Renovate proposed bumping `azure/setup-helm` to Helm 4 (#465). Helm 4 makes plugin signature verification the default for `helm plugin install`, and the helm-unittest plugin installs from a `.git` source that cannot be signature-verified — so the chart-lint job hard-errored with `plugin source does not support verification`. Helm 4 also added a greedy global `--color string` flag that shadows helm-unittest's own boolean `--color`, breaking the unittest invocation as well.

This finishes the Helm 4 migration rather than declining it. The chart is `apiVersion: v2` and the publish job already ran on the floating `latest` (= Helm 4), so the chart itself was always Helm 4-compatible — only the CI tooling needed fixing. Dropping Helm as the packaging tool was never warranted: the chart is the only supported install path and carries CEL validation, RBAC, `values.schema.json`, and the helm-unittest suite.

## Changes

- Pin all four `azure/setup-helm` steps to a single Renovate-tracked `v4.2.0`. Two of them were on a floating `latest` that would silently drift onto an untested Helm release.
- Pass `--verify=false` on every helm-unittest plugin install so the `.git` source installs under Helm 4. The command string is now identical across both workflows, the Makefile `check-deps` hint, and the testing docs.
- Drop `--color` from the unittest invocation. Under Helm 4 the new global `--color` flag consumes the following `--with-subchart=false` token as its value and errors with `invalid color mode`. Output stays plain; the suite passes on both Helm 3 and Helm 4 without it.
- Sync `docs/development/testing.md`: the suite itself runs on Helm 3+; only the plugin install uses Helm 4 syntax.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

Verified on Helm v4.2.0 (the pinned version) under `bash -eo pipefail`:

- `helm unittest charts/cloudflare-tunnel-gateway-controller --with-subchart=false` → 15 suites / 245 tests pass, exit 0.
- The old `--color --with-subchart=false` form → exits 1 (`invalid color mode`), confirming the regression this fixes.
- `helm plugin install <...>.git` without `--verify=false` → `plugin source does not support verification`; with the flag it installs cleanly.
- `helm lint`, `helm package`, `helm template`, `actionlint`, and `mkdocs build --strict` all clean on v4.2.0.

Gateway API conformance and custom e2e suites were intentionally not run for this PR: it touches only CI workflow YAML, a Makefile dependency hint, and docs — no controller/proxy Go code, no chart templates, no CRDs. Those suites validate runtime behaviour this change cannot affect. The authoritative gate here is CI itself: the chart-lint job that was red under #465's bump is now green on Helm 4.

## Documentation

- [x] README updated (if needed) — N/A
- [x] Code comments added for complex logic — workflow comments explain both Helm 4 mechanisms
- [x] CLAUDE.md updated (if workflow/standards changed) — N/A, no standard change

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced (if any)

## Additional Notes

Supersedes #465, the Renovate-only bump that left the chart-lint job red. #465 should be closed once this merges.
