### PR TITLE
fix(controller): isolate config-push transport from http.DefaultTransport

### DIFF
--- a/internal/controller/proxy_syncer.go
+++ b/internal/controller/proxy_syncer.go
@@ -137,12 +137,28 @@ func WithSyncerTracing() ProxySyncerOption {
 }
 
 // proxyPushClient builds the config-push HTTP client. When tracing is enabled
-// its transport is wrapped with otelhttp; when disabled Transport stays nil so
-// the stdlib default transport is used unchanged.
+// its transport is wrapped with otelhttp; either way the controller owns its
+// transport rather than the process-global http.DefaultTransport.
+//
+// Leaving Transport nil would make net/http fall back to http.DefaultTransport,
+// a singleton shared with every other HTTP client in the process. A
+// CloseIdleConnections call on that shared transport — from unrelated code or,
+// in tests, a sibling parallel case — can tear down an in-flight config push
+// ("transport connection broken: http: CloseIdleConnections called"). Cloning
+// DefaultTransport gives an isolated connection pool with the same defaults.
 func proxyPushClient(tracing bool) *http.Client {
+	// Always an isolated transport. Clone DefaultTransport for its tuned
+	// defaults on the normal path; the bare *http.Transport fallback (an
+	// unreachable case — DefaultTransport is always *http.Transport in the
+	// stdlib) still avoids sharing the global pool.
+	transport := &http.Transport{}
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = defaultTransport.Clone()
+	}
+
 	return &http.Client{
 		Timeout:   proxyPushTimeout,
-		Transport: tracingpkg.WrapTransport(nil, tracing),
+		Transport: tracingpkg.WrapTransport(transport, tracing),
 	}
 }
 

--- a/internal/controller/proxy_syncer_pushclient_internal_test.go
+++ b/internal/controller/proxy_syncer_pushclient_internal_test.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProxyPushClient_OwnsIsolatedTransport pins that the config-push client
+// owns its transport instead of falling back to the process-global
+// http.DefaultTransport. A nil Transport makes net/http use DefaultTransport,
+// which every ProxySyncer in the process then shares. A CloseIdleConnections
+// call on that shared transport — from unrelated code, or a sibling parallel
+// test tearing down its own httptest server — can break an in-flight config
+// push, surfacing as "transport connection broken: http: CloseIdleConnections
+// called" and a flaky TestProxySyncer_SyncRoutes_* failure.
+func TestProxyPushClient_OwnsIsolatedTransport(t *testing.T) {
+	t.Parallel()
+
+	client := proxyPushClient(false)
+
+	require.NotNil(t, client.Transport,
+		"push client must set Transport — a nil Transport makes net/http use the shared http.DefaultTransport")
+	assert.NotSame(t, http.DefaultTransport, client.Transport,
+		"push client must own its transport, not share the process-global http.DefaultTransport")
+}
+
+// TestProxyPushClient_TracingStillOwnsIsolatedTransport pins the same isolation
+// with tracing enabled: the otelhttp wrapper must wrap the controller's own
+// transport, never the shared DefaultTransport.
+func TestProxyPushClient_TracingStillOwnsIsolatedTransport(t *testing.T) {
+	t.Parallel()
+
+	client := proxyPushClient(true)
+
+	require.NotNil(t, client.Transport,
+		"tracing push client must set Transport")
+	assert.NotSame(t, http.DefaultTransport, client.Transport,
+		"tracing push client must wrap its own transport, not the shared http.DefaultTransport")
+}

--- a/internal/controller/proxy_syncer_tracing_internal_test.go
+++ b/internal/controller/proxy_syncer_tracing_internal_test.go
@@ -8,14 +8,16 @@ import (
 )
 
 // TestProxyPushClient_TracingTogglesTransport pins that the config-push client
-// wraps its transport with otelhttp only when tracing is enabled; disabled
-// leaves Transport nil so the stdlib default transport is used unchanged.
+// wraps its transport with otelhttp only when tracing is enabled. Transport
+// isolation (never the shared http.DefaultTransport) is pinned separately in
+// TestProxyPushClient_OwnsIsolatedTransport.
 func TestProxyPushClient_TracingTogglesTransport(t *testing.T) {
 	t.Parallel()
 
 	plain := proxyPushClient(false)
-	assert.Nil(t, plain.Transport,
-		"tracing disabled must leave Transport nil (stdlib default, outbound path unchanged)")
+
+	_, plainWrapped := plain.Transport.(*otelhttp.Transport)
+	assert.False(t, plainWrapped, "tracing disabled must not wrap the transport with otelhttp")
 
 	traced := proxyPushClient(true)
 


### PR DESCRIPTION
## Summary

`TestProxySyncer_SyncRoutes_HeadlessBackend` flaked on CI with `transport connection broken: http: CloseIdleConnections called`. Root cause: the controller's config-push client left `http.Client.Transport` nil, so net/http used the process-global `http.DefaultTransport`. `httptest.Server.Close()` unconditionally calls `http.DefaultTransport.CloseIdleConnections()`, so any sibling parallel test tearing down its server could break an in-flight push another ProxySyncer was making through the same shared pool.

## Changes

- `proxyPushClient` now clones `http.DefaultTransport` so each client owns an isolated connection pool with the same tuned defaults, instead of sharing the global singleton.
- Added a test pinning transport isolation (non-nil, not the shared `DefaultTransport`), for both tracing on and off.
- Updated the tracing test that pinned the old nil-Transport contract to assert only the otelhttp wrap toggle.

## Testing

- [x] All tests pass locally (`go test ./...`) — `go test -race ./...` exit 0
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`) — 0 issues
- [x] Markdown linting passes (`markdownlint **/*.md`) — N/A, no markdown
- [x] Manual testing completed (if applicable) — 50× `-race` stress on the formerly-flaky test, green

TDD: the isolation test fails (RED) against the old nil-Transport code and passes (GREEN) with the clone.

Gateway API conformance and custom e2e suites were not run: this change isolates the controller→proxy config-push HTTP connection pool and is wire-equivalent (same transport defaults, same requests). It does not touch Gateway API routing, the proxy data plane, or the tunnel — the surface those suites exercise. Unit + race + 50× stress cover the behavior changed here.

## Documentation

- [x] README updated (if needed) — N/A
- [x] Code comments added for complex logic — the `DefaultTransport`-sharing hazard is explained at the fix site
- [x] CLAUDE.md updated (if workflow/standards changed) — N/A

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [x] Related issues referenced (if any) — N/A

## Additional Notes

The trigger is documented `httptest` behaviour: `Server.Close()` calls `http.DefaultTransport.CloseIdleConnections()` on the assumption most callers use the standard transport. Owning the transport sidesteps it entirely, and also stops the controller sharing a connection pool with unrelated code in production.
