### PR TITLE
docs: refresh README to current state, require user-facing doc sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ Every feature/fix follows the gates below. No shortcuts: each gate must close be
 
 Step 6's real-cluster verification is maintainer-only — it requires a Cloudflare account, a registered tunnel, and a Kubernetes cluster the maintainer can reach. Contributors finishing a branch should leave the PR in draft and ping the maintainer; the verification + merge is owned by them.
 
+**User-facing docs are part of the change, not a follow-up.** Any PR that changes something a user can observe — a new or changed feature, flag, default, supported Gateway API field, CLI command, install step, or limitation — MUST update `README.md` and the relevant `docs/` pages in the same PR. Before opening the PR, diff the change against what the docs currently claim: if `README.md` or the docs site would now describe the product incorrectly or incompletely, fix them here, not later. `README.md` describes only the product's current behaviour — it MUST NOT contain historical data ("changed in vX", "removed in vY", migration narration); that belongs in release notes and git history. Keep the README slop-free and crisp: lead with what the product does, and push deep technical detail to the docs site with the README keeping a short pointer. Purely internal changes (refactors, test-only, CI tooling) that surface nothing to a user are exempt — state that exemption in the PR body rather than skipping the check silently.
+
 ## Project Overview
 
 Kubernetes controller implementing Gateway API for Cloudflare Tunnel. Watches Gateway and HTTPRoute resources, automatically configures Cloudflare Tunnel ingress rules via API. Supports hot reload without cloudflared restart. Ships a single L7 proxy data plane (embeds cloudflared transport in-process via the vendored fork's `OverrideProxy` hook).
@@ -528,7 +530,7 @@ Standalone labels not enumerated above (`epic`, `community`, `help wanted`, `goo
 
 ### Milestone
 
-Always assign a milestone when creating issues. The current active milestone is `v3.1.0`; anything bound to an earlier release line goes in the corresponding `vX.Y.Z` milestone if one exists. Exception: issues filed automatically by workflows (e.g. the scheduled-e2e failure alert) carry no milestone — the right release target is unknown until a human triages them.
+Always assign a milestone when creating issues. Use the lowest-numbered open `vX.Y.Z` milestone as the current target (run `gh api repos/lexfrei/cloudflare-tunnel-gateway-controller/milestones --jq '.[].title'` to list them); anything bound to a specific later release line goes in the corresponding milestone if one exists. Exception: issues filed automatically by workflows (e.g. the scheduled-e2e failure alert) carry no milestone — the right release target is unknown until a human triages them.
 
 ## Conformance Testing
 

--- a/README.md
+++ b/README.md
@@ -8,32 +8,27 @@
 
 Kubernetes controller implementing Gateway API for Cloudflare Tunnel.
 
-Enables routing traffic through Cloudflare Tunnel using standard Gateway API resources (Gateway, HTTPRoute).
+Expose in-cluster services through a Cloudflare Tunnel using standard Gateway API resources (Gateway, HTTPRoute, GRPCRoute), with no public load balancer or inbound firewall rule.
 
 ## Features
 
-- Standard Gateway API implementation (GatewayClass, Gateway, HTTPRoute, GRPCRoute, ListenerSet)
-- Cross-namespace backend references with ReferenceGrant support
-- Hot reload of tunnel configuration (no cloudflared restart required)
-- In-process L7 proxy embeds cloudflared transport (single data plane, no separate cloudflared deployment)
-- Leader election for high availability deployments
-- Multi-arch container images (amd64, arm64)
-- Signed container images with cosign
-- In-process L7 reverse proxy for full Gateway API HTTPRoute support
-- Header, query parameter, and HTTP method matching
-- Request/response header modification
-- URL rewriting and request redirects
-- Request mirroring
-- Weighted traffic splitting between backends
-- Regex path matching
+- Standard Gateway API: GatewayClass, Gateway, HTTPRoute, GRPCRoute, ListenerSet
+- In-process L7 reverse proxy embeds the cloudflared transport — a single data plane handles routing and tunnel egress
+- Hot reload of routing configuration (no cloudflared restart on route changes)
+- Path matching (prefix, exact, regex), header / query-parameter / HTTP-method matching
+- Request and response header modification, URL rewrite, request redirect, request mirror
+- Weighted traffic splitting across backends
+- HTTPRoute CORS filter
+- Cross-namespace backend references gated by ReferenceGrant
+- Backend TLS (`BackendTLSPolicy`) and backend WebSocket via `appProtocol`
+- Leader election for high-availability deployments
+- Multi-arch images (amd64, arm64), signed with cosign
 
-> **Warning:** The controller assumes **exclusive ownership** of the tunnel configuration. It will remove any ingress rules not managed by HTTPRoute resources. Do not use a tunnel that has manually configured routes or is shared with other systems.
+> **Warning:** The controller assumes **exclusive ownership** of the tunnel configuration. It removes any ingress rules not managed by HTTPRoute/GRPCRoute resources. Do not point it at a tunnel that has manually configured routes or is shared with other systems.
 
 ## L7 Proxy
 
-The controller runs an in-process L7 reverse proxy inside the cloudflared process via the `OverrideProxy` hook (using a [fork of cloudflared](https://github.com/lexfrei/cloudflared)). This enables full Gateway API HTTPRoute support beyond Cloudflare Tunnel's native capabilities: header matching, query parameter matching, HTTP method matching, request/response header modification, URL rewriting, request redirects, request mirroring, weighted traffic splitting, and regex path matching.
-
-All tunnel traffic is intercepted by the in-process proxy, which applies Gateway API routing rules before forwarding requests to backends. Cloudflare Tunnel API configuration is used only for DNS/edge routing — actual request routing is handled entirely by the proxy.
+The controller runs an in-process L7 reverse proxy inside the cloudflared process via the `OverrideProxy` hook (using a [fork of cloudflared](https://github.com/lexfrei/cloudflared)). All tunnel traffic is intercepted by the proxy, which applies Gateway API routing rules — hostname, path, header, query and method matching, filters, and weighted backend selection — before forwarding to backends. The Cloudflare Tunnel API configuration is used only for DNS / edge routing; request routing is handled entirely by the proxy, so HTTPRoute features work end-to-end regardless of Cloudflare Tunnel's native capabilities.
 
 See [L7 Proxy Architecture](https://cf.k8s.lex.la/latest/development/architecture/) for full details.
 
@@ -105,7 +100,7 @@ The controller manages tunnel ingress configuration via the Cloudflare API. Tunn
 Create an API token at [Cloudflare API Tokens](https://dash.cloudflare.com/profile/api-tokens) with the following permissions:
 
 | Scope | Permission | Access |
-|-------|------------|--------|
+| --- | --- | --- |
 | Account | Cloudflare Tunnel | Edit |
 
 Account ID is auto-detected from the API token when not explicitly provided (works if the token has access to a single account).
@@ -128,7 +123,7 @@ For manual installation without Helm, see [Manual Installation](https://cf.k8s.l
 
 ## Usage
 
-Create standard [Gateway API](https://gateway-api.sigs.k8s.io/) HTTPRoute or GRPCRoute resources referencing the `cloudflare-tunnel` Gateway. The controller automatically syncs routes to Cloudflare Tunnel configuration with hot reload (no cloudflared restart required). Both HTTPRoute and GRPCRoute route through the in-process L7 proxy at runtime.
+Create standard [Gateway API](https://gateway-api.sigs.k8s.io/) HTTPRoute or GRPCRoute resources referencing the `cloudflare-tunnel` Gateway. The controller syncs routes to the in-process L7 proxy and the Cloudflare Tunnel configuration with hot reload (no cloudflared restart). Both HTTPRoute and GRPCRoute are served by the proxy at runtime.
 
 ### Supported Gateway Fields
 
@@ -137,7 +132,7 @@ Create standard [Gateway API](https://gateway-api.sigs.k8s.io/) HTTPRoute or GRP
 | `spec.gatewayClassName` | ✅ | Must match controller's GatewayClass |
 | `spec.listeners` | ✅ | Fully processed for route binding and status |
 | `spec.listeners[].name` | ✅ | Used for route binding, status reporting, attached route counting |
-| `spec.listeners[].protocol` | ✅ | Used for route kind filtering (HTTP/HTTPS → HTTPRoute; GRPCRoute filtering still applies but binding is broken in v3 — see Limitations) |
+| `spec.listeners[].protocol` | ✅ | HTTP/HTTPS listeners bind HTTPRoute and GRPCRoute |
 | `spec.listeners[].port` | ✅ | Used for route binding when route specifies a port |
 | `spec.listeners[].hostname` | ✅ | Routes must have intersecting hostnames |
 | `spec.listeners[].tls` | ✅ | CertificateRefs validated with ReferenceGrant support |
@@ -149,62 +144,47 @@ Create standard [Gateway API](https://gateway-api.sigs.k8s.io/) HTTPRoute or GRP
 
 ### Supported Route Fields
 
-The controller supports a subset of Gateway API fields that map to Cloudflare Tunnel ingress rules:
-
 All matching and filter behavior is performed by the in-process L7 proxy that the chart deploys alongside the controller.
 
 **HTTPRoute:**
 
 | Field | Supported | Notes |
-|-------|-----------|-------|
+| --- | --- | --- |
 | `spec.hostnames` | ✅ | Wildcard `*` supported |
 | `spec.rules[].matches[].path` | ✅ | PathPrefix, Exact, RegularExpression |
 | `spec.rules[].matches[].headers` | ✅ | Exact and RegularExpression |
 | `spec.rules[].matches[].queryParams` | ✅ | Exact and RegularExpression |
 | `spec.rules[].matches[].method` | ✅ | All HTTP methods |
-| `spec.rules[].filters` | ✅ | Header modifier, redirect, URL rewrite, mirror |
+| `spec.rules[].filters` | ✅ | Header modifier, redirect, URL rewrite, mirror, CORS |
 | `spec.rules[].backendRefs` | ✅ | Service name, namespace, port |
 | `spec.rules[].backendRefs[].namespace` | ✅ | Cross-namespace refs require ReferenceGrant |
 | `spec.rules[].backendRefs[].weight` | ✅ | True weighted traffic splitting across backends |
 
-**GRPCRoute:** ✅ Supported — served by the in-process L7 proxy. gRPC service/method matches map onto `/{service}/{method}` path rules. The upstream hop is cleartext h2c by default; attaching a `BackendTLSPolicy` upgrades the hop to TLS with HTTP/2 negotiated via ALPN, and the Gateway's `clientCertificateRef` is presented on the handshake for mTLS. See [GRPCRoute docs](https://cf.k8s.lex.la/latest/gateway-api/grpcroute/).
+**GRPCRoute:** ✅ Served by the in-process L7 proxy. gRPC service/method matches map onto `/{service}/{method}` path rules. The upstream hop is cleartext h2c by default; attaching a `BackendTLSPolicy` upgrades the hop to TLS with HTTP/2 negotiated via ALPN, and the Gateway's `clientCertificateRef` is presented on the handshake for mTLS. See [GRPCRoute docs](https://cf.k8s.lex.la/latest/gateway-api/grpcroute/).
 
-> **Load Balancing:** All traffic flows through the in-process L7 proxy, so full weighted traffic splitting between multiple backends is supported end-to-end. See [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/#traffic-splitting-and-load-balancing) for the edge-side caveats that still apply.
+A `backendRef` may target a core `Service`, a `ServiceImport` (`multicluster.x-k8s.io`), or an `ExternalBackend` (`cf.k8s.lex.la`, an out-of-cluster HTTP(S) URL). Other kinds are reported `ResolvedRefs=False, InvalidKind`.
 
-### Known Limitations
+### Limitations
 
-The in-process L7 proxy handles routing for every tunnel request. Edge-side caveats (Cloudflare hostname registration, edge HTTPS termination, etc.) are documented in the [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/) page. In particular, a GRPCRoute also needs Cloudflare zone gRPC proxying enabled (dashboard → Network → gRPC); if disabled, the edge returns `403` zone-wide for `application/grpc` and gRPC fails before reaching the proxy ([details](https://cf.k8s.lex.la/latest/gateway-api/limitations/#grpc-requires-cloudflare-zone-grpc-proxying)).
+The L7 proxy handles routing for every tunnel request, so most Gateway API behavior works end-to-end. The caveats that remain are documented in full on the [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/) page:
 
-`BackendTLSPolicy` (proxy → backend TLS) is supported at minimum-viable scope:
+- Edge-side constraints — Cloudflare hostname registration and edge HTTPS termination apply to all traffic.
+- gRPC requires Cloudflare zone gRPC proxying enabled (dashboard → Network → gRPC); otherwise the edge returns `403` zone-wide for `application/grpc`.
+- `BackendTLSPolicy` (proxy → backend TLS) is supported at minimum-viable scope: explicit `CACertificateRefs` only, `Hostname` and `URI` SANs, backend mTLS via the Gateway's `clientCertificateRef`.
+- Backend WebSocket via `appProtocol: kubernetes.io/ws` (and `/wss` with a `BackendTLSPolicy`).
+- `timeouts.request` / `timeouts.backendRequest` are enforced as header-only deadlines, so streaming responses (SSE, chunked, gRPC server-streaming) keep flowing past the deadline.
+- Unavailable backends in a weighted rule return a status (`500`/`503`) for their share rather than dialing a dead address, so the other backends keep serving.
+- `HTTPRouteRule.name` uniqueness is not enforced at admission; an opt-in `ValidatingAdmissionPolicy` (`ruleNameUniquenessPolicy` Helm value) enforces it on Kubernetes 1.30+.
 
-- `SubjectAltNames` of both `Hostname` (RFC 6125 wildcards via `VerifyHostname`) and `URI` types (e.g. SPIFFE IDs, exact string match against the leaf cert's URIs) are supported, with OR-matching across the list
-- `WellKnownCACertificates: System` is not honoured — only explicit `CACertificateRefs`
-- Multi-policy conflicts resolve by oldest-creationTimestamp (then alphabetical). Losing policies are stamped `Accepted=False, Reason=Conflicted, Message="conflicts with BackendTLSPolicy <ns/name>"` per GEP-713; distinct `SectionName` scopes do not conflict
-- HTTPS-listener Re-encrypt is not supported (Cloudflare terminates frontend TLS at the edge)
-- `RequestMirror` filter routes mirrored traffic through the same per-cert TLS-aware transport pool the main leg uses; when a `BackendTLSPolicy` targets a mirror destination the mirrored copy completes the same TLS handshake the main leg would, including mTLS via the Gateway's `clientCertificateRef`
-- Backend mTLS is supported via `Gateway.spec.tls.backend.clientCertificateRef` (Gateway API `GatewayBackendClientCertificate` feature, Standard channel). The referenced `kubernetes.io/tls` Secret's keypair is presented during the backend TLS handshake **only** when a `BackendTLSPolicy` also targets the Service — a client cert over plaintext is meaningless. Cross-namespace refs require ReferenceGrant.
-- Backend WebSocket is supported via `Service.spec.ports[].appProtocol: kubernetes.io/ws` (and `kubernetes.io/wss` when paired with a `BackendTLSPolicy`). The proxy handles the upgrade on a custom path (`proxyWebSocketUpgrade`) rather than `httputil.ReverseProxy`, because the stdlib path hijacks the conn before writing the 101 status — which fails over cloudflared's HTTP/2 response writer. Route-level `ResponseHeaderModifier` filters apply to the 101 (and to the non-101 fallback when the backend refuses the upgrade), matching how filters apply to plain HTTP responses. If `kubernetes.io/wss` is declared without a `BackendTLSPolicy` the proxy logs a WARN at conversion time and falls through to plaintext — the backend will then reject the upgrade. The proxy does not enforce the precondition; operators must attach the policy themselves.
-- `spec.rules[].timeouts.request` and `timeouts.backendRequest` are enforced as header-only deadlines on the backend transport (`http.Transport.ResponseHeaderTimeout`), not as full-request context deadlines. The deadline bounds only the wait for backend response headers; once headers arrive the body streams freely. This keeps Server-Sent Events, chunked transfer, large file downloads, and gRPC server-streaming responses alive past the timeout boundary — a context-based deadline would have truncated them at the timeout mark. Backends that miss the header deadline get a 504 to the client. WebSocket routes are naturally exempt (the upgrade path bypasses the cached transport). The `BackendProtocol: H2C` path uses `golang.org/x/net/http2.Transport`, which has no `ResponseHeaderTimeout` knob; the proxy synthesises one by wrapping the h2c transport with a `headerTimeoutRoundTripper` so h2c backends honour the same streaming-friendly contract.
+The proxy can emit a structured per-request access log via `proxy.accessLog.enabled: true`. See [Access Logging](https://cf.k8s.lex.la/latest/operations/access-logging/).
 
-Besides a core `Service`, a `backendRef` may target a `ServiceImport` (`multicluster.x-k8s.io`, resolved via `clusterset.local` DNS) or an `ExternalBackend` (`cf.k8s.lex.la`, an out-of-cluster HTTP(S) URL). A kind outside that set is reported `ResolvedRefs=False, InvalidKind`. Cross-namespace `ServiceImport`/`ExternalBackend` refs need a `ReferenceGrant` keyed on the matching group/kind. See [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/#non-service-backend-kinds) for details.
-
-An unavailable backend in a weighted rule returns an HTTP status for its traffic fraction rather than dialing a dead address (a generic 502): an invalid `backendRef` (nonexistent Service, missing `ServiceImport`/`ExternalBackend`, unauthorized cross-namespace ref, or unsupported kind) returns `500`, and an authorized Service with no ready endpoints returns `503`. The backend stays in the weighted pool so the other backends keep serving their share, and the `503` clears automatically once an endpoint becomes ready. See [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/#unavailable-backends-return-a-status-not-a-dial-error) for details.
-
-The L7 proxy implements the Gateway API `HTTPRouteCORS` filter (preflight + simple requests, wildcard origin / methods / headers, credentials-aware echoing), including the `HTTPRouteCORSAllowCredentialsBehavior` conformance subtest: `Access-Control-Allow-Credentials` is emitted only for a matched origin, and a credentialed response echoes the concrete request origin rather than `*`.
-
-See [Backend mTLS](https://cf.k8s.lex.la/latest/gateway-api/limitations/#backend-mtls-backendtlspolicy) for details.
-
-The proxy can emit a structured per-request access log (method, host, path, query, status, bytes_written, duration_ms, user_agent) via `proxy.accessLog.enabled: true` in Helm values. Off by default; sampling-rate knob keeps log volume manageable on busy gateways. See [Access Logging](https://cf.k8s.lex.la/latest/operations/access-logging/) for the full contract.
-
-Per Gateway API, `HTTPRouteRule.name` / `GRPCRouteRule.name` must be unique within a Route, but the Standard-channel CRDs do not enforce it (the uniqueness CEL is experimental-channel only) and rule names are cosmetic, so duplicates do not affect routing. To enforce uniqueness at admission, enable the opt-in `ruleNameUniquenessPolicy` Helm value, which installs a cluster-scoped `ValidatingAdmissionPolicy` (Kubernetes 1.30+). See [Limitations](https://cf.k8s.lex.la/latest/gateway-api/limitations/#route-rule-name-uniqueness-specrulesname) for the trade-offs.
-
-See [Gateway API documentation](https://cf.k8s.lex.la/latest/gateway-api/) for full details and examples.
+See the [Gateway API documentation](https://cf.k8s.lex.la/latest/gateway-api/) for full details and examples.
 
 ## External-DNS Integration
 
-The controller sets `status.addresses` on the Gateway with the tunnel CNAME (`TUNNEL_ID.cfargotunnel.com`). If you have [external-dns](https://github.com/kubernetes-sigs/external-dns) configured with Gateway API source, it will automatically create DNS records for your HTTPRoute hostnames.
+The controller sets `status.addresses` on the Gateway with the tunnel CNAME (`TUNNEL_ID.cfargotunnel.com`). If you run [external-dns](https://github.com/kubernetes-sigs/external-dns) with the Gateway API source, it will automatically create DNS records for your HTTPRoute hostnames.
 
-All external-dns annotations (TTL, provider-specific settings, etc.) should be placed on HTTPRoute resources, not on Gateway. See the [external-dns Gateway API documentation](https://kubernetes-sigs.github.io/external-dns/latest/docs/sources/gateway-api/) for details.
+All external-dns annotations (TTL, provider-specific settings, etc.) should be placed on HTTPRoute resources, not on the Gateway. See the [external-dns Gateway API documentation](https://kubernetes-sigs.github.io/external-dns/latest/docs/sources/gateway-api/) for details.
 
 ## FAQ
 
@@ -215,14 +195,14 @@ Cloudflare's free [Universal SSL](https://developers.cloudflare.com/ssl/edge-cer
 - ✅ `example.com`, `*.example.com`
 - ❌ `app.dev.example.com`
 
-For multi-level subdomains, you need [Advanced Certificate Manager](https://developers.cloudflare.com/ssl/edge-certificates/advanced-certificate-manager/) ($10/month) or a Business/Enterprise plan.
+For multi-level subdomains, you need [Advanced Certificate Manager](https://developers.cloudflare.com/ssl/edge-certificates/advanced-certificate-manager/) or a Business/Enterprise plan.
 
 ## Documentation
 
 Full documentation is available at **[cf.k8s.lex.la](https://cf.k8s.lex.la)**.
 
 | Section | Description |
-|---------|-------------|
+| --- | --- |
 | [Getting Started](https://cf.k8s.lex.la/latest/getting-started/) | Prerequisites, installation, and quick start |
 | [Configuration](https://cf.k8s.lex.la/latest/configuration/) | Controller configuration and Helm values |
 | [Gateway API](https://cf.k8s.lex.la/latest/gateway-api/) | Supported resources, examples, and limitations |
@@ -230,19 +210,6 @@ Full documentation is available at **[cf.k8s.lex.la](https://cf.k8s.lex.la)**.
 | [Operations](https://cf.k8s.lex.la/latest/operations/) | Troubleshooting, metrics, manual installation |
 | [Development](https://cf.k8s.lex.la/latest/development/) | Development setup, architecture, contributing |
 | [Reference](https://cf.k8s.lex.la/latest/reference/) | CRD reference, Helm chart, security policy |
-
-## Roadmap
-
-Planned features and improvements:
-
-| Issue | Description | Status |
-|-------|-------------|--------|
-| -- | L7 reverse proxy for full Gateway API HTTPRoute support | Done |
-| [#45](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/45) | Weighted backend traffic splitting | Done |
-| [#44](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/44) | Warning logs for partially ignored route configuration | Planned |
-| [#40](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/40) | TCPRoute and TLSRoute support (GRPCRoute removed from the runtime in v3 — see [migration guide](https://cf.k8s.lex.la/latest/upgrading/v2-to-v3/)) | In Progress |
-| [#33](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/33) | Auto-generate artifacthub.io/changes from git history | Planned |
-| [#25](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/issues/25) | Increase unit test coverage for core packages | Ongoing |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

The README described a stale, self-contradictory state — most visibly GRPCRoute, which was simultaneously "binding broken in v3", "removed in v3", and "fully supported". This rewrites the README to describe only the current product, with no historical data, and adds a CLAUDE.md rule so user-facing docs stay in sync going forward.

## Changes

- Align GRPCRoute to "served by the in-process L7 proxy" — the reconciler, route binding (`internal/routebinding/kind.go`), and the gRPC e2e suite all confirm it works. Removed the contradictory "binding broken in v3" and "removed in v3" lines.
- Drop the Roadmap section and all version-history narration; the README now contains no historical data.
- Condense Known Limitations to a pointer list — full detail stays on the docs site.
- De-duplicate the L7-proxy feature line; surface CORS, BackendTLSPolicy, WebSocket, ServiceImport, and ExternalBackend.
- Add a CLAUDE.md rule: user-facing doc updates ship in the same PR as the change, and the README must not contain historical data.
- Replace the hardcoded "current milestone" value in CLAUDE.md with a lookup so it cannot go stale.

## Testing

- [x] All tests pass locally (`go test ./...`) — N/A, docs-only (no Go changes)
- [x] Linters pass locally — `markdownlint-cli2 README.md CLAUDE.md`: 0 errors
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

Docs checks: `hack/check-doc-links.sh` passes (all `cf.k8s.lex.la` links versioned); all referenced files (CONTRIBUTING / SECURITY / LICENSE / chart README) and the `#installation` anchor resolve.

Gateway API conformance and custom e2e suites are not run: this PR changes only `README.md` and `CLAUDE.md` — no controller/proxy code, no chart, no CRD. There is no runtime surface for those suites to exercise.

## Documentation

- [x] README updated (if needed) — this PR
- [x] Code comments added for complex logic — N/A
- [x] CLAUDE.md updated (if workflow/standards changed) — added the doc-sync rule

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced (if any) — N/A

## Additional Notes

The GRPCRoute factual correction was cross-checked against `internal/routebinding/kind.go`, `internal/controller/grpcroute_controller.go`, and the gRPC e2e suite.
