### PR TITLE
fix(testing): retry e2e transport failures and dump diagnostics on setup failure

### DIFF
--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -70,6 +70,64 @@ check_tool() {
   command -v "$1" >/dev/null 2>&1 || die "$1 is not installed"
 }
 
+# Dump pod-level cluster state on any failure once the cluster exists. Setup
+# timeouts (helm --wait, rollout status) and test failures alike otherwise die
+# with no record of what the controller and proxy saw -- and in CI the next
+# attempt deletes the cluster, so the moment of failure is the only window to
+# capture it.
+dump_diagnostics() {
+  # Every call is bounded: the dump runs exactly when the cluster may be
+  # half-alive (apiserver accepts TCP but never answers), and an unbounded
+  # kubectl here would burn the remaining CI job timeout.
+  local kdump=(kubectl --context "${KUBE_CONTEXT}" --request-timeout=10s)
+
+  {
+    echo ""
+    echo "==> FAILURE DIAGNOSTICS (cluster '${CLUSTER_NAME}')"
+
+    if ! kubectl --context "${KUBE_CONTEXT}" --request-timeout=5s get nodes >/dev/null 2>&1; then
+      echo "==> Cluster unreachable; skipping diagnostics"
+      return 0
+    fi
+
+    echo "--- pods (all namespaces) ---"
+    "${kdump[@]}" get pods --all-namespaces --output wide || true
+
+    # All namespaces: test-phase failures surface in the test namespaces
+    # (echo backends, per-test routes), not just the controller's.
+    echo "--- events (all namespaces) ---"
+    "${kdump[@]}" get events --all-namespaces --sort-by=.lastTimestamp || true
+
+    echo "--- describe pods (${NAMESPACE}) ---"
+    "${kdump[@]}" describe pods --namespace "${NAMESPACE}" || true
+
+    # Test namespaces too: per-Gateway data planes and echo backends live
+    # there -- "e2e-test" is created by the e2e suite, and the official
+    # conformance suite creates its own "gateway-conformance-*" namespaces.
+    local dump_namespaces ns pod
+    dump_namespaces="$("${kdump[@]}" get namespaces --output name 2>/dev/null \
+      | sed 's|^namespace/||' \
+      | grep -E "^(${NAMESPACE}|${TEST_NAMESPACE}|e2e-test|gateway-conformance)" || true)"
+
+    for ns in ${dump_namespaces}; do
+      for pod in $("${kdump[@]}" get pods \
+          --namespace "${ns}" --output name 2>/dev/null); do
+        echo "--- logs ${ns}/${pod#pod/} (last 300 lines per container) ---"
+        "${kdump[@]}" logs "${pod}" --namespace "${ns}" \
+          --all-containers --tail=300 --prefix || true
+      done
+    done
+  } >&2
+}
+
+on_exit() {
+  local exit_code=$1
+  # 130 = operator interrupt (Ctrl-C), not a failure worth a dump.
+  if [[ "${exit_code}" -ne 0 && "${exit_code}" -ne 130 ]]; then
+    dump_diagnostics
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --test) RUN_TESTS=true ;;
@@ -187,6 +245,9 @@ KINDEOF
 # Verify connectivity
 kubectl --context "${KUBE_CONTEXT}" cluster-info --request-timeout=5s >/dev/null 2>&1 \
   || die "Cannot connect to cluster '${KUBE_CONTEXT}'"
+
+# From here on the cluster exists -- capture its state if anything fails.
+trap 'on_exit $?' EXIT
 
 # --- Step 4: Install Gateway API CRDs (channel selectable via --channel) ---
 info "Installing Gateway API CRDs (${GATEWAY_API_VERSION}, ${CHANNEL})..."

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -108,6 +108,58 @@ type echoHTTPResponse struct {
 	Header     http.Header
 }
 
+// transportAttempts is the total number of tries (first attempt plus retries)
+// for a request that produced no response at all. Single un-retried requests
+// through the live edge flake: a transient latency spike blowing the 15s
+// client timeout or a dropped connection fails a test that a poll loop would
+// have survived. Only transport-level errors are retried -- a received
+// response, whatever its status, IS the routing verdict the tests assert on.
+// All requests target idempotent echo backends, so re-sending is safe.
+const transportAttempts = 3
+
+// transportRetryDelay spaces retry attempts out so an instant failure (e.g.
+// connection reset) does not burn every attempt within milliseconds against
+// an edge that has not had time to recover.
+const transportRetryDelay = 500 * time.Millisecond
+
+// doWithTransportRetry sends req, retrying transport-level failures (no
+// response received) up to transportAttempts times with a short delay between
+// attempts. Requests are built with a nil body, so the same req is safe to
+// re-send. Context cancellation stops the retry loop immediately.
+func doWithTransportRetry(httpClient *http.Client, req *http.Request) (*http.Response, error) {
+	// A body is consumed by the first attempt, so a re-send would silently go
+	// out empty -- such a request gets exactly one try.
+	if req.Body != nil {
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("sending request with unretryable body: %w", err)
+		}
+
+		return resp, nil
+	}
+
+	var lastErr error
+
+	for attempt := range transportAttempts {
+		if attempt > 0 {
+			select {
+			case <-req.Context().Done():
+				return nil, lastErr
+			case <-time.After(transportRetryDelay):
+			}
+		}
+
+		resp, err := httpClient.Do(req)
+		if err == nil {
+			return resp, nil
+		}
+
+		lastErr = err
+	}
+
+	return nil, lastErr
+}
+
 // makeRequest sends a request through the Cloudflare tunnel and parses the
 // echo-basic JSON response.
 func makeRequest(
@@ -132,7 +184,7 @@ func makeRequest(
 		req.Header.Set(key, val)
 	}
 
-	resp, err := httpClient.Do(req)
+	resp, err := doWithTransportRetry(httpClient, req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("sending %s request to %s: %w", method, reqURL, err)
 	}

--- a/test/e2e/request_retry_test.go
+++ b/test/e2e/request_retry_test.go
@@ -1,0 +1,155 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// connKillingServer returns a test server that drops the connection without
+// writing a response for the first failures requests, then serves 200. The
+// returned counter reports how many requests reached the server.
+func connKillingServer(t *testing.T, failures int64) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+
+	var seen atomic.Int64
+
+	// The handler runs on a server goroutine, so it must not call FailNow
+	// (require) -- t.Error marks the test failed without terminating the
+	// wrong goroutine.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if seen.Add(1) <= failures {
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Error("test server response writer must support Hijack")
+
+				return
+			}
+
+			conn, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Errorf("hijacking connection: %v", err)
+
+				return
+			}
+
+			closeErr := conn.Close()
+			if closeErr != nil {
+				t.Errorf("closing hijacked connection: %v", closeErr)
+			}
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	return server, &seen
+}
+
+func TestDoWithTransportRetry_RecoversFromTransientFailures(t *testing.T) {
+	t.Parallel()
+
+	server, seen := connKillingServer(t, transportAttempts-1)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := doWithTransportRetry(server.Client(), req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(transportAttempts), seen.Load(), "every attempt should reach the server")
+}
+
+func TestDoWithTransportRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	t.Parallel()
+
+	server, seen := connKillingServer(t, transportAttempts)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	start := time.Now()
+
+	resp, err := doWithTransportRetry(server.Client(), req) //nolint:bodyclose // no response on error
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, int64(transportAttempts), seen.Load(), "must stop after transportAttempts tries")
+
+	wantDelay := time.Duration(transportAttempts-1) * transportRetryDelay
+	assert.GreaterOrEqual(t, time.Since(start), wantDelay,
+		"attempts must be spaced by transportRetryDelay, not fired back-to-back")
+}
+
+func TestDoWithTransportRetry_NeverRetriesReceivedResponse(t *testing.T) {
+	t.Parallel()
+
+	// Error statuses ARE routing verdicts the e2e tests assert on (fail-closed
+	// tests expect 503s); a received response must never trigger a retry.
+	var seen atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		seen.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := doWithTransportRetry(server.Client(), req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, int64(1), seen.Load(), "a received response must be returned, not retried")
+}
+
+func TestDoWithTransportRetry_NeverRetriesRequestWithBody(t *testing.T) {
+	t.Parallel()
+
+	// A body is consumed by the first attempt; a re-send would go out empty.
+	// Such requests must get exactly one try.
+	server, seen := connKillingServer(t, transportAttempts)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, server.URL, strings.NewReader("payload"))
+	require.NoError(t, err)
+
+	resp, err := doWithTransportRetry(server.Client(), req) //nolint:bodyclose // no response on error
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, int64(1), seen.Load(), "a request with a body must get exactly one attempt")
+}
+
+func TestDoWithTransportRetry_StopsOnContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	server, seen := connKillingServer(t, transportAttempts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := doWithTransportRetry(server.Client(), req) //nolint:bodyclose // no response on error
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int64(0), seen.Load(), "a cancelled context must not burn retry attempts")
+}


### PR DESCRIPTION
# Pull Request

## Summary

Hardens the e2e suite against the two failure classes behind the scheduled e2e alert (#580): single un-retried HTTP requests failing on transient Cloudflare edge latency spikes, and setup failures dying with no record of pod-level state.

The alert's red run combined a transient edge latency spike (three tests each failed on one GET that blew the 15s client timeout, while poll-based checks absorbed the same spikes) with a separate, longer-standing setup problem now tracked in #581. A dispatch re-run confirmed the spike was transient; no code regression was involved.

Closes #580

## Changes

- All e2e HTTP requests now retry transport-level failures (no response received) up to 3 tries, 500ms apart. A received response of any status is never retried, since error statuses are routing verdicts the fail-closed tests assert on; a request with a body gets exactly one try. gRPC and WebSocket paths already have their own poll/retry loops and are unchanged.
- `hack/conformance-setup.sh` now dumps pod-level diagnostics (pods, all-namespace events, pod descriptions, per-container logs for the controller and test namespaces) on any failure after cluster creation. In CI the retry attempt deletes the failed cluster, so the moment of failure is the only window to capture state; until now attempt-1 failures left nothing to diagnose. Every kubectl call in the dump is bounded by a request timeout so a half-alive apiserver cannot hang the failure path.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

The retry helper contract is covered by five new unit tests (recovery, exhaustion with spacing, received-response passthrough, bodied-request single-shot, context cancellation) that run without a cluster. The diagnostics dump was smoke-tested against an unreachable cluster and exercised via shellcheck; the shell area has no test harness, which is a deliberate scope decision for this PR. Full conformance and custom e2e suites were run against a live tunnel on a kind cluster.

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

Docs exemption: both changes are test-infrastructure only (e2e client, setup script failure path); nothing user-observable changed, so README and docs pages stay as-is.

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

The diagnostics dump is the unblock for #581: the next attempt-1 failure in the scheduled workflow will leave pod-level evidence instead of a bare helm timeout.
