### PR TITLE
test(conformance): stop claiming the BackendTLSPolicy family

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -90,9 +90,15 @@ func TestGatewayAPIConformance(t *testing.T) {
 		// non-regression rather than tuned — see docs/development/testing.md
 		// "Known conformance flakes" and kubernetes-sigs/gateway-api#4933.
 		features.SupportHTTPRouteRequestPercentageMirror,
-		features.SupportBackendTLSPolicy,
-		features.SupportBackendTLSPolicySANValidation,
-		features.SupportGatewayBackendClientCertificate,
+		// BackendTLSPolicy (+ its SAN-validation and
+		// GatewayBackendClientCertificate siblings) is implemented but NOT
+		// claimed for conformance. Every one of its v1.6.1 tests is gated on
+		// SupportBackendTLSPolicy, whose parent "BackendTLSPolicy" test needs an
+		// in-cluster HTTPS listener for the Re-encrypt case that edge-terminated
+		// TLS cannot provide. Per gateway-api maintainer guidance, a feature
+		// whose top-level test cannot run is not claimed even when the sibling
+		// tests pass, so the whole family stays in unsupportedFeatures. The
+		// feature itself works end to end; see docs/gateway-api/limitations.md.
 		features.SupportHTTPRouteCORS,
 		features.SupportHTTPRouteNamedRouteRule,
 
@@ -270,18 +276,6 @@ func conformanceSkipTests() []string {
 		"MeshHTTPRouteSchemeRedirect",
 		"MeshHTTPRouteSimpleSameNamespace",
 		"MeshHTTPRouteWeight",
-
-		// BackendTLSPolicy: the main test exercises Re-encrypt against the
-		// "same-namespace-with-https-listener" Gateway; Cloudflare terminates
-		// TLS at the edge so HTTPS listeners are not supported (see the
-		// HTTPRouteHTTPSListener skip above) and the parent test would fail on
-		// its first sub-test. The subsequent HTTP sub-tests are covered by the
-		// HTTPRoute_ extended suite. ConflictResolution is newly enabled this
-		// revision — the controller now emits Conflicted on losing policies
-		// per GEP-713 — alongside the previously-enabled
-		// InvalidCACertificateRef / InvalidKind / ObservedGenerationBump /
-		// SANValidation sub-tests.
-		"BackendTLSPolicy",
 
 		// Gateway features not applicable to tunnel architecture.
 		"GatewayStaticAddresses",


### PR DESCRIPTION
## Summary

The BackendTLSPolicy family (`BackendTLSPolicy`, `BackendTLSPolicySANValidation`, `GatewayBackendClientCertificate`) is implemented but can't be claimed for Gateway API conformance: every one of its v1.6.1 tests is gated on `SupportBackendTLSPolicy`, whose parent test needs an in-cluster HTTPS listener for the re-encrypt case. This controller terminates TLS at the Cloudflare edge, so that test can't run. A feature whose top-level test can't run shouldn't be claimed even when its siblings pass, so this drops the three from the conformance `SupportedFeatures` and removes the now-dead `BackendTLSPolicy` skip entry.

The feature still works end to end; only the conformance claim changes.

## Changes

- Remove `SupportBackendTLSPolicy`, `SupportBackendTLSPolicySANValidation`, and `SupportGatewayBackendClientCertificate` from the conformance `SupportedFeatures`, with a comment explaining why.
- Remove the now-dead `BackendTLSPolicy` entry from `conformanceSkipTests()` (its tests no longer run once the feature is undeclared).

## Testing

- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
- [x] Conformance guards pass (`TestGRPCConformanceTestsRunThroughTunnelClient`, `TestStaleSkipsStayLifted`) and the package builds under `-tags conformance`

## Documentation

- [x] No user-facing docs change: the feature still works and is still documented as supported; only the conformance-report claim changes (test config)

## Additional Notes

Change is under the `conformance` build tag, so the default `go test ./...` suite does not compile this file and is unaffected. Context and upstream suite discussion: kubernetes-sigs/gateway-api#4945.
