### PR TITLE
ci(renovate): extend shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":semanticCommits",
-    ":semanticCommitTypeAll(chore)",
-    ":prHourlyLimitNone",
-    ":prConcurrentLimitNone",
-    "helpers:pinGitHubActionDigests"
+    "github>lexfrei/renovate-config"
   ],
   "labels": [
     "area/dependencies"


### PR DESCRIPTION
Replace the hand-copied base presets (`config:recommended`, `:semanticCommits`, PR limits, `helpers:pinGitHubActionDigests`) with a single `github>lexfrei/renovate-config` reference, so policy changes propagate from one place and the repo picks up `docker:enableMajor`. Repo-specific rules stay layered on top: `area/dependencies` label, `gomodVendor`, the Go-toolchain custom manager, and the pinned Go base image.