### PR TITLE
ci(docs): verify publication reached the live site

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,6 +35,10 @@ jobs:
   deploy:
     name: Deploy Documentation
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      alias: ${{ steps.version.outputs.alias }}
+      cname: ${{ steps.version.outputs.cname }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -72,6 +76,10 @@ jobs:
             echo "alias=" >> "$GITHUB_OUTPUT"
           fi
 
+          # Emit the live-site hostname from source so the verify job follows the
+          # domain automatically if docs/CNAME ever changes.
+          echo "cname=$(tr -d '[:space:]' < docs/CNAME)" >> "$GITHUB_OUTPUT"
+
       - name: Deploy with mike
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -84,28 +92,108 @@ jobs:
             mike deploy --push "${VERSION}"
           fi
 
-      - name: Publish versionless 404 redirect to gh-pages root
+      - name: Publish 404 redirect and build marker to gh-pages
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
 
-          # mike deploy --push lays each version under its own gh-pages subdir
-          # but never writes a root 404.html. GitHub Pages serves <root>/404.html
-          # for any unmatched path, so copy our redirect there -- it sends
-          # versionless links and stale bookmarks to their /latest/ equivalent.
-          # Done in a throwaway worktree so the main checkout's branch is
-          # untouched; idempotent, so steady-state runs push nothing.
-          cp docs/404.html "${RUNNER_TEMP}/404.html"
+          # mike deploy --push lays each version under its own gh-pages subdir but
+          # never writes two things this workflow needs, so add them here in one
+          # throwaway worktree (the main checkout's branch stays untouched):
+          #
+          # 1. A root 404.html. GitHub Pages serves <root>/404.html for any unmatched
+          #    path, so our redirect sends versionless links and stale bookmarks to
+          #    their /latest/ equivalent.
+          # 2. A per-version build-sha.txt recording the commit this deploy was built
+          #    from. It is written only into the deployed version's dir; mike's default
+          #    symlink aliases (e.g. latest -> 3.2.0) expose it, so the verify job reads
+          #    it through both the version and its alias. This depends on mike's
+          #    alias-type=symlink default -- a switch to redirect aliases would make
+          #    <alias>/build-sha.txt a 404 and must update the verify job's alias check.
+          #    The job polls this marker to confirm the NEW content actually reached the
+          #    live site -- catching a stuck Pages deployment that leaves gh-pages
+          #    correct but the site stale.
 
           git fetch origin gh-pages
           git worktree add "${RUNNER_TEMP}/ghp" origin/gh-pages
-          cp "${RUNNER_TEMP}/404.html" "${RUNNER_TEMP}/ghp/404.html"
-          git -C "${RUNNER_TEMP}/ghp" add 404.html
+
+          cp docs/404.html "${RUNNER_TEMP}/ghp/404.html"
+          printf '%s' "${GITHUB_SHA}" > "${RUNNER_TEMP}/ghp/${VERSION}/build-sha.txt"
+          git -C "${RUNNER_TEMP}/ghp" add 404.html "${VERSION}/build-sha.txt"
 
           if git -C "${RUNNER_TEMP}/ghp" diff --cached --quiet; then
-            echo "404.html already current at gh-pages root"
+            echo "gh-pages root already current"
           else
-            git -C "${RUNNER_TEMP}/ghp" commit -m "docs: publish versionless 404 redirect to site root"
+            git -C "${RUNNER_TEMP}/ghp" commit -m "docs: publish 404 redirect and build marker for ${VERSION}"
             git -C "${RUNNER_TEMP}/ghp" push origin HEAD:gh-pages
           fi
 
           git worktree remove --force "${RUNNER_TEMP}/ghp"
+
+  verify:
+    name: Verify publication
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions: {}
+    timeout-minutes: 15   # defense-in-depth; the poll loop self-bounds at 720s
+    steps:
+      - name: Poll the live site until it serves this deploy
+        env:
+          CNAME: ${{ needs.deploy.outputs.cname }}
+          VERSION: ${{ needs.deploy.outputs.version }}
+          ALIAS: ${{ needs.deploy.outputs.alias }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # 'mike deploy --push' only proves the gh-pages BRANCH was updated; the
+          # actual publish is a separate GitHub-managed 'pages build and deployment'
+          # that this workflow never waits on. When that deployment stalls (observed
+          # 2026-07-02: release 3.2.0 pushed to gh-pages fine, but the Pages deploy
+          # sat in deployment_queued for 10 min and timed out), the branch is correct
+          # yet the live site stays stale -- and every Documentation run still reports
+          # success. Poll the per-deploy build marker so a non-converging publish turns
+          # this job red instead of lying green.
+
+          # The Pages deployment's own ceiling is ~10 min; add margin because the mike
+          # push and the marker push each trigger a deployment and they queue in order.
+          budget_seconds=720
+          interval=15
+          deadline=$(( $(date +%s) + budget_seconds ))
+
+          # A path serves this exact deploy once its build-sha.txt equals the commit
+          # the workflow built from. Checking the alias too (e.g. latest) proves it was
+          # repointed to this version, not just that some old copy still answers.
+          #
+          # No cache-busting here on purpose: GitHub Pages fronts the site with Fastly,
+          # which ignores both a ?cb= query string (not part of its cache key) and a
+          # client Cache-Control: no-cache. Freshness instead comes from GitHub purging
+          # that Fastly cache when a Pages deployment completes. So while a deploy is
+          # stuck -- this job's whole reason to exist -- the edge keeps serving the old
+          # marker (or a 404 for a brand-new version dir) and we stay red; the moment it
+          # completes, the purge lets the next poll read the new SHA and we go green.
+          serves() {
+            local path="$1" got
+            # -fs (not -fsS): a 404 while a new version dir is still converging is
+            # expected, so keep curl quiet and let the loop log progress instead.
+            got="$(curl -fs "https://${CNAME}/${path}/build-sha.txt")" || return 1
+            got="$(printf '%s' "${got}" | tr -d '[:space:]')"
+            [[ "${got}" == "${EXPECTED_SHA}" ]]
+          }
+
+          converged() {
+            serves "${VERSION}" || return 1
+            [[ -z "${ALIAS}" ]] || serves "${ALIAS}"
+          }
+
+          until converged; do
+            if (( $(date +%s) >= deadline )); then
+              echo "::error::https://${CNAME}/${VERSION}/ did not serve build ${EXPECTED_SHA} within ${budget_seconds}s. mike updated gh-pages but the GitHub Pages deployment did not converge (stuck or timed out). Re-run the failed 'pages build and deployment' for gh-pages, then re-run this job."
+              exit 1
+            fi
+            echo "waiting for https://${CNAME} to serve build ${EXPECTED_SHA} for ${VERSION}${ALIAS:+ / ${ALIAS}} (retry in ${interval}s)..."
+            sleep "${interval}"
+          done
+
+          echo "Publication confirmed: https://${CNAME} serves build ${EXPECTED_SHA} for '${VERSION}'${ALIAS:+ (alias ${ALIAS})}."

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -62,29 +62,42 @@ jobs:
 
       - name: Determine version and alias
         id: version
+        env:
+          # Route event inputs through env, never inline ${{ }} in the shell: a
+          # workflow_dispatch caller controls version/alias and inline expansion
+          # would let them inject shell. As env vars they are inert data.
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_ALIAS: ${{ github.event.inputs.alias }}
         run: |
+          set -euo pipefail
+
           # Check if running from a tag (works for both push and workflow_dispatch)
           if [[ "$GITHUB_REF_NAME" == v* ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "alias=latest" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.version }}" != "dev" ]]; then
-            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
-            echo "alias=${{ github.event.inputs.alias }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" && "${INPUT_VERSION}" != "dev" ]]; then
+            echo "version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "alias=${INPUT_ALIAS}" >> "$GITHUB_OUTPUT"
           else
             echo "version=dev" >> "$GITHUB_OUTPUT"
             echo "alias=" >> "$GITHUB_OUTPUT"
           fi
 
           # Emit the live-site hostname from source so the verify job follows the
-          # domain automatically if docs/CNAME ever changes.
-          echo "cname=$(tr -d '[:space:]' < docs/CNAME)" >> "$GITHUB_OUTPUT"
+          # domain automatically if docs/CNAME ever changes. Assign first so a missing
+          # file trips set -e here instead of silently emitting an empty hostname.
+          cname="$(tr -d '[:space:]' < docs/CNAME)"
+          echo "cname=${cname}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy with mike
+        env:
+          # steps.version.outputs.* can carry a workflow_dispatch input; pass via
+          # env so the value stays data and cannot inject shell.
+          VERSION: ${{ steps.version.outputs.version }}
+          ALIAS: ${{ steps.version.outputs.alias }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          ALIAS="${{ steps.version.outputs.alias }}"
-
           if [[ -n "$ALIAS" ]]; then
             mike deploy --push --update-aliases "${VERSION}" "${ALIAS}"
             mike set-default --push latest
@@ -109,8 +122,9 @@ jobs:
           #    from. It is written only into the deployed version's dir; mike's default
           #    symlink aliases (e.g. latest -> 3.2.0) expose it, so the verify job reads
           #    it through both the version and its alias. This depends on mike's
-          #    alias-type=symlink default -- a switch to redirect aliases would make
-          #    <alias>/build-sha.txt a 404 and must update the verify job's alias check.
+          #    alias-type=symlink default. A non-symlink alias-type breaks the alias
+          #    check and must update it: redirect makes <alias>/build-sha.txt a 404,
+          #    and copy snapshots the version dir before this marker is written.
           #    The job polls this marker to confirm the NEW content actually reached the
           #    live site -- catching a stuck Pages deployment that leaves gh-pages
           #    correct but the site stale.
@@ -156,8 +170,9 @@ jobs:
           # success. Poll the per-deploy build marker so a non-converging publish turns
           # this job red instead of lying green.
 
-          # The Pages deployment's own ceiling is ~10 min; add margin because the mike
-          # push and the marker push each trigger a deployment and they queue in order.
+          # The Pages deployment's own ceiling is ~10 min; add margin because a deploy
+          # makes several gh-pages pushes (mike deploy, set-default on a release, the
+          # marker), each triggering a Pages deployment that queues in order.
           budget_seconds=720
           interval=15
           deadline=$(( $(date +%s) + budget_seconds ))
@@ -177,7 +192,10 @@ jobs:
             local path="$1" got
             # -fs (not -fsS): a 404 while a new version dir is still converging is
             # expected, so keep curl quiet and let the loop log progress instead.
-            got="$(curl -fs "https://${CNAME}/${path}/build-sha.txt")" || return 1
+            # Bound each probe so a hung connection can't outlast the poll budget --
+            # the deadline below is only meaningful if no single curl blocks forever.
+            got="$(curl -fs --connect-timeout 10 --max-time 30 \
+              "https://${CNAME}/${path}/build-sha.txt")" || return 1
             got="$(printf '%s' "${got}" | tr -d '[:space:]')"
             [[ "${got}" == "${EXPECTED_SHA}" ]]
           }


### PR DESCRIPTION
## Summary

`mike deploy --push` only proves the `gh-pages` branch was updated. The actual publish is a separate GitHub-managed "pages build and deployment" that this workflow never waited on, so when that deployment stalls the branch is correct but the live site stays stale — and every Documentation run still reports success. That silent failure happened on the 3.2.0 release: `gh-pages` was correct but the Pages deployment timed out, and the live site kept serving the previous version for ~20h under all-green runs.

This adds a post-deploy check that turns the run red when publication does not actually land.

## Changes

- Write a per-version `build-sha.txt` marker (the built commit) into the deployed version's dir, next to the existing root `404.html`, in the same idempotent `gh-pages` worktree commit.
- Add a `verify` job that polls the live site until it serves that marker for both the version and its alias — proving the alias (e.g. `latest`) was repointed, not just that some old copy still answers — and fails within a bounded budget if it never converges. One uniform freshness signal covers both `dev` (master push) and release (tag) deploys.
- The hostname is read from `docs/CNAME`; the job runs with an empty token scope.

## Testing

- [x] `actionlint` clean (it runs shellcheck over the `run:` blocks).
- [x] Poll logic exercised locally against a mock server: passes when the marker matches for version+alias and for `dev`; fails on a stale version, a stale/mis-pointed alias, and a missing marker.
- [x] Confirmed empirically that GitHub Pages' Fastly ignores `?cb=` and client `Cache-Control: no-cache`, so freshness relies on GitHub's purge-on-deploy (documented in the job, no dead cache-busting shipped).
- Go / markdown / helm linters: not applicable — the change touches only `.github/workflows/docs.yaml`.

## Documentation

- Internal CI change with no user-visible surface, so the README / docs-sync requirement does not apply. The `docs/404.html` redirect behavior is unchanged.

## Additional Notes

- It also hardens the pre-existing `workflow_dispatch` path: `version`/`alias` inputs (and the step outputs derived from them) now reach the shell via `env:` instead of inline `${{ }}`, closing a script-injection vector.
- The workflow triggers on `push`/`tags` (not on `.github/**`), so this is a post-merge / post-tag guard, not a PR gate — the next docs push or release exercises it; it can also be smoke-tested via `workflow_dispatch`.
- The workflow-level `concurrency: {group: pages, cancel-in-progress: false}` now covers the `verify` job too, so a genuinely stuck Pages deploy holds the `pages` slot for up to the budget before the next Documentation run proceeds — intended serialization, but a behavior change worth noting.
- The 720s poll budget covers the Pages deployment's ~10 min ceiling with margin for the two queued deploys; worth revisiting after the first real release if a slow-but-healthy deploy ever trips it (a re-run clears a false red).
