### PR TITLE
chore(controller): per-Gateway and hostname-ownership review follow-ups

### DIFF
--- a/api/v1alpha1/crd_no_issue_refs_test.go
+++ b/api/v1alpha1/crd_no_issue_refs_test.go
@@ -1,0 +1,52 @@
+package v1alpha1_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// issueRefPattern matches a GitHub-style issue/PR reference (e.g. #110).
+var issueRefPattern = regexp.MustCompile(`#\d+`)
+
+// TestShippedCRDsHaveNoIssueReferences guards the shipped CRDs against issue/PR
+// references leaking into user-facing API descriptions. controller-gen copies
+// the Go doc comments on the CRD types verbatim into the CRD `description`
+// fields, which users read via `kubectl explain` / `kubectl get crd -o yaml`;
+// this repo forbids issue references in public/shipped content. The only way to
+// keep the descriptions clean is to keep the source comments clean, so scan the
+// generated artifact to catch a regression at its visible surface.
+func TestShippedCRDsHaveNoIssueReferences(t *testing.T) {
+	t.Parallel()
+
+	crdDir := filepath.Join("..", "..", "charts", "cloudflare-tunnel-gateway-controller", "crds")
+
+	entries, err := os.ReadDir(crdDir)
+	require.NoError(t, err)
+
+	var scanned int
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+
+		raw, err := os.ReadFile(filepath.Join(crdDir, entry.Name()))
+		require.NoError(t, err)
+
+		scanned++
+
+		for i, line := range strings.Split(string(raw), "\n") {
+			match := issueRefPattern.FindString(line)
+			require.Empty(t, match,
+				"%s:%d carries an issue/PR reference %q — strip it from the source Go doc comment and re-run controller-gen",
+				entry.Name(), i+1, match)
+		}
+	}
+
+	require.Positive(t, scanned, "no CRD files were scanned")
+}

--- a/api/v1alpha1/gatewayclassconfig_types.go
+++ b/api/v1alpha1/gatewayclassconfig_types.go
@@ -36,7 +36,7 @@ type GatewayClassConfigSpec struct {
 	// Cloudflare uses for account IDs. Validated server-side via a CRD-level CEL
 	// rule (Kubernetes >= 1.25) so an invalid value is rejected at admission time,
 	// before the controller has to reconcile it. Empty string passes through
-	// because the field is optional. Closes #110.
+	// because the field is optional.
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^[a-f0-9]{32}$')",message="accountID must be a 32-character lowercase hexadecimal string (Cloudflare account ID format)"
 	AccountID string `json:"accountId,omitempty"`

--- a/charts/cloudflare-tunnel-gateway-controller/crds/cf.k8s.lex.la_gatewayclassconfigs.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/crds/cf.k8s.lex.la_gatewayclassconfigs.yaml
@@ -2,111 +2,165 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: gatewayclassconfigs.cf.k8s.lex.la
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: gatewayclassconfigs.cf.k8s.lex.la
 spec:
   group: cf.k8s.lex.la
   names:
     kind: GatewayClassConfig
     listKind: GatewayClassConfigList
     plural: gatewayclassconfigs
-    singular: gatewayclassconfig
     shortNames:
-      - gcconfig
+    - gcconfig
+    singular: gatewayclassconfig
   scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - name: Tunnel ID
-          type: string
-          jsonPath: .spec.tunnelID
-        - name: Age
-          type: date
-          jsonPath: .metadata.creationTimestamp
-      schema:
-        openAPIV3Schema:
-          type: object
-          description: GatewayClassConfig is the Schema for the gatewayclassconfigs API.
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              type: object
-              required:
-                - cloudflareCredentialsSecretRef
-                - tunnelID
-              properties:
-                cloudflareCredentialsSecretRef:
-                  type: object
-                  description: Reference to Secret containing Cloudflare API credentials.
-                  required:
-                    - name
+  - additionalPrinterColumns:
+    - jsonPath: .spec.tunnelID
+      name: Tunnel ID
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GatewayClassConfig is the Schema for the gatewayclassconfigs API.
+          It provides configuration for Cloudflare Tunnel Gateway API implementation.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GatewayClassConfigSpec defines the desired state of GatewayClassConfig.
+            properties:
+              accountId:
+                description: |-
+                  AccountID is the Cloudflare account ID. Optional - if not specified, it will be
+                  read from the credentials secret ("account-id" key) or auto-detected if the API token
+                  has access to only one account.
+
+                  When set, must be a 32-character lowercase hexadecimal string -- the format
+                  Cloudflare uses for account IDs. Validated server-side via a CRD-level CEL
+                  rule (Kubernetes >= 1.25) so an invalid value is rejected at admission time,
+                  before the controller has to reconcile it. Empty string passes through
+                  because the field is optional. Closes #110.
+                type: string
+                x-kubernetes-validations:
+                - message: accountID must be a 32-character lowercase hexadecimal
+                    string (Cloudflare account ID format)
+                  rule: self == '' || self.matches('^[a-f0-9]{32}$')
+              cloudflareCredentialsSecretRef:
+                description: |-
+                  CloudflareCredentialsSecretRef references a Secret containing Cloudflare API credentials.
+                  The Secret must contain an "api-token" key with a valid Cloudflare API token.
+                properties:
+                  key:
+                    description: |-
+                      Key in the Secret. Defaults depend on context:
+                      - For cloudflareCredentialsSecretRef: "api-token"
+                    type: string
+                  name:
+                    description: Name of the Secret.
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace of the Secret. Defaults to the namespace
+                      of the referencing resource.
+                    type: string
+                required:
+                - name
+                type: object
+              tunnelID:
+                description: TunnelID is the Cloudflare Tunnel UUID.
+                pattern: ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$
+                type: string
+            required:
+            - cloudflareCredentialsSecretRef
+            - tunnelID
+            type: object
+          status:
+            description: GatewayClassConfigStatus defines the observed state of GatewayClassConfig.
+            properties:
+              conditions:
+                description: Conditions describe the current state of the GatewayClassConfig.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
-                    name:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
                       type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
                       minLength: 1
-                    namespace:
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
-                    key:
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
-                accountId:
-                  type: string
-                  description: Cloudflare account ID. Optional - auto-detected if not set.
-                  x-kubernetes-validations:
-                    - rule: "self == '' || self.matches('^[a-f0-9]{32}$')"
-                      message: "accountID must be a 32-character lowercase hexadecimal string (Cloudflare account ID format)"
-                tunnelID:
-                  type: string
-                  description: Cloudflare Tunnel UUID.
-                  pattern: ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$
-            status:
-              type: object
-              properties:
-                conditions:
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-      subresources:
-        status: {}
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/cloudflare-tunnel-gateway-controller/crds/cf.k8s.lex.la_gatewayclassconfigs.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/crds/cf.k8s.lex.la_gatewayclassconfigs.yaml
@@ -60,7 +60,7 @@ spec:
                   Cloudflare uses for account IDs. Validated server-side via a CRD-level CEL
                   rule (Kubernetes >= 1.25) so an invalid value is rejected at admission time,
                   before the controller has to reconcile it. Empty string passes through
-                  because the field is optional. Closes #110.
+                  because the field is optional.
                 type: string
                 x-kubernetes-validations:
                 - message: accountID must be a 32-character lowercase hexadecimal

--- a/charts/cloudflare-tunnel-gateway-controller/crds/cf.k8s.lex.la_gatewayconfigs.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/crds/cf.k8s.lex.la_gatewayconfigs.yaml
@@ -72,7 +72,8 @@ spec:
                   key:
                     description: |-
                       Key in the Secret. Defaults depend on context: "tunnel-token" for
-                      tunnelTokenSecretRef, "auth-token" for authTokenSecretRef.
+                      tunnelTokenSecretRef, "auth-token" for authTokenSecretRef, "api-token"
+                      for cloudflareCredentialsSecretRef.
                     type: string
                   name:
                     description: Name of the Secret.
@@ -138,7 +139,8 @@ spec:
                   key:
                     description: |-
                       Key in the Secret. Defaults depend on context: "tunnel-token" for
-                      tunnelTokenSecretRef, "auth-token" for authTokenSecretRef.
+                      tunnelTokenSecretRef, "auth-token" for authTokenSecretRef, "api-token"
+                      for cloudflareCredentialsSecretRef.
                     type: string
                   name:
                     description: Name of the Secret.
@@ -237,7 +239,8 @@ spec:
                   key:
                     description: |-
                       Key in the Secret. Defaults depend on context: "tunnel-token" for
-                      tunnelTokenSecretRef, "auth-token" for authTokenSecretRef.
+                      tunnelTokenSecretRef, "auth-token" for authTokenSecretRef, "api-token"
+                      for cloudflareCredentialsSecretRef.
                     type: string
                   name:
                     description: Name of the Secret.

--- a/charts/cloudflare-tunnel-gateway-controller/tests/deployment_test.yaml
+++ b/charts/cloudflare-tunnel-gateway-controller/tests/deployment_test.yaml
@@ -748,6 +748,29 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--hostname-ownership-namespace-selector=alpha=aval,mango=mval,zebra=zval"
 
+  # Pins the rendering of every remaining matchExpressions operator (In,
+  # Exists, DoesNotExist) — the controller parses this string back with
+  # labels.Parse, and the round-trip parity is asserted Go-side in
+  # internal/hostnameownership/selector_parity_test.go. matchExpressions render
+  # in list order, after the sorted matchLabels terms.
+  - it: should render In, Exists and DoesNotExist operators in list order
+    set:
+      hostnameOwnershipPolicy:
+        enabled: true
+        namespaceSelector:
+          matchExpressions:
+            - key: team
+              operator: In
+              values: [a, b]
+            - key: tenancy
+              operator: Exists
+            - key: system
+              operator: DoesNotExist
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hostname-ownership-namespace-selector=team in (a,b),tenancy,!system"
+
   - it: should omit the selector flag when the selector is empty
     set:
       hostnameOwnershipPolicy:

--- a/docs/upgrading/v3-to-v3.1.md
+++ b/docs/upgrading/v3-to-v3.1.md
@@ -1,6 +1,6 @@
 # Upgrading from v3.0 to v3.1
 
-v3.1 hardens multi-tenant isolation. There is no CRD migration and no required values change — existing `GatewayClassConfig` and chart values keep working. But four behaviours change in ways existing automation can observe, and one of them (the data-plane NetworkPolicy now on by default) can break an existing Prometheus scrape if your monitoring namespace is not admitted. Read the four notes below; only the metrics/NetworkPolicy one needs action, and only for some setups.
+v3.1 hardens multi-tenant isolation. There is no CRD migration and no required values change — existing `GatewayClassConfig` and chart values keep working. But four behaviours change in ways existing automation can observe, and one of them — the data-plane NetworkPolicy now on by default — can break two things on a NetworkPolicy-enforcing CNI: an existing Prometheus scrape from an unadmitted namespace, and, more seriously, proxy pod readiness if the CNI also enforces host→pod (kubelet) traffic. Read the four notes below, then the two "change that can break" sections; only the metrics/NetworkPolicy one needs action, and only on some setups.
 
 ## What changed
 
@@ -55,9 +55,21 @@ proxy:
 
 If you do not run a NetworkPolicy-enforcing CNI, the policy is a no-op and scraping is unaffected — but it is then also not providing the isolation, so treat it as defense in depth, not a guarantee. To keep the v3.0 behaviour (no data-plane NetworkPolicy at all), set `proxy.networkPolicy.enabled: false` — that one switch gates BOTH the chart's shared-proxy policy AND the per-Gateway policies the controller renders (it forwards the value as the controller's `--render-network-policy` flag, which deletes any policy it previously rendered).
 
+## The change that can break silently: proxy readiness on a strict CNI
+
+!!! warning "Proxy pods can go NotReady on a host-policy-enforcing CNI"
+    This is more likely to bite — and bite silently — than the Prometheus break above, because nothing is misconfigured on your side: the policy simply blocks the node.
+
+    The proxy's startup/liveness/readiness probes hit the config API port (8081). The default-on NetworkPolicy admits 8081 only from the controller namespace, but **kubelet probe traffic originates from the node, not a pod namespace**. Most CNIs allow host→pod traffic implicitly, so probes keep working. A CNI that also enforces host policies (Cilium with host policy enforcement, Calico with host endpoints) drops the probes, and **every proxy pod — shared and per-Gateway — goes `NotReady`, taking the data plane down**.
+
+    Two fixes:
+
+    - add an ingress rule admitting the node/kubelet source for port 8081, or
+    - set `proxy.networkPolicy.enabled: false` to drop the policy entirely (covers both the shared and per-Gateway planes).
+
 ## Verify after upgrade
 
-- **Kubelet probes.** The proxy's startup/liveness/readiness probes hit the config API port (8081). The rendered NetworkPolicy admits 8081 from the controller namespace only; kubelet probe traffic originates from the node, so it relies on the CNI allowing host→pod traffic (most do). If proxy pods go `NotReady` after upgrade on a strict CNI, either add an ingress rule admitting the node/kubelet source for 8081, or set `proxy.networkPolicy.enabled: false` to drop the policy entirely (covers both the shared and per-Gateway planes).
+- **Proxy readiness.** Confirm proxy pods (shared and per-Gateway) reach `Ready` after upgrade. If they stay `NotReady` on a strict CNI, see the warning above — kubelet probes are being dropped by the new NetworkPolicy.
 - **Controller → proxy config push.** The controller pushes config to the proxy from its own namespace, which the default policy admits; verify routes still program after upgrade.
 
 ## No CRD or values migration

--- a/internal/config/resolver_gateway_test.go
+++ b/internal/config/resolver_gateway_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -182,6 +184,50 @@ func TestResolveForGateway_HappyPath_ClassCredentialFallback(t *testing.T) {
 	assert.Equal(t, "edge-tunnel-token", resolved.TunnelTokenSecret.Name)
 	require.NotNil(t, resolved.GatewayConfig)
 	assert.Equal(t, "edge-config", resolved.GatewayConfig.Name)
+}
+
+// TestResolveForGateway_TunnelIDIsCanonicalLowercase pins that the resolved
+// PerGatewayConfig.TunnelID is always the canonical lowercase UUID form,
+// regardless of how the connector token spells it. Same-tunnel union
+// correctness (route_partition) keys on exact-string TunnelID equality, so a
+// future refactor that stored the raw token "t" value instead of
+// uuid.UUID.String() would silently break the merge — this fails it instead.
+func TestResolveForGateway_TunnelIDIsCanonicalLowercase(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(map[string]any{
+		"a": testAccountTag,
+		"s": base64.StdEncoding.EncodeToString([]byte("tunnel-secret")),
+		"t": strings.ToUpper(testTunnelUUID), // a non-canonical (uppercase) tunnel ID
+	})
+	require.NoError(t, err)
+
+	gwConfig := &v1alpha1.GatewayConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "edge-config", Namespace: testGwNamespace},
+		Spec: v1alpha1.GatewayConfigSpec{
+			TunnelTokenSecretRef: v1alpha1.LocalSecretReference{Name: "edge-tunnel-token"},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "edge-tunnel-token", Namespace: testGwNamespace},
+		Data:       map[string][]byte{"tunnel-token": []byte(base64.StdEncoding.EncodeToString(payload))},
+	}
+
+	objects := append(classFixtures(), gwConfig, secret, generatedAuthSecret())
+	resolver := newGatewayResolver(t, objects...)
+
+	resolved, err := resolver.ResolveForGateway(context.Background(),
+		gatewayWithInfra("cf.k8s.lex.la", "GatewayConfig", "edge-config"))
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+
+	assert.Equal(t, testTunnelUUID, resolved.TunnelID,
+		"an uppercase token tunnel ID must resolve to the canonical lowercase form")
+	assert.Equal(t, strings.ToLower(resolved.TunnelID), resolved.TunnelID, "TunnelID must be lowercase")
+
+	parsed, err := uuid.Parse(resolved.TunnelID)
+	require.NoError(t, err)
+	assert.Equal(t, parsed.String(), resolved.TunnelID, "TunnelID must be the canonical uuid string form")
 }
 
 // TestResolveForGateway_CredentialOverride pins that a GatewayConfig-level

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -822,7 +822,14 @@ func (r *GatewayReconciler) gatewayConfigToGateways(ctx context.Context, obj cli
 			continue
 		}
 
-		if gateway.Spec.Infrastructure.ParametersRef.Name != obj.GetName() {
+		ref := gateway.Spec.Infrastructure.ParametersRef
+		// Match Group/Kind too, not just Name: a parametersRef to a foreign CRD
+		// that happens to share the GatewayConfig's name is not ours to resolve.
+		if string(ref.Group) != config.ParametersRefGroup || string(ref.Kind) != config.GatewayParametersRefKind {
+			continue
+		}
+
+		if ref.Name != obj.GetName() {
 			continue
 		}
 

--- a/internal/controller/gateway_controller_pergateway_test.go
+++ b/internal/controller/gateway_controller_pergateway_test.go
@@ -164,6 +164,51 @@ func TestGatewayReconciler_PerGateway_ProgrammedTrueWhenReady(t *testing.T) {
 	assert.Equal(t, metav1.ConditionTrue, programmed.Status)
 }
 
+// TestGatewayReconciler_PerGateway_ProgrammedTransientDeploymentReadKeepsPending
+// pins the CURRENT behaviour of the transient Deployment-read branch: unlike
+// the other transient paths (which propagate the error for controller-runtime
+// backoff), a non-NotFound Get failure here is folded into
+// Programmed=False/Pending and returned, not propagated. The Deployment watch +
+// requeue self-heals, so this inconsistency is intentional and harmless; pin it
+// so a future refactor that changes the shape is a conscious decision rather
+// than a silent drift.
+func TestGatewayReconciler_PerGateway_ProgrammedTransientDeploymentReadKeepsPending(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(gatewayv1.Install(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey,
+				obj client.Object, opts ...client.GetOption,
+			) error {
+				if _, ok := obj.(*appsv1.Deployment); ok {
+					return apierrors.NewInternalError(errSimulatedCacheMiss)
+				}
+
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &GatewayReconciler{Client: fakeClient, Scheme: scheme}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "pg-gateway", Namespace: "default"},
+	}
+
+	condition := reconciler.perGatewayProgrammedCondition(context.Background(), gateway, metav1.Now())
+
+	assert.Equal(t, metav1.ConditionFalse, condition.Status,
+		"a transient Deployment-read failure folds into Programmed=False, not a propagated error")
+	assert.Equal(t, string(gatewayv1.GatewayReasonPending), condition.Reason)
+	assert.Contains(t, condition.Message, "Failed to read per-Gateway proxy deployment")
+}
+
 // TestGatewayReconciler_PerGateway_TransientResolveErrorKeepsStatus pins the
 // sentinel/transient split end to end: ResolveForGateway deliberately keeps a
 // transient API failure's identity (only deterministic spec problems classify

--- a/internal/controller/gateway_infra_reconciler.go
+++ b/internal/controller/gateway_infra_reconciler.go
@@ -344,6 +344,12 @@ func (r *GatewayInfraReconciler) applyRendered(
 	// readiness-only reconcile returns None and does not re-sync, so this does
 	// not fire on every Deployment status flip. Best-effort: a failure here is
 	// retried by the next route reconcile; never fail the render over it.
+	//
+	// This is a FULL (not partition-scoped) sync run synchronously inside this
+	// Reconcile, so on a many-route cluster a per-Gateway spec change couples
+	// this reconcile's latency to the total route-sync cost. Acceptable while
+	// per-Gateway spec edits are rare; partition-scope the sync to this
+	// Gateway's data plane if that coupling becomes a latency concern at scale.
 	if deploymentOp != controllerutil.OperationResultNone && r.TriggerRouteSync != nil {
 		if err := r.TriggerRouteSync(ctx); err != nil {
 			log.FromContext(ctx).Info("route sync after data-plane render failed; will retry on next route reconcile",
@@ -414,7 +420,22 @@ func assertAdoptable(existing client.Object, gateway *gatewayv1.Gateway) error {
 		return nil // already ours
 	}
 
-	return errors.Wrapf(errRefusedAdoption, "%T %s/%s (rename it or the Gateway)",
+	// A controller owner that is a Gateway (this API group) of THIS name but a
+	// different UID is a stale render from a previous incarnation — the Gateway
+	// was deleted and re-created with the same name before GC removed the old
+	// objects. The remediation is to delete the orphan so a fresh one renders,
+	// NOT to rename it (it carries our generated name, not a name the operator
+	// picked). Match the API group too: a foreign CRD also kinded "Gateway" in
+	// another group is a genuinely foreign object, so it gets the rename hint.
+	if owner != nil && owner.APIVersion == gatewayv1.GroupVersion.String() &&
+		owner.Kind == "Gateway" && owner.Name == gateway.Name {
+		return errors.Wrapf(errRefusedAdoption,
+			"%T %s/%s is owned by a previous Gateway of the same name (UID %s); "+
+				"delete the orphaned object so this Gateway can render a fresh one",
+			existing, existing.GetNamespace(), existing.GetName(), owner.UID)
+	}
+
+	return errors.Wrapf(errRefusedAdoption, "%T %s/%s (rename the conflicting object or the Gateway)",
 		existing, existing.GetNamespace(), existing.GetName())
 }
 

--- a/internal/controller/gateway_infra_reconciler_test.go
+++ b/internal/controller/gateway_infra_reconciler_test.go
@@ -815,6 +815,96 @@ func TestGatewayInfraReconciler_RefusesToAdoptForeignObject(t *testing.T) {
 	assert.Empty(t, deployment.OwnerReferences, "the foreign object must not be adopted")
 }
 
+// TestGatewayInfraReconciler_RefusesStaleRenderFromRecreatedGateway pins the
+// same-name/new-UID re-creation path: a Gateway deleted and re-created with the
+// same name before GC removed its rendered objects must NOT adopt the stale
+// objects (owned by the old UID), and the failure must point the operator at
+// the right remediation — delete the orphan — distinct from the "rename it"
+// hint a genuinely foreign object gets.
+func TestGatewayInfraReconciler_RefusesStaleRenderFromRecreatedGateway(t *testing.T) {
+	t.Parallel()
+
+	stale := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cf-proxy-edge", Namespace: infraNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: gatewayv1.GroupVersion.String(),
+				Kind:       "Gateway",
+				Name:       "edge",
+				UID:        "gw-uid-stale",
+				Controller: new(true),
+			}},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "stale"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "stale"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "old/proxy:v1"}}},
+			},
+		},
+	}
+
+	objects := append(infraFixtures(t), stale)
+	reconciler := newInfraReconciler(t, objects...)
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "edge", Namespace: infraNamespace},
+	})
+	require.Error(t, err, "a stale same-name render owned by a previous UID must not be adopted")
+	assert.ErrorIs(t, err, errRefusedAdoption)
+	assert.Contains(t, err.Error(), "delete the orphaned",
+		"the remediation must tell the operator to delete the stale render, not rename it")
+
+	var deployment appsv1.Deployment
+	require.NoError(t, reconciler.Get(context.Background(),
+		types.NamespacedName{Name: "cf-proxy-edge", Namespace: infraNamespace}, &deployment))
+	assert.Equal(t, "stale", deployment.Spec.Selector.MatchLabels["app"], "the stale render must be left untouched")
+	require.Len(t, deployment.OwnerReferences, 1)
+	assert.Equal(t, types.UID("gw-uid-stale"), deployment.OwnerReferences[0].UID,
+		"the stale render must not be re-owned by the new Gateway")
+}
+
+// TestGatewayInfraReconciler_ForeignGatewayKindGetsRenameRemediation pins that
+// the stale-render remediation is scoped to THIS API group: an object owned by
+// a foreign CRD that is also kinded "Gateway" but in another group is a
+// genuinely foreign object, so it is refused with the "rename" hint, not the
+// "delete the orphan" one (which is only correct for our own stale renders).
+func TestGatewayInfraReconciler_ForeignGatewayKindGetsRenameRemediation(t *testing.T) {
+	t.Parallel()
+
+	foreign := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cf-proxy-edge", Namespace: infraNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "other.example.com/v1",
+				Kind:       "Gateway",
+				Name:       "edge",
+				UID:        "foreign-uid",
+				Controller: new(true),
+			}},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foreign"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "foreign"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "other/app:v1"}}},
+			},
+		},
+	}
+
+	objects := append(infraFixtures(t), foreign)
+	reconciler := newInfraReconciler(t, objects...)
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "edge", Namespace: infraNamespace},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errRefusedAdoption)
+	assert.Contains(t, err.Error(), "rename the conflicting object",
+		"a foreign Gateway-kind in another API group is not our stale render")
+	assert.NotContains(t, err.Error(), "delete the orphaned")
+}
+
 // TestGatewayInfraReconciler_RefusesForeignAuthSecret pins that the
 // generated-auth-Secret bootstrap never adopts a pre-existing Secret it does
 // not own. Wiring the data plane's push auth to material the controller

--- a/internal/controller/gatewayconfig_watch_test.go
+++ b/internal/controller/gatewayconfig_watch_test.go
@@ -44,8 +44,22 @@ func TestGatewayConfigToGateways(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "team-a"},
 		Spec:       gatewayv1.GatewaySpec{GatewayClassName: "cloudflare-tunnel"},
 	}
+	// Matches the event by Name but points at a foreign Group/Kind — a different
+	// CRD that happens to share the name. It must NOT be enqueued: the mapper
+	// resolves only this controller's GatewayConfig parametersRef.
+	wrongGroupKind := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "foreign", Namespace: "team-a"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cloudflare-tunnel",
+			Infrastructure: &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &gatewayv1.LocalParametersReference{
+					Group: "other.example.com", Kind: "SomeOtherConfig", Name: "edge-config",
+				},
+			},
+		},
+	}
 
-	fakeClient := setupGatewayFakeClient(referencing, otherName, shared)
+	fakeClient := setupGatewayFakeClient(referencing, otherName, shared, wrongGroupKind)
 	reconciler := &GatewayReconciler{Client: fakeClient, Scheme: fakeClient.Scheme()}
 
 	gwConfig := &v1alpha1.GatewayConfig{

--- a/internal/controller/route_partition_union_test.go
+++ b/internal/controller/route_partition_union_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,4 +60,59 @@ func TestUnionPartitionRoutes(t *testing.T) {
 	assert.ElementsMatch(t, []string{"shared-r", "same-tunnel-r"}, routeNames(byKey["default/same-tunnel-gw"].HTTPRoutes))
 	assert.ElementsMatch(t, []string{"tenant-r"}, routeNames(byKey["default/tenant-gw"].HTTPRoutes),
 		"a distinct tunnel keeps its disjoint config — the isolation property")
+}
+
+// TestUnionPartitionRoutes_SameTunnelSiblingsShareReadOnlyBacking pins the
+// zero-copy contract unionPartitionRoutes documents: same-tunnel partitions
+// share ONE union backing slice rather than each getting its own copy. The
+// slices are READ-ONLY downstream — an in-place sort/filter on one would
+// corrupt the sibling. Run under -race: concurrent reads of the aliased slices
+// mirror the real push (the edge load-balances a tunnel's requests across all
+// its connectors, so each same-tunnel partition's config is pushed
+// concurrently), so a future change that mutates a partition's slice in place
+// on that path would data-race here. Switching to per-partition copies would
+// break the identity check below, forcing a conscious decision.
+func TestUnionPartitionRoutes_SameTunnelSiblingsShareReadOnlyBacking(t *testing.T) {
+	t.Parallel()
+
+	sharedTunnel := "shared-tunnel"
+
+	partitions := []routePartition{
+		{
+			Key:        sharedPartitionKey,
+			HTTPRoutes: gatewayv1HTTPRoutes("shared-r"),
+		},
+		{
+			Key:        "default/same-tunnel-gw",
+			PerGateway: &config.PerGatewayConfig{ResolvedConfig: config.ResolvedConfig{TunnelID: sharedTunnel}},
+			HTTPRoutes: gatewayv1HTTPRoutes("same-tunnel-r"),
+		},
+	}
+
+	unioned := unionPartitionRoutes(partitions, sharedTunnel)
+	require.Len(t, unioned, 2)
+
+	first, second := unioned[0].HTTPRoutes, unioned[1].HTTPRoutes
+	require.NotEmpty(t, first)
+	require.Len(t, second, len(first))
+
+	// Identical element addresses prove both partitions point at one backing
+	// slice — the deliberate aliasing.
+	assert.Same(t, &first[0], &second[0], "same-tunnel partitions must share the union backing slice")
+
+	var wg sync.WaitGroup
+
+	for _, routes := range [][]gatewayv1.HTTPRoute{first, second} {
+		wg.Add(1)
+
+		go func(rs []gatewayv1.HTTPRoute) {
+			defer wg.Done()
+
+			for i := range rs {
+				_ = rs[i].Name
+			}
+		}(routes)
+	}
+
+	wg.Wait()
 }

--- a/internal/hostnameownership/cel_vector_test.go
+++ b/internal/hostnameownership/cel_vector_test.go
@@ -35,13 +35,7 @@ func TestCELPolicyMatchesVectors(t *testing.T) {
 
 	suffixExpr, validations := extractCELExpressions(t)
 
-	env, err := cel.NewEnv(
-		cel.Variable("object", cel.DynType),
-		cel.Variable("namespaceObject", cel.DynType),
-		cel.Variable("variables", cel.DynType),
-		ext.Strings(),
-	)
-	require.NoError(t, err)
+	env := newCELTestEnv(t)
 
 	suffixPrg := compileCEL(t, env, suffixExpr)
 
@@ -130,6 +124,23 @@ func buildRouteObject(hostnames []string) map[string]any {
 	return map[string]any{"spec": spec}
 }
 
+// newCELTestEnv builds the CEL environment the rendered policy expressions are
+// compiled against: the same variables and string extensions the apiserver
+// exposes to a ValidatingAdmissionPolicy.
+func newCELTestEnv(t *testing.T) *cel.Env {
+	t.Helper()
+
+	env, err := cel.NewEnv(
+		cel.Variable("object", cel.DynType),
+		cel.Variable("namespaceObject", cel.DynType),
+		cel.Variable("variables", cel.DynType),
+		ext.Strings(),
+	)
+	require.NoError(t, err)
+
+	return env
+}
+
 // vapPolicyDoc is the subset of the rendered ValidatingAdmissionPolicy the test
 // reads.
 type vapPolicyDoc struct {
@@ -139,22 +150,22 @@ type vapPolicyDoc struct {
 			Expression string `yaml:"expression"`
 		} `yaml:"variables"`
 		Validations []struct {
-			Expression string `yaml:"expression"`
+			Expression        string `yaml:"expression"`
+			MessageExpression string `yaml:"messageExpression"`
 		} `yaml:"validations"`
 	} `yaml:"spec"`
 }
 
-// extractCELExpressions reads the chart template, renders away the single
-// Helm directive the expressions carry (the label key), drops the remaining
-// control directives, and returns the suffix-variable expression plus the
-// ordered validation expressions — the EXACT strings the chart ships.
-func extractCELExpressions(t *testing.T) (string, []string) {
+// loadPolicyDoc reads the chart template, renders away the single Helm
+// directive the expressions carry (the label key), drops the remaining control
+// directives, and unmarshals the first YAML document (the policy; the binding
+// follows after "---") into vapPolicyDoc.
+func loadPolicyDoc(t *testing.T) vapPolicyDoc {
 	t.Helper()
 
 	raw, err := os.ReadFile(vapTemplatePath)
 	require.NoError(t, err)
 
-	// The policy is the first YAML document; the binding follows after "---".
 	src := strings.SplitN(string(raw), "\n---", 2)[0]
 	src = strings.ReplaceAll(src, `{{ .Values.hostnameOwnershipPolicy.labelKey | quote }}`, `"`+celTestLabelKey+`"`)
 	src = strings.ReplaceAll(src, `{{ .Values.hostnameOwnershipPolicy.labelKey }}`, celTestLabelKey)
@@ -164,7 +175,7 @@ func extractCELExpressions(t *testing.T) (string, []string) {
 	// include) so the policy document parses as plain YAML.
 	var kept []string
 
-	for _, line := range strings.Split(src, "\n") {
+	for line := range strings.SplitSeq(src, "\n") {
 		if strings.Contains(line, "{{") {
 			continue
 		}
@@ -174,6 +185,55 @@ func extractCELExpressions(t *testing.T) (string, []string) {
 
 	var policy vapPolicyDoc
 	require.NoError(t, yaml.Unmarshal([]byte(strings.Join(kept, "\n")), &policy))
+
+	return policy
+}
+
+// TestCELMessageExpressionsCompile pins the denial-message expressions. The
+// verdict expressions are exercised by TestCELPolicyMatchesVectors, but a typo
+// in a messageExpression would surface only at live admission (it is the
+// human-facing reason string, not the allow/deny decision). Compile each
+// non-empty messageExpression in the same environment and assert it evaluates
+// to a string so a malformed one fails in CI instead.
+func TestCELMessageExpressionsCompile(t *testing.T) {
+	t.Parallel()
+
+	policy := loadPolicyDoc(t)
+	env := newCELTestEnv(t)
+
+	input := map[string]any{
+		"object":          buildRouteObject([]string{"app.example.com"}),
+		"namespaceObject": buildNamespaceObject("example.com"),
+		"variables":       map[string]any{"suffix": "example.com"},
+	}
+
+	compiled := 0
+
+	for _, validation := range policy.Spec.Validations {
+		if validation.MessageExpression == "" {
+			continue
+		}
+
+		prg := compileCEL(t, env, validation.MessageExpression)
+
+		out, _, err := prg.Eval(input)
+		require.NoError(t, err)
+
+		_, ok := out.Value().(string)
+		require.True(t, ok, "a messageExpression must evaluate to a string: %s", validation.MessageExpression)
+
+		compiled++
+	}
+
+	require.Positive(t, compiled, "the policy must ship at least one messageExpression to compile")
+}
+
+// extractCELExpressions returns the suffix-variable expression plus the ordered
+// validation expressions — the EXACT strings the chart ships.
+func extractCELExpressions(t *testing.T) (string, []string) {
+	t.Helper()
+
+	policy := loadPolicyDoc(t)
 
 	var suffix string
 

--- a/internal/hostnameownership/selector_parity_test.go
+++ b/internal/hostnameownership/selector_parity_test.go
@@ -1,0 +1,113 @@
+package hostnameownership_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/lexfrei/cloudflare-tunnel-gateway-controller/internal/hostnameownership"
+)
+
+// TestNamespaceSelectorParity_MatchesLabelSelectorAsSelector pins the one
+// parity axis the shared Vectors() table does not cover: namespace-selector
+// scoping. The CEL ValidatingAdmissionPolicy binding consumes the raw
+// metav1.LabelSelector (matchResources.namespaceSelector), while the controller
+// consumes the kubectl-syntax string the chart's labelSelectorString helper
+// renders, parsed by labels.Parse in hostnameownership.New. Those two paths
+// must scope the SAME namespaces, or a namespace policed at admission could go
+// unpoliced by the controller (or vice versa).
+//
+// The Helm helper is expected to emit the canonical kubectl form of the
+// selector — exactly metav1.LabelSelectorAsSelector(ls).String() — which the
+// helm-unittest in deployment_test.yaml pins as a literal string. This test
+// owns the Go half: that canonical form, parsed by the controller's real path
+// (New -> labels.Parse -> selector.Matches via Evaluate), scopes identically to
+// metav1.LabelSelectorAsSelector. The literal string both sides agree on is the
+// cross-language bridge.
+func TestNamespaceSelectorParity_MatchesLabelSelectorAsSelector(t *testing.T) {
+	t.Parallel()
+
+	// A non-trivial selector exercising every matchExpression operator plus a
+	// matchLabels term — the axes a naive string flattener gets wrong.
+	selectors := []struct {
+		name     string
+		selector *metav1.LabelSelector
+	}{
+		{
+			name:     "matchLabels only",
+			selector: &metav1.LabelSelector{MatchLabels: map[string]string{"tenancy": "enforced"}},
+		},
+		{
+			name: "In",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "team", Operator: metav1.LabelSelectorOpIn, Values: []string{"a", "b"}},
+			}},
+		},
+		{
+			name: "NotIn",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
+			}},
+		},
+		{
+			name: "Exists",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "tenancy", Operator: metav1.LabelSelectorOpExists},
+			}},
+		},
+		{
+			name: "DoesNotExist",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "system", Operator: metav1.LabelSelectorOpDoesNotExist},
+			}},
+		},
+		{
+			name: "matchLabels and matchExpressions combined",
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"tenancy": "enforced"},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
+				},
+			},
+		},
+	}
+
+	// Candidate namespace label sets, deliberately WITHOUT the ownership label
+	// so that "in selector scope" maps cleanly to "policed -> denied" and "out
+	// of scope" to "not policed -> allowed", isolating the scoping decision.
+	candidates := []labels.Set{
+		{},
+		{"tenancy": "enforced"},
+		{"team": "a"},
+		{"team": "c"},
+		{"system": "true"},
+		{"kubernetes.io/metadata.name": "kube-system"},
+		{"kubernetes.io/metadata.name": "team-x", "tenancy": "enforced"},
+	}
+
+	for _, tc := range selectors {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			want, err := metav1.LabelSelectorAsSelector(tc.selector)
+			require.NoError(t, err)
+
+			policy, err := hostnameownership.New(celTestLabelKey, want.String())
+			require.NoError(t, err)
+
+			for _, set := range candidates {
+				inScope := want.Matches(set)
+
+				// A namespace without the ownership label: policed namespaces
+				// (in scope) fail closed; unpoliced ones (out of scope) pass.
+				verdict := policy.Evaluate(map[string]string(set), []gatewayv1.Hostname{"app.example.com"})
+
+				require.Equal(t, inScope, !verdict.Allowed,
+					"selector scope must match metav1.LabelSelectorAsSelector for labels %v", set)
+			}
+		})
+	}
+}

--- a/internal/proxy/shadow.go
+++ b/internal/proxy/shadow.go
@@ -313,10 +313,14 @@ func shadowBasis(winner, loser *shadowClaimant) string {
 	}
 
 	if winner.provenance.CreationTimestamp.Equal(&loser.provenance.CreationTimestamp) {
-		winnerKey := winner.provenance.Namespace + "/" + winner.provenance.Name
-		loserKey := loser.provenance.Namespace + "/" + loser.provenance.Name
-
-		if winnerKey < loserKey {
+		// Compare namespace then name as SEPARATE fields, matching
+		// sortRoutesByPrecedence (which decides the real flatIdx). Concatenating
+		// "namespace/name" and comparing the joined strings diverges when a
+		// namespace contains '-' or a name contains '.' — both sort below the
+		// '/' separator, so the joined compare can disagree with the field-wise
+		// order the winner was actually chosen by.
+		wns, lns := winner.provenance.Namespace, loser.provenance.Namespace
+		if wns < lns || (wns == lns && winner.provenance.Name < loser.provenance.Name) {
 			return "alphabetical {namespace}/{name} precedence"
 		}
 	}

--- a/internal/proxy/shadow_test.go
+++ b/internal/proxy/shadow_test.go
@@ -114,6 +114,34 @@ func TestDetectShadowedRules_TimestampTieUsesNamespaceName(t *testing.T) {
 	assert.Contains(t, diags[0].Message, "alphabetical {namespace}/{name}")
 }
 
+// TestDetectShadowedRules_TimestampTieComparesNamespaceFieldWise pins that the
+// {namespace}/{name} reconstruction compares namespace and name as SEPARATE
+// fields, exactly like sortRoutesByPrecedence (which decides the real flatIdx).
+// A concatenated "namespace/name" compare diverges here: '-' (0x2D) sorts below
+// '/' (0x2F), so namespace "a" beats "a-b" field-wise (the prefix is shorter)
+// yet "a/app" > "a-b/app" as concatenated strings. The winner holds the lower
+// flatIdx by the field-wise rule, so the basis must read as the alphabetical
+// precedence, not fall through to "earlier position in the generated config".
+func TestDetectShadowedRules_TimestampTieComparesNamespaceFieldWise(t *testing.T) {
+	t.Parallel()
+
+	cfg := &proxy.Config{
+		Rules: []proxy.RouteRule{
+			{Hostnames: []string{"app.example.com"}, Matches: []proxy.RouteMatch{pathExactMatch("/v1")}},
+			{Hostnames: []string{"app.example.com"}, Matches: []proxy.RouteMatch{pathExactMatch("/v1")}},
+		},
+		Provenance: []proxy.RuleProvenance{
+			prov("HTTPRoute", "a", "app", shadowT0, 0),
+			prov("HTTPRoute", "a-b", "app", shadowT0, 0),
+		},
+	}
+
+	diags := proxy.DetectShadowedRules(cfg)
+	require.Len(t, diags, 1)
+	assert.Equal(t, "a-b", diags[0].Namespace, "the diagnostic lands on the field-wise loser")
+	assert.Contains(t, diags[0].Message, "alphabetical {namespace}/{name}")
+}
+
 // TestDetectShadowedRules_FlatIndexTieReportsConfigOrder pins that when the
 // winner is decided purely by flattened index — same kind, same timestamp, and
 // the winner sorts alphabetically AFTER the loser — the basis is reported as

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -71,7 +71,15 @@ const (
 	// length cap; exported for consumers reasoning about truncated
 	// GatewayLabel values.
 	MaxDNSLabelLength = 63
-	nameHashLength    = 8
+	// nameHashLength is the hex width of the disambiguating hash suffix appended
+	// to overflowing/sanitized names (truncateName). 8 hex = 32 bits: by the
+	// birthday bound a 50% collision needs ~2^16 (~65k) distinct hashed names,
+	// and only names that overflow 63 chars or carry non-DNS characters are
+	// hashed at all — far above the realistic per-namespace Gateway cardinality.
+	// Do NOT widen this: the suffix is part of every rendered object's name, so
+	// changing it renames (and so recreates) every per-Gateway Deployment,
+	// Service, and NetworkPolicy in place.
+	nameHashLength = 8
 
 	tunnelTokenKey = "tunnel-token"
 	authTokenKey   = "auth-token"

--- a/internal/tunnel/bootstrap.go
+++ b/internal/tunnel/bootstrap.go
@@ -160,7 +160,6 @@ func StartTunnel(ctx context.Context, cfg *Config) error {
 	connectedSignal := cfdsignal.New(make(chan struct{}))
 	reconnectCh := make(chan supervisor.ReconnectSignal, defaultHAConnections)
 	graceShutdownC := graceChannel(ctx, cfg.GraceShutdownC)
-	tunnelCfg.GracePeriod = resolveGracePeriod(cfg.GracePeriod)
 
 	go waitConnected(ctx, connectedSignal, logger, cfg.OnConnected)
 
@@ -274,6 +273,12 @@ func buildOrchestrator(
 
 		logger.Info("in-process origin proxy enabled")
 	}
+
+	// Apply the operator-configured drain window over buildProtocolAndClient's
+	// default here, where it is observable in the returned tunnelCfg — keeping
+	// it out of StartTunnel (which returns only an error) so a regression
+	// dropping it fails a test instead of silently ignoring PROXY_GRACE_PERIOD.
+	tunnelCfg.GracePeriod = resolveGracePeriod(cfg.GracePeriod)
 
 	return orchestrator, tunnelCfg, nil
 }

--- a/internal/tunnel/bootstrap_internal_test.go
+++ b/internal/tunnel/bootstrap_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -552,21 +553,26 @@ func TestBuildOrchestrator_EmptyProxyURL_NilOriginProxy(t *testing.T) {
 	assert.Contains(t, err.Error(), "build tunnel config")
 }
 
-// TestBuildOrchestrator_ExplicitProxyURL_NilOriginProxy verifies buildOrchestrator
-// passes cfg.ProxyURL through when OriginProxy is nil.
-// Uses an invalid URL scheme that fails at ingress validation, before prometheus.
+// TestBuildOrchestrator_ExplicitProxyURL_NilOriginProxy_InvalidScheme verifies
+// buildOrchestrator passes cfg.ProxyURL through to ingress parsing when
+// OriginProxy is nil: a non-empty but malformed URL fails inside
+// buildCatchAllIngress (before the prometheus-registering origin services), so
+// no fresh registerer is needed. Distinct from the empty-URL case — it pins the
+// explicit pass-through path, not just the absent-URL one.
 func TestBuildOrchestrator_ExplicitProxyURL_NilOriginProxy_InvalidScheme(t *testing.T) {
 	t.Parallel()
 
 	token := newTestToken()
 	cfg := &Config{
-		ProxyURL:    "",
+		ProxyURL:    "://bad",
 		OriginProxy: nil,
 	}
 
 	_, _, err := buildOrchestrator(t.Context(), cfg, token, slog.Default())
 
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse catch-all ingress",
+		"a malformed explicit ProxyURL must fail in ingress parsing, proving it was passed through")
 }
 
 // TestBuildTunnelConfig_EmptyProxyURL_ErrorMessage verifies the exact error
@@ -805,6 +811,28 @@ func TestBuildOrchestrator_SuccessPath_NilOriginProxy(t *testing.T) {
 		assert.NotNil(t, orchestrator)
 		assert.NotNil(t, tunnelCfg)
 		assert.Nil(t, orchestrator.OverrideProxy, "OverrideProxy should be nil when OriginProxy is not set")
+	})
+}
+
+// TestBuildOrchestrator_AppliesResolvedGracePeriod pins that buildOrchestrator
+// applies the configured (and clamped) grace period to the returned tunnel
+// config. The assignment used to live in StartTunnel AFTER buildOrchestrator,
+// where no test reached it — a regression dropping it would silently ignore
+// PROXY_GRACE_PERIOD. NOT parallel: replaces prometheus.DefaultRegisterer.
+func TestBuildOrchestrator_AppliesResolvedGracePeriod(t *testing.T) {
+	token := newTestToken()
+	cfg := &Config{
+		ProxyURL:    "http://localhost:8080",
+		GracePeriod: 5 * time.Second,
+	}
+
+	withFreshRegisterer(func() {
+		_, tunnelCfg, err := buildOrchestrator(t.Context(), cfg, token, slog.Default())
+
+		require.NoError(t, err)
+		require.NotNil(t, tunnelCfg)
+		assert.Equal(t, 5*time.Second, tunnelCfg.GracePeriod,
+			"the configured grace period must be applied to the returned tunnel config")
 	})
 }
 


### PR DESCRIPTION
# Pull Request

## Summary

A batch of non-blocking follow-ups raised during review of the multi-tenant / per-Gateway isolation work. All are test-completeness gaps, diagnostic-message corrections, a controller-gen CRD regen, and one upgrade-doc clarification — grouped into one PR so the heavy pre-merge gates run once.

## Changes

- **Shadow precedence basis** now compares namespace and name as separate fields, matching the actual route precedence sort. The previous joined-string compare could diverge for a namespace containing `-` (which sorts below `/`); winner/loser attribution was always correct, only the explanatory wording could read wrong.
- **GatewayConfig → Gateway watch mapper** now matches the parametersRef Group/Kind, not just the name, so a foreign CRD that shares a name is not enqueued.
- **Per-Gateway adoption refusal** distinguishes a stale render of a re-created same-name Gateway (remediation: delete the orphan) from a genuinely foreign object (remediation: rename), scoped to this API group.
- **Grace-period resolution** moved into `buildOrchestrator`, where it is observable on the returned tunnel config, closing a test blind spot that let a dropped assignment go unnoticed.
- **CRDs regenerated** with controller-gen v0.21.0 (the GatewayClassConfig CRD was still annotated v0.14.0). This also dropped a stale tracker reference that the regen would otherwise have surfaced into a shipped CRD description, and adds a test guarding shipped CRDs against issue/PR references.
- **Behaviour-pinning tests**: CEL `messageExpression` compilation, CEL ↔ controller namespace-selector parity, the same-tunnel union shared-slice read-only contract (under `-race`), per-Gateway TunnelID canonicalization, and the transient Deployment-read `Programmed` branch.
- **Upgrade guide** raises the strict-CNI proxy-readiness break to a prominent warning — a more likely silent failure than the Prometheus scrape note that was already prominent.

## Testing

- [x] All tests pass locally (`go test ./...`, plus `-tags envtest`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

## Documentation

- [ ] README updated (if needed)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed)

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

Closes #497, #498, #499, #500, #501.

Also green locally: `helm unittest` (268), `helm lint`, `helm-docs` (no README drift), `mkdocs build --strict`. The Gateway API conformance suite (GATEWAY-HTTP + GATEWAY-GRPC) and the custom e2e suite both pass against a live tunnel on a kind cluster.

README is intentionally unchanged: the only user-observable change is the v3.0 → v3.1 upgrade-guide clarification, updated in this PR. Everything else is tests, code comments, a generated-artifact regen, or internal diagnostics — nothing that alters documented product behaviour. CLAUDE.md is unchanged: no workflow or standards changed.
