### PR TITLE
fix(proxy): retry the tunnel bootstrap dial instead of exiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The controller runs an in-process L7 reverse proxy inside the cloudflared proces
 
 See [L7 Proxy Architecture](https://cf.k8s.lex.la/latest/development/architecture/) for full details.
 
+If the tunnel's initial connection to the Cloudflare edge fails (for example, cluster DNS not yet reachable right after a node reboot), the proxy retries with backoff and reports NotReady instead of restarting — see [Proxy Pod Stuck NotReady After a Restart](https://cf.k8s.lex.la/latest/operations/troubleshooting/#proxy-pod-stuck-notready-after-a-restart).
+
 ## Quick Start
 
 ```bash

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -202,7 +202,13 @@ func runTunnelMode(logger *slog.Logger, token string) {
 
 	logger.Info("starting cloudflared tunnel with in-process proxy", "protocol", effectiveProtocol)
 
-	err := tunnel.StartTunnel(ctx, &tunnel.Config{
+	// StartTunnelWithRetry retries a bootstrap-window failure (cluster DNS not
+	// yet reachable, the edge briefly unreachable) with capped backoff instead
+	// of exiting outright -- readiness stays NotReady throughout via
+	// router.SetTunnelConnected, which only fires on an actual connection. A
+	// non-retryable failure (malformed token, unsupported protocol) still
+	// returns immediately below.
+	err := tunnel.StartTunnelWithRetry(ctx, &tunnel.Config{
 		Token:       token,
 		Logger:      logger,
 		OriginProxy: originProxy,
@@ -215,7 +221,7 @@ func runTunnelMode(logger *slog.Logger, token string) {
 		// alive so the connector can unregister and in-flight requests finish.
 		GraceShutdownC: graceC,
 		GracePeriod:    parseEnvDuration(logger, "PROXY_GRACE_PERIOD"),
-	})
+	}, graceC)
 
 	// The daemon has exited (drained, failed, or force-cancelled) — release the
 	// signal goroutine before shutting the config server down.

--- a/docs/development/proxy-architecture.md
+++ b/docs/development/proxy-architecture.md
@@ -40,7 +40,8 @@ internal/
 │
 ├── tunnel/
 │   ├── origin.go      # GatewayOriginProxy (connection.OriginProxy)
-│   └── bootstrap.go   # Tunnel startup, token parsing, supervisor config
+│   ├── bootstrap.go   # Tunnel startup, token parsing, supervisor config
+│   └── retry.go       # StartTunnelWithRetry: bootstrap-dial backoff loop
 │
 └── cmd/proxy/
     └── main.go        # Binary entry point (tunnel mode / standalone mode)
@@ -139,13 +140,15 @@ Weighted random selection using cumulative weight sums:
 - `ProxyHTTP`: Delegates to `proxy.Handler.ServeHTTP`
 - `ProxyTCP`: Returns error (TCPRoute is future work)
 
-`StartTunnel` builds the full cloudflared supervisor config:
+`StartTunnel` (`internal/tunnel/bootstrap.go`) builds the full cloudflared supervisor config:
 
 - Parse tunnel token (base64 JSON)
 - Build edge TLS configs (Cloudflare root CAs + system pool)
 - Create protocol selector (auto: QUIC preferred)
 - **In-process mode** (default): Set `OverrideProxy` on supervisor config to route all requests directly to `proxy.Handler`, bypassing ingress rules entirely
 - Start `supervisor.StartTunnelDaemon`
+
+`cmd/proxy/main.go`'s `runTunnelMode` calls `StartTunnelWithRetry` (`internal/tunnel/retry.go`), not `StartTunnel` directly. It wraps `StartTunnel` in a full-jitter exponential-backoff loop scoped to the bootstrap window — before the tunnel has ever registered a connection with the edge — so a transient dial failure (cluster DNS not yet reachable, the edge briefly unreachable) retries instead of exiting the process. A deterministic, config-derived failure (a token that fails to parse, an unsupported protocol setting) is marked non-retryable and still returns immediately. Because the retry loop can call `StartTunnel` more than once per process, `StartTunnel` also derives a per-attempt child context (`attemptCtx`) for everything it spawns and reuses a process-lifetime `connection.Observer` (`sharedObserver`), so a repeated call cannot leak background goroutines or double-register cloudflared's Prometheus collectors — see the doc comments on `attemptCtx`, `startWaitConnected`, and `sharedObserver` in `bootstrap.go` for the full reasoning.
 
 When `TUNNEL_TOKEN` is unset the binary runs in **standalone mode** instead: `runStandaloneMode` (`cmd/proxy/main.go`) starts a plain HTTP server on `PROXY_ADDR` (default `:8080`) that serves `proxy.Handler` directly, plus the config API on `PROXY_CONFIG_ADDR`. `StartTunnel` is never called, so no cloudflared tunnel is started — this mode is for local development and testing.
 

--- a/docs/guides/l7-proxy.md
+++ b/docs/guides/l7-proxy.md
@@ -130,6 +130,8 @@ The proxy binary accepts the following environment variables:
 | `/healthz` | Config API | Liveness check |
 | `/readyz` | Config API | Readiness: config loaded at least once AND, in tunnel mode, the tunnel has connected to the Cloudflare edge (standalone mode latches the tunnel condition at startup) |
 
+In tunnel mode, a bootstrap dial failure (cluster DNS unreachable, the edge briefly unreachable) retries with jittered exponential backoff (2s up to a 30s cap) instead of exiting — the pod stays `Running` and reports `/readyz` false throughout, rather than crash-looping. See [Proxy Pod Stuck NotReady After a Restart](../operations/troubleshooting.md#proxy-pod-stuck-notready-after-a-restart) for diagnosis.
+
 ## Example HTTPRoute
 
 ```yaml

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -95,6 +95,27 @@ kubectl describe pod --namespace cloudflare-tunnel-system \
 | `secret not found` | Missing secret | Create required secret |
 | `read-only file system` | Security context issue | Check emptyDir volumes |
 
+### Proxy Pod Stuck NotReady After a Restart
+
+**Symptoms**:
+
+- A proxy pod is `Running` but `0/1 Ready` for longer than expected after a restart or node reboot, with a low or zero `RESTARTS` count in `kubectl get pods` — this is the tell that distinguishes the new behavior from the old crash loop an operator might be expecting
+- Logs repeat `tunnel bootstrap dial failed, retrying`, one line per attempt
+
+**Cause**: this is expected, not a bug. The proxy retries the tunnel's bootstrap dial instead of exiting on a transient failure — cluster DNS not yet reachable while the CNI is still wiring pods up after a reboot, or the Cloudflare edge briefly unreachable. Each retry waits a random duration between 0 and an exponentially growing cap (2s up to 30s, jittered so that replicas which failed at the same instant do not all retry in lockstep), so the logged `backoff` value moves around rather than climbing in a straight line. `/readyz` stays false for the whole retry window; the pod does not crash-loop.
+
+**Diagnosis**: a proxy that is retrying, not wedged, keeps emitting a new `tunnel bootstrap dial failed, retrying` log line on every attempt — an `attempt` count that keeps climbing is the pod actively working the problem, not stuck. Follow the logs to watch it happen:
+
+```bash
+kubectl logs --namespace cloudflare-tunnel-system \
+  --selector app.kubernetes.io/component=proxy --follow
+```
+
+**Solution**: if the retry log line keeps repeating well past the time the underlying network issue should have cleared (DNS, egress to the Cloudflare edge), check the error text on each attempt:
+
+- A DNS/dial/edge-unreachable error clears on its own once connectivity is restored — no action needed.
+- The same error persisting for many minutes with no change usually means the tunnel token itself is invalid or was revoked in the Cloudflare Zero Trust Dashboard. A malformed token (fails to decode) makes the pod exit immediately instead of retrying; a well-formed but rejected token retries indefinitely, because the proxy cannot reliably distinguish "the edge rejected this token" from "the edge is temporarily unreachable" from the error alone. Regenerate the connector token and update `proxy.tunnelTokenSecretRef` if this is the case.
+
 ### ImagePullBackOff
 
 **Diagnosis**:

--- a/internal/tunnel/bootstrap.go
+++ b/internal/tunnel/bootstrap.go
@@ -152,16 +152,42 @@ func StartTunnel(ctx context.Context, cfg *Config) error {
 		logger = slog.Default()
 	}
 
-	orchestrator, tunnelCfg, err := buildOrchestrator(ctx, cfg, token, logger)
+	// attemptCtx scopes every background goroutine this call spawns --
+	// directly (startWaitConnected) and indirectly, inside buildOrchestrator
+	// and supervisor.StartTunnelDaemon (the feature-selector refresh loop,
+	// the orchestrator's proxy-close watcher, the DNS resolver refresh loop)
+	// -- to THIS SPECIFIC call, cancelled the moment StartTunnel returns.
+	// Passing ctx itself to those constructors, as a single call to
+	// StartTunnel always did before the retry loop existed, ties their
+	// goroutines to ctx's own lifetime instead: harmless for exactly one
+	// call per process, but a growing set of orphaned goroutines --
+	// pinning whatever they closed over -- for every attempt that fails
+	// before connecting, once StartTunnelWithRetry can call StartTunnel
+	// many times across a long outage. cancelAttempt only ever fires after
+	// this function's own remaining work is done (it is the last defer to
+	// run), so nothing downstream observes attemptCtx as "more cancelled"
+	// than ctx itself would have been at any point that mattered to it.
+	attemptCtx, cancelAttempt := context.WithCancel(ctx)
+	defer cancelAttempt()
+
+	orchestrator, tunnelCfg, err := buildOrchestrator(attemptCtx, cfg, token, logger)
 	if err != nil {
 		return err
 	}
 
 	connectedSignal := cfdsignal.New(make(chan struct{}))
 	reconnectCh := make(chan supervisor.ReconnectSignal, defaultHAConnections)
+	// graceChannel's fallback (deriving the drain trigger from ctx.Done()
+	// when cfg.GraceShutdownC is nil) intentionally keeps using the outer
+	// ctx, not attemptCtx: production always sets GraceShutdownC, so this
+	// branch never runs today, and the drain trigger is conceptually an
+	// operator-level signal (SIGTERM), not a per-attempt one.
 	graceShutdownC := graceChannel(ctx, cfg.GraceShutdownC)
 
-	go waitConnected(ctx, connectedSignal, logger, cfg.OnConnected)
+	// See startWaitConnected's own doc comment for why this must be scoped
+	// per-attempt rather than tied to ctx directly.
+	stopWaiting := startWaitConnected(attemptCtx, connectedSignal, logger, cfg.OnConnected)
+	defer stopWaiting()
 
 	logger.Info("starting tunnel daemon",
 		"tunnelID", token.TunnelID.String(),
@@ -170,7 +196,7 @@ func StartTunnel(ctx context.Context, cfg *Config) error {
 	)
 
 	err = supervisor.StartTunnelDaemon(
-		ctx,
+		attemptCtx,
 		tunnelCfg,
 		orchestrator,
 		connectedSignal,
@@ -179,6 +205,60 @@ func StartTunnel(ctx context.Context, cfg *Config) error {
 	)
 
 	return errors.Wrap(err, "tunnel daemon")
+}
+
+// startWaitConnected spawns waitConnected on a context scoped to the
+// returned stop function rather than directly on ctx, and returns that stop
+// function for the caller to invoke when done waiting. stop() blocks until
+// the spawned goroutine has actually returned.
+//
+// This matters because StartTunnelWithRetry calls StartTunnel repeatedly
+// with the SAME long-lived ctx across every bootstrap attempt -- it is only
+// cancelled at process shutdown, not between attempts. Spawning
+// "go waitConnected(ctx, ...)" directly, as a single call to StartTunnel
+// always did before the retry loop existed, would park the goroutine on
+// ctx.Done() until the process exits whenever that attempt fails before
+// connecting -- harmless for exactly one call per process lifetime, but a
+// goroutine leaked per failed retry once StartTunnel can be called many
+// times in the same process, unbounded for an outage long enough to matter.
+// stop() -- called via defer in StartTunnel -- cancels the child context
+// when that specific attempt returns, regardless of ctx's own lifetime.
+//
+// Blocking until the goroutine exits (rather than just cancelling and
+// returning immediately) also closes a narrower race: runBootstrapAttempt
+// (retry.go) reads its connected flag right after dial() returns, but
+// onConnected runs on this goroutine, asynchronously with respect to
+// StartTunnel's own return. Waiting for the goroutine here, in StartTunnel's
+// deferred call, means any onConnected call already in flight when
+// StartTunnel returns has definitely completed -- and therefore so has the
+// flag write -- before runBootstrapAttempt ever reads it. What this does
+// NOT close: the select inside waitConnected itself has no defined
+// preference between connected.Wait() and ctx.Done() when both are ready in
+// the same instant, so a connect that lands at the exact moment this
+// specific attempt is giving up remains a real, if vanishingly narrow, race
+// -- unreachable in practice because cloudflared's own shutdown sequence
+// (supervisor.Run() unwinding every HA connection's retry budget) takes
+// seconds to minutes, far longer than a goroutine needs to be scheduled.
+func startWaitConnected(
+	ctx context.Context,
+	connected *cfdsignal.Signal,
+	logger *slog.Logger,
+	onConnected func(),
+) func() {
+	waitCtx, cancel := context.WithCancel(ctx)
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		waitConnected(waitCtx, connected, logger, onConnected)
+	}()
+
+	return func() {
+		cancel()
+		<-done
+	}
 }
 
 // waitConnected blocks until the tunnel registers its first connection with the
@@ -283,6 +363,54 @@ func buildOrchestrator(
 	return orchestrator, tunnelCfg, nil
 }
 
+// sharedObserver returns a process-lifetime connection.Observer, constructed
+// once on first use.
+//
+// connection.NewObserver spawns an unconditional background goroutine
+// (dispatchEvents) with no way to stop it -- no ctx parameter, no Close()
+// method exposed by the vendored library -- unlike buildOrchestrator's other
+// two per-attempt goroutine hazards (the feature-selector refresh loop, the
+// orchestrator's proxy-close watcher), which are closed by threading
+// StartTunnel's per-attempt context through instead (see attemptCtx in
+// StartTunnel). A fresh Observer per bootstrap attempt, as buildTunnelConfig
+// always constructed before the retry loop existed, would leak that
+// goroutine -- and everything it closes over via registered EventSinks --
+// once per failed attempt, unboundedly for an outage long enough to matter.
+//
+// Reusing one Observer for the process's lifetime bounds this to exactly
+// one goroutine, trading it for a smaller ongoing cost: Observer exposes no
+// way to unregister a sink, so supervisor.NewSupervisor's per-attempt
+// *tunnelstate.ConnTracker (registered as a sink on every call, via
+// NewConnAwareLogger) accumulates in the shared Observer's internal sinks
+// slice across every attempt instead of being freed, and dispatchEvents
+// walks the whole slice on every forwarded event -- so both memory and
+// per-event dispatch cost grow with attempt count. Per attempt that cost is
+// small and fixed (a stale ConnTracker only receives and discards forwarded
+// events -- it holds no dial or connection state of its own), but the TOTAL
+// is NOT bounded by this fix alone: for a bootstrap loop that retries
+// indefinitely (see errNonRetryableStart's doc comment on a well-formed but
+// edge-rejected token), sinks grows for as long as that condition persists,
+// unboundedly in principle. This is a real, disclosed trade-off, not a
+// closed one -- tracked in #606.
+//
+// The proper fix is a vendor patch giving Observer a Close()/UnregisterSink;
+// deliberately out of scope here, since it touches a separate repository
+// (the cloudflared fork). Sharing the OTHER per-attempt state Observer's
+// sinks carry -- reusing tunnelstate.ConnTracker itself instead of
+// registering a fresh one per attempt -- is not a safe alternative either:
+// ConnTracker.HasConnectedWith feeds the vendored supervisor's own
+// protocol-fallback decision (supervisor/tunnel.go's serveTunnel), so
+// sharing it would leak one attempt's connection history into another
+// attempt's control flow, trading a bounded memory cost for an unbounded
+// correctness one.
+//
+//nolint:gochecknoglobals // see doc comment above: one Observer must outlive any single StartTunnel call
+var sharedObserver = sync.OnceValue(func() *connection.Observer {
+	zlog := newZerologLogger()
+
+	return connection.NewObserver(&zlog, &zlog)
+})
+
 func buildTunnelConfig(
 	ctx context.Context,
 	token *Token,
@@ -311,7 +439,7 @@ func buildTunnelConfig(
 		DefaultDialer: ingress.NewDialer(warpRouting),
 	}, zlog)
 
-	observer := connection.NewObserver(zlog, zlog)
+	observer := sharedObserver()
 	dnsService := origins.NewDNSResolverService(originDialerService, zlog, origins.NewMetrics(prometheus.DefaultRegisterer))
 
 	tunnelCfg.EdgeTLSConfigs = edgeTLSConfigs

--- a/internal/tunnel/bootstrap.go
+++ b/internal/tunnel/bootstrap.go
@@ -144,7 +144,9 @@ func ParseTunnelToken(tokenStr string) (*Token, error) {
 func StartTunnel(ctx context.Context, cfg *Config) error {
 	token, err := ParseTunnelToken(cfg.Token)
 	if err != nil {
-		return errors.Wrap(err, "parse tunnel token")
+		// Marked non-retryable: a malformed token fails identically on every
+		// retry, so StartTunnelWithRetry must not back off and wait on it.
+		return markNonRetryable(errors.Wrap(err, "parse tunnel token"))
 	}
 
 	logger := cfg.Logger
@@ -172,7 +174,13 @@ func StartTunnel(ctx context.Context, cfg *Config) error {
 
 	orchestrator, tunnelCfg, err := buildOrchestrator(attemptCtx, cfg, token, logger)
 	if err != nil {
-		return err
+		// Marked non-retryable: every failure reachable here (protocol/TLS
+		// selection, ingress parsing, orchestrator construction) is a
+		// deterministic config-build error, not a network condition -- the
+		// network-dependent lookups nested in this path (feature fetch,
+		// protocol-percentage fetch) degrade gracefully on their own DNS
+		// failure and never propagate an error through this return.
+		return markNonRetryable(err)
 	}
 
 	connectedSignal := cfdsignal.New(make(chan struct{}))

--- a/internal/tunnel/bootstrap_internal_test.go
+++ b/internal/tunnel/bootstrap_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"log/slog"
+	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/cloudflare/cloudflared/connection"
 	"github.com/cloudflare/cloudflared/orchestration"
 	cfdsignal "github.com/cloudflare/cloudflared/signal"
+	"github.com/cloudflare/cloudflared/supervisor"
 )
 
 func TestBuildCatchAllIngress(t *testing.T) {
@@ -358,6 +361,60 @@ func TestWaitConnected_NoCallbackOnContextCancel(t *testing.T) {
 	waitConnected(ctx, sig, slog.Default(), func() { calls++ })
 
 	assert.Equal(t, 0, calls, "OnConnected must not fire when the context is cancelled before connecting")
+}
+
+// TestStartWaitConnected_SpawnsAGoroutine sanity-checks that
+// startWaitConnected actually starts waitConnected in the background (a
+// goroutine-count bump), rather than, say, silently running it inline or not
+// at all. The behavioral half of the fix -- that stop() actually ends the
+// wait -- is pinned separately in
+// TestStartWaitConnected_StopEndsWaitWithoutOuterCtxDone, since comparing
+// runtime.NumGoroutine() against a "went back down" threshold is too noisy
+// in a shared test binary (other tests' goroutines, GC workers, etc. can
+// keep the count elevated for reasons unrelated to this one).
+func TestStartWaitConnected_SpawnsAGoroutine(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	stop := startWaitConnected(t.Context(), cfdsignal.New(make(chan struct{})), slog.Default(), func() {})
+	defer stop()
+
+	assert.Eventually(t, func() bool {
+		return runtime.NumGoroutine() > before
+	}, time.Second, time.Millisecond, "waitConnected goroutine must have started")
+}
+
+// TestStartWaitConnected_StopEndsWaitWithoutOuterCtxDone pins the fix for a
+// goroutine leak: StartTunnelWithRetry calls StartTunnel with the SAME
+// long-lived context on every bootstrap attempt (it is only cancelled at
+// process shutdown, not between attempts), so a naive
+// "go waitConnected(ctx, ...)" spawned fresh on every failed attempt would
+// park forever on that never-done ctx -- one leaked goroutine per retry,
+// unbounded for a long outage, which is exactly the scenario this feature
+// exists to survive. startWaitConnected must scope the goroutine to a
+// context the caller can cancel independently of ctx, so a StartTunnel call
+// that never connects still cleans up on return.
+//
+// Proven behaviorally rather than via goroutine counting: a connect signal
+// arriving AFTER stop() -- as if cloudflared registered just after this
+// specific StartTunnel attempt had already given up and returned -- must not
+// invoke onConnected. If the goroutine were still parked on ctx (the leak),
+// it would still be listening and would fire the callback. No sleeps needed:
+// stop() blocks until the goroutine has actually returned (see its doc
+// comment), so the ordering here is deterministic, not timing-dependent.
+func TestStartWaitConnected_StopEndsWaitWithoutOuterCtxDone(t *testing.T) {
+	ctx := t.Context() // long-lived: this test never cancels it
+	sig := cfdsignal.New(make(chan struct{}))
+
+	var calls atomic.Int32
+
+	stop := startWaitConnected(ctx, sig, slog.Default(), func() { calls.Add(1) })
+	stop()
+
+	sig.Notify() // a late connect signal, as if cloudflared registered just
+	// after this StartTunnel attempt already gave up and returned
+
+	assert.Equal(t, int32(0), calls.Load(),
+		"a connect signal after stop() must not fire onConnected -- the wait must already be over")
 }
 
 func TestConstants(t *testing.T) {
@@ -953,4 +1010,203 @@ func TestResolveProtocolFlag(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestBuildOrchestrator_CalledTwice_DoesNotPanic pins the fix for a
+// Prometheus double-registration panic. buildOrchestrator (via
+// buildTunnelConfig) registers cloudflared's DNS-resolver metrics on
+// prometheus.DefaultRegisterer unconditionally on every call -- it was
+// written assuming "construct once per process." StartTunnelWithRetry
+// breaks that assumption: a retryable failure re-enters buildOrchestrator
+// from scratch on the next attempt. Without ensureRetrySafeRegisterer, the
+// second call panics with "duplicate metrics collector registration
+// attempted" instead of the retry loop backing off -- exactly the
+// reproduction scenario in the issue this feature exists for, since
+// buildOrchestrator has no network dependency and succeeds identically on
+// every attempt regardless of what made the previous attempt retry.
+//
+// NOT parallel: temporarily replaces prometheus.DefaultRegisterer.
+func TestBuildOrchestrator_CalledTwice_DoesNotPanic(t *testing.T) {
+	token := newTestToken()
+	cfg := &Config{ProxyURL: "http://localhost:8080"}
+
+	withFreshRegisterer(func() {
+		ensureRetrySafeRegisterer()
+
+		_, _, err := buildOrchestrator(t.Context(), cfg, token, slog.Default())
+		require.NoError(t, err)
+
+		assert.NotPanics(t, func() {
+			_, _, err := buildOrchestrator(t.Context(), cfg, token, slog.Default())
+			require.NoError(t, err)
+		})
+	})
+}
+
+// TestNewSupervisor_CalledTwice_DoesNotPanic covers the second Prometheus
+// double-registration hazard on the bootstrap-retry path: vendored
+// supervisor.NewSupervisor (called from within StartTunnelDaemon, one call
+// per bootstrap attempt) unconditionally registers cloudflared's QUIC
+// datagram metrics on prometheus.DefaultRegisterer too, via v3.NewMetrics.
+// That call site is inside the vendored fork, not something this package's
+// own code calls directly, so it needs the same registerer-level fix as
+// buildOrchestrator's hazard above rather than a call-site change.
+//
+// EdgeAddrs is set to a literal IP (RFC 5737 TEST-NET-1) so NewSupervisor
+// takes the StaticEdge path instead of resolving a real Cloudflare edge
+// hostname: net.ResolveTCPAddr/ResolveUDPAddr short-circuit on an IP
+// literal without touching the network, keeping this test fast and
+// independent of the sandbox's network access -- construction is all that
+// is needed to reach the metrics registration, no actual dial.
+//
+// NOT parallel: temporarily replaces prometheus.DefaultRegisterer.
+func TestNewSupervisor_CalledTwice_DoesNotPanic(t *testing.T) {
+	token := newTestToken()
+	cfg := &Config{ProxyURL: "http://localhost:8080"}
+
+	withFreshRegisterer(func() {
+		ensureRetrySafeRegisterer()
+
+		orchestrator, tunnelCfg, err := buildOrchestrator(t.Context(), cfg, token, slog.Default())
+		require.NoError(t, err)
+
+		tunnelCfg.EdgeAddrs = []string{"192.0.2.1:7844"}
+
+		reconnectCh := make(chan supervisor.ReconnectSignal, 1)
+		graceShutdownC := make(chan struct{})
+
+		_, err = supervisor.NewSupervisor(tunnelCfg, orchestrator, reconnectCh, graceShutdownC)
+		require.NoError(t, err)
+
+		assert.NotPanics(t, func() {
+			_, err := supervisor.NewSupervisor(tunnelCfg, orchestrator, reconnectCh, graceShutdownC)
+			require.NoError(t, err)
+		})
+	})
+}
+
+// TestBuildOrchestrator_PerAttemptCtx_PreventsGoroutineAccumulation proves
+// the pattern StartTunnel now uses (see attemptCtx in StartTunnel) to avoid
+// a goroutine leak the bootstrap retry loop would otherwise cause.
+// buildOrchestrator's constructors -- features.NewFeatureSelector's hourly
+// refresh loop, orchestration.NewOrchestrator's proxy-close watcher -- spawn
+// goroutines scoped to whatever context they are given, with no way to stop
+// them other than cancelling that context. Confirmed independently by two
+// review passes: calling buildOrchestrator repeatedly on ONE shared,
+// never-cancelled context -- exactly what StartTunnel did before this fix,
+// since StartTunnelWithRetry reuses the same long-lived ctx across every
+// bootstrap attempt -- measurably grows the goroutine count call over call.
+// Calling it with a FRESH context per call, cancelled right after (what
+// StartTunnel's attemptCtx now does around every attempt), must not.
+//
+// This exercises buildOrchestrator directly rather than the full
+// StartTunnel/StartTunnelWithRetry path: StartTunnel's remaining work after
+// buildOrchestrator succeeds is supervisor.StartTunnelDaemon, which dials
+// the real Cloudflare edge with no test seam to avoid it -- confirmed by
+// direct probe (not committed) to take 20+ seconds per call, touch real
+// cloudflared connection-retry internals against the live edge, and even
+// trip the race detector inside that vendored retry logic. Unsuitable for a
+// unit test. buildOrchestrator is where the leak actually originates and
+// has no such dependency.
+//
+// Flakiness protections, since runtime.NumGoroutine() on ambient counts is a
+// classic source of them in a shared test binary:
+//   - NOT parallel (see below): nothing else touching goroutine counts runs
+//     concurrently with this test's measurement windows.
+//   - The "grows" half (sharedCtx) needs no wait at all: a "go f()" statement
+//     registers the goroutine with the runtime synchronously as part of
+//     executing it, before buildOrchestrator can return -- NumGoroutine()
+//     reflects it immediately, whether or not the goroutine has actually been
+//     scheduled to start running yet.
+//   - The "does not accumulate" half (per-call ctx) DOES need to wait: a
+//     cancelled goroutine needs a scheduler turn to observe ctx.Done() and
+//     actually return, shrinking the count. That side polls for the count to
+//     settle (require.Eventually, generous 5s budget) instead of sleeping a
+//     fixed duration -- a fixed sleep either wastes time when the runtime is
+//     fast or, under CI contention, isn't long enough and flakes.
+//   - The pass/fail bound is a delta from a measurement taken earlier in
+//     THIS SAME test (beforeScoped), not a hardcoded absolute -- immune to
+//     whatever ambient goroutine count the rest of the test binary happens
+//     to be sitting at when this test runs.
+//
+// NOT parallel: temporarily replaces prometheus.DefaultRegisterer, and
+// goroutine-count measurements would be polluted by concurrently-running
+// tests.
+func TestBuildOrchestrator_PerAttemptCtx_PreventsGoroutineAccumulation(t *testing.T) {
+	token := newTestToken()
+	cfg := &Config{ProxyURL: "http://localhost:8080"}
+
+	const calls = 5
+
+	withFreshRegisterer(func() {
+		// Calling buildOrchestrator more than once needs the same
+		// double-registration fix TestBuildOrchestrator_CalledTwice_DoesNotPanic
+		// pins -- otherwise the second call here panics before this test
+		// ever reaches what it is actually checking.
+		ensureRetrySafeRegisterer()
+
+		// Shared, never-cancelled context -- the pre-fix shape: StartTunnel
+		// used to hand buildOrchestrator its caller's own long-lived ctx.
+		sharedCtx := t.Context()
+
+		before := runtime.NumGoroutine()
+
+		for range calls {
+			_, _, err := buildOrchestrator(sharedCtx, cfg, token, slog.Default())
+			require.NoError(t, err)
+		}
+
+		afterShared := runtime.NumGoroutine()
+
+		assert.Greater(t, afterShared, before,
+			"sanity check: buildOrchestrator on a shared, never-cancelled context must actually grow the goroutine count -- otherwise this test proves nothing")
+
+		// Per-call context, cancelled right after each call -- the fix's
+		// shape: StartTunnel's attemptCtx.
+		beforeScoped := runtime.NumGoroutine()
+
+		for range calls {
+			ctx, cancel := context.WithCancel(t.Context())
+
+			_, _, err := buildOrchestrator(ctx, cfg, token, slog.Default())
+			require.NoError(t, err)
+
+			cancel()
+		}
+
+		require.Eventually(t, func() bool {
+			return runtime.NumGoroutine() <= beforeScoped+2
+		}, 5*time.Second, 10*time.Millisecond,
+			"a per-call context cancelled right after buildOrchestrator returns must not accumulate goroutines across repeated calls -- a growing count here is exactly the leak an unbounded bootstrap retry would trigger")
+	})
+}
+
+// TestBuildTunnelConfig_ObserverIsSharedAcrossCalls pins the mitigation for
+// the same "constructed once per process" hazard that also broke Prometheus
+// registration and the waitConnected goroutine: connection.NewObserver
+// spawns an unconditional background goroutine (dispatchEvents) with no
+// exposed way to stop it -- no ctx parameter, no Close() method -- so a
+// fresh Observer per bootstrap attempt leaks that goroutine (plus whatever
+// it closes over via registered EventSinks) once StartTunnelWithRetry can
+// call buildTunnelConfig many times in the same process. Unlike the other
+// two hazards this one cannot be closed by threading a per-attempt context
+// through -- the vendored constructor does not accept one -- so
+// buildTunnelConfig reuses ONE Observer for the process's lifetime instead
+// of building a fresh one per call.
+func TestBuildTunnelConfig_ObserverIsSharedAcrossCalls(t *testing.T) {
+	token := newTestToken()
+	zlog := newZerologLogger()
+
+	withFreshRegisterer(func() {
+		ensureRetrySafeRegisterer()
+
+		tunnelCfg1, _, err := buildTunnelConfig(t.Context(), token, "http://localhost:8080", connection.AutoSelectFlag, &zlog)
+		require.NoError(t, err)
+
+		tunnelCfg2, _, err := buildTunnelConfig(t.Context(), token, "http://localhost:8080", connection.AutoSelectFlag, &zlog)
+		require.NoError(t, err)
+
+		assert.Same(t, tunnelCfg1.Observer, tunnelCfg2.Observer,
+			"buildTunnelConfig must reuse one Observer across calls -- a fresh one per call leaks its unstoppable dispatchEvents goroutine on every bootstrap retry")
+	})
 }

--- a/internal/tunnel/bootstrap_internal_test.go
+++ b/internal/tunnel/bootstrap_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -324,6 +325,38 @@ func TestStartTunnel_EmptyToken_ErrorPath(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tunnel token is empty")
+}
+
+// TestStartTunnel_InvalidToken_IsNonRetryable pins that a token-parse
+// failure classifies as non-retryable: retrying with the same malformed
+// token can never succeed, so StartTunnelWithRetry must return immediately
+// instead of backing off.
+func TestStartTunnel_InvalidToken_IsNonRetryable(t *testing.T) {
+	t.Parallel()
+
+	err := StartTunnel(t.Context(), &Config{
+		Token:    "not-valid-base64!!!",
+		ProxyURL: "http://localhost:8080",
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNonRetryableStart))
+}
+
+// TestStartTunnel_BuildOrchestratorError_IsNonRetryable pins that a
+// deterministic config-build failure (here: an unparseable catch-all
+// ingress URL) also classifies as non-retryable -- same reasoning as an
+// invalid token, it is not a network condition that clears on retry.
+func TestStartTunnel_BuildOrchestratorError_IsNonRetryable(t *testing.T) {
+	t.Parallel()
+
+	err := StartTunnel(t.Context(), &Config{
+		Token:    validTestTokenBase64(),
+		ProxyURL: "",
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNonRetryableStart))
 }
 
 // TestWaitConnected_FiresCallbackOnConnect pins that the connected-signal hook

--- a/internal/tunnel/retry.go
+++ b/internal/tunnel/retry.go
@@ -1,0 +1,281 @@
+package tunnel
+
+import (
+	"context"
+	"log/slog"
+	"math/rand/v2"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// defaultBootstrapRetryBaseDelay is the first backoff wait after a
+	// retryable bootstrap-dial failure.
+	defaultBootstrapRetryBaseDelay = 2 * time.Second
+	// defaultBootstrapRetryMaxDelay caps the exponential backoff so a
+	// persistent outage still retries every 30s rather than growing
+	// unboundedly.
+	defaultBootstrapRetryMaxDelay = 30 * time.Second
+)
+
+// errNonRetryableStart marks StartTunnel errors that stem from invalid
+// input -- a tunnel token that does not parse, an unsupported protocol or
+// TLS setting -- rather than a network condition. Retrying with the same
+// Config reproduces the identical failure, so StartTunnelWithRetry
+// classifies via errors.Is against this sentinel instead of matching
+// cloudflared's error text (which is not a stable contract across vendor
+// bumps) and returns immediately rather than backing off.
+//
+// Deliberately NOT covered: a well-formed tunnel token that the Cloudflare
+// edge rejects (revoked, deleted tunnel, wrong secret) rather than a token
+// that fails to parse. That distinction is made inside the vendored
+// cloudflared supervisor -- connection.ServerRegisterTunnelError carries a
+// Permanent bool from the registration RPC -- but it never crosses back out
+// to this package: the error is unwrapped to its Cause and the Permanent
+// bit consumed as a plain retry/no-retry decision before StartTunnel ever
+// sees it (supervisor/tunnel.go's serveTunnel, in the vendored fork).
+// cloudflared itself treats an "Unauthorized" registration response as
+// possibly transient (edge propagation lag on a newly created tunnel) and
+// retries it internally for the same reason. Matching on that string from
+// here would be exactly the fragile, upgrade-breaking coupling the vendor
+// rebase discipline in CLAUDE.md warns against, so a rejected-but-parseable
+// token falls through to the retryable path: it retries indefinitely with
+// capped backoff, staying NotReady and logging the error on every attempt
+// instead of exiting. See docs/operations/troubleshooting.md for the
+// operator-facing diagnosis of that case.
+var errNonRetryableStart = errors.New("non-retryable tunnel start error")
+
+// markNonRetryable tags err with errNonRetryableStart without altering its
+// Error() text (Wrap with an empty message adds only a stack frame, no
+// prefix -- see cockroachdb/errors' WrapWithDepth). StartTunnel calls this
+// at its deterministic, config-derived failure points so
+// StartTunnelWithRetry can classify them via errors.Is.
+func markNonRetryable(err error) error {
+	return errors.Wrap(errors.Mark(err, errNonRetryableStart), "")
+}
+
+// ensureRetrySafeRegisterer swaps prometheus.DefaultRegisterer for a
+// wrapper that tolerates re-registering the same collector, unless it is
+// already wrapped. StartTunnelWithRetry calls this before every attempt.
+//
+// It exists because a bootstrap retry calls StartTunnel -- and therefore
+// buildOrchestrator and, further in, the vendored supervisor.NewSupervisor
+// -- more than once in the same process. Both unconditionally MustRegister
+// cloudflared's own Prometheus collectors on prometheus.DefaultRegisterer
+// (origins.NewMetrics inside buildTunnelConfig; v3.NewMetrics inside
+// NewSupervisor), written assuming "construct once per process." A second
+// bootstrap attempt registering the exact same collector a second time is
+// not a bug to report -- it is the still-registered collector from the
+// first (failed) attempt, so client_golang's AlreadyRegisteredError for
+// that specific case is swallowed rather than left to panic. A genuine
+// registration failure (a different metric, malformed descriptor) is not
+// an AlreadyRegisteredError and still panics.
+//
+// buildOrchestrator's origins.NewMetrics call is the only one this package
+// controls directly and could otherwise fix by memoizing instead (reusing
+// one collector across attempts keeps that specific metric's value alive
+// across retries); v3.NewMetrics is inside the vendored fork with no
+// injection point for a memoized registerer, so this wrapper is the only
+// fix available without a fork patch. One mechanism for both is simpler
+// than two, and it comes at a bounded, documented cost: the collector
+// object from a failed attempt is orphaned (unregistered but referenced by
+// that attempt's already-discarded origin dialer/DNS resolver), so these
+// specific cloudflared-internal metrics stop advancing until the process
+// actually connects or restarts. Neither collector is on the proxy's own
+// documented metrics surface.
+func ensureRetrySafeRegisterer() {
+	if _, ok := prometheus.DefaultRegisterer.(retrySafeRegisterer); ok {
+		return
+	}
+
+	prometheus.DefaultRegisterer = retrySafeRegisterer{prometheus.DefaultRegisterer}
+}
+
+// retrySafeRegisterer wraps a prometheus.Registerer so MustRegister no
+// longer panics when a collector describing an already-registered metric
+// (same name and labels, not necessarily the same object) is registered
+// again. See ensureRetrySafeRegisterer for why that happens on a bootstrap
+// retry, and why swallowing it here is safe.
+type retrySafeRegisterer struct {
+	prometheus.Registerer
+}
+
+func (r retrySafeRegisterer) MustRegister(collectors ...prometheus.Collector) {
+	for _, c := range collectors {
+		err := r.Register(c)
+		if err == nil {
+			continue
+		}
+
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if errors.As(err, &alreadyRegistered) {
+			continue
+		}
+
+		panic(err)
+	}
+}
+
+// StartTunnelWithRetry wraps StartTunnel in a capped exponential-backoff
+// retry loop for the BOOTSTRAP dial: the window before the tunnel has ever
+// registered a connection with the Cloudflare edge. A transient failure in
+// that window -- cluster DNS not yet reachable after a node reboot, the edge
+// briefly unreachable -- retries instead of returning, so the caller does
+// not exit and crash-loop while the condition clears on its own.
+//
+// The retry is deliberately scoped to the bootstrap window only. cloudflared
+// reconnects transparently on its own once a connection has been
+// established (that is what Config.OnConnected observes); if StartTunnel
+// still returns an error after OnConnected has already fired once, that
+// means cloudflared exhausted its own reconnect budget entirely, which is a
+// different failure than "never got up in the first place" and is returned
+// unchanged here. Retrying it silently would be actively worse than the
+// previous exit(1): proxy.Router's tunnel-connected readiness gate is a
+// one-way latch (see its doc comment) that never flips back to NotReady, so
+// a pod stuck in this state would keep reporting Ready while unable to serve
+// any traffic.
+//
+// A non-retryable failure (see errNonRetryableStart) also returns
+// immediately -- retrying a deterministic misconfiguration never succeeds.
+//
+// A close of drainC breaks the loop promptly, even mid-backoff-wait,
+// mirroring how proxy.ResolveStartupProtocol already handles a drain during
+// its own startup wait -- so a SIGTERM during a long backoff sleep does not
+// burn the pod's termination grace period.
+func StartTunnelWithRetry(ctx context.Context, cfg *Config, drainC <-chan struct{}) error {
+	return startTunnelWithRetry(ctx, cfg, drainC, StartTunnel,
+		defaultBootstrapRetryBaseDelay, defaultBootstrapRetryMaxDelay, fullJitter)
+}
+
+// runBootstrapAttempt runs a single dial attempt with a fresh, wrapped
+// OnConnected so the caller can observe whether the tunnel connected during
+// THIS attempt specifically, without disturbing the caller-supplied
+// OnConnected (still invoked, so readiness still flips on a real connect).
+func runBootstrapAttempt(
+	ctx context.Context,
+	cfg *Config,
+	dial func(context.Context, *Config) error,
+) (bool, error) {
+	var connectedFlag atomic.Bool
+
+	attemptCfg := *cfg
+	userOnConnected := cfg.OnConnected
+	attemptCfg.OnConnected = func() {
+		connectedFlag.Store(true)
+
+		if userOnConnected != nil {
+			userOnConnected()
+		}
+	}
+
+	// Sequenced as two statements, not "return connectedFlag.Load(),
+	// dial(...)": Go evaluates return-expression operands left to right, so
+	// that form would read connectedFlag BEFORE dial ever runs -- always
+	// false, since dial is what invokes attemptCfg.OnConnected and sets it.
+	err := dial(ctx, &attemptCfg)
+
+	return connectedFlag.Load(), err
+}
+
+// startTunnelWithRetry is the testable core of StartTunnelWithRetry. dial,
+// baseDelay, maxDelay, and jitter are injected so tests can drive the loop's
+// control flow -- classification, backoff growth, drain/context interruption
+// -- deterministically, without dialing cloudflared, waiting out the real
+// backoff durations, or fighting real randomness.
+func startTunnelWithRetry(
+	ctx context.Context,
+	cfg *Config,
+	drainC <-chan struct{},
+	dial func(context.Context, *Config) error,
+	baseDelay, maxDelay time.Duration,
+	jitter func(time.Duration) time.Duration,
+) error {
+	// Before the first attempt, not once per attempt: the check inside is
+	// already idempotent, and installing it before dial's first call covers
+	// the same-process double-dial hazard regardless of which attempt first
+	// hits it.
+	ensureRetrySafeRegisterer()
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	delay := baseDelay
+
+	for attempt := 1; ; attempt++ {
+		connected, err := runBootstrapAttempt(ctx, cfg, dial)
+		if err == nil {
+			return nil
+		}
+
+		if connected {
+			// Connected at least once during this attempt -- out of scope
+			// for the bootstrap retry, see the doc comment above.
+			return err
+		}
+
+		if errors.Is(err, errNonRetryableStart) {
+			return err
+		}
+
+		if ctx.Err() != nil {
+			// Not "return err": the raw dial error is not guaranteed to
+			// already be context.Canceled-flavored -- cloudflared's own
+			// shutdown handling can wrap a cancellation differently
+			// depending on exactly where it landed -- but it must still
+			// read as a clean shutdown to main.go's
+			// "!errors.Is(err, context.Canceled)" exit(1) gate. Otherwise a
+			// SIGTERM landing in this exact window would spuriously exit
+			// non-zero and log an ERROR for what is a clean shutdown.
+			return errors.Wrap(ctx.Err(), "tunnel bootstrap retry")
+		}
+
+		wait := jitter(delay)
+
+		// err.Error() (not err) -- cockroachdb/errors formats a raw error
+		// value under slog's default "%+v" attribute encoding with an
+		// attached stack trace, which would otherwise repeat on every
+		// attempt and drown the log in noise across a long outage.
+		logger.Error("tunnel bootstrap dial failed, retrying",
+			"attempt", attempt, "error", err.Error(), "backoff", wait)
+
+		select {
+		case <-drainC:
+			return context.Canceled
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "tunnel bootstrap retry")
+		case <-time.After(wait):
+		}
+
+		delay = nextBootstrapRetryDelay(delay, maxDelay)
+	}
+}
+
+// nextBootstrapRetryDelay doubles the backoff delay, capped at maxDelay.
+func nextBootstrapRetryDelay(current, maxDelay time.Duration) time.Duration {
+	next := current * 2
+	if next > maxDelay || next <= 0 {
+		return maxDelay
+	}
+
+	return next
+}
+
+// fullJitter implements the "full jitter" backoff strategy: a uniformly
+// random duration in [0, ceiling]. Every proxy replica that hit the same
+// bootstrap failure at nearly the same time -- e.g. all of them dialing
+// right after the same node reboot -- would otherwise retry in lockstep
+// against the same recovering dependency; spreading their actual wait times
+// out avoids that. A non-positive ceiling returns zero rather than panicking
+// (math/rand/v2's N-family requires a positive bound).
+func fullJitter(ceiling time.Duration) time.Duration {
+	if ceiling <= 0 {
+		return 0
+	}
+
+	return time.Duration(rand.Int64N(int64(ceiling) + 1)) //nolint:gosec // jitter timing, not a security context -- crypto/rand is unnecessary overhead here
+}

--- a/internal/tunnel/retry_internal_test.go
+++ b/internal/tunnel/retry_internal_test.go
@@ -1,0 +1,415 @@
+package tunnel
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testRetryDelays keeps the retry-loop tests fast: backoff waits use these
+// instead of the real (seconds-to-minutes) defaults.
+const (
+	testBaseDelay = time.Millisecond
+	testMaxDelay  = 4 * time.Millisecond
+)
+
+var errFakeRetryable = errors.New("fake: edge unreachable")
+
+// identityJitter is injected in place of fullJitter so the loop-control-flow
+// tests stay deterministic: the requested delay is used verbatim, with none
+// of fullJitter's real randomness.
+func identityJitter(d time.Duration) time.Duration { return d }
+
+// Every test below that calls startTunnelWithRetry is NOT parallel and runs
+// inside withFreshRegisterer: startTunnelWithRetry unconditionally calls
+// ensureRetrySafeRegisterer, which reads and writes the package-level
+// prometheus.DefaultRegisterer -- the same hazard withFreshRegisterer's own
+// doc comment already warns about for the buildOrchestrator tests in
+// bootstrap_internal_test.go.
+
+func TestStartTunnelWithRetry_SucceedsOnFirstAttempt(t *testing.T) {
+	var calls atomic.Int32
+
+	dial := func(context.Context, *Config) error {
+		calls.Add(1)
+
+		return nil
+	}
+
+	withFreshRegisterer(func() {
+		err := startTunnelWithRetry(t.Context(), &Config{}, make(chan struct{}), dial,
+			testBaseDelay, testMaxDelay, identityJitter)
+
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestStartTunnelWithRetry_RetriesRetryableErrorThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+
+	dial := func(context.Context, *Config) error {
+		n := calls.Add(1)
+		if n < 3 {
+			return errFakeRetryable
+		}
+
+		return nil
+	}
+
+	withFreshRegisterer(func() {
+		err := startTunnelWithRetry(t.Context(), &Config{}, make(chan struct{}), dial,
+			testBaseDelay, testMaxDelay, identityJitter)
+
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, int32(3), calls.Load(), "must retry the retryable error until it succeeds")
+}
+
+func TestStartTunnelWithRetry_NonRetryableErrorReturnsImmediately(t *testing.T) {
+	var calls atomic.Int32
+
+	terminalErr := errors.Mark(errors.New("bad token"), errNonRetryableStart)
+	dial := func(context.Context, *Config) error {
+		calls.Add(1)
+
+		return errors.Wrap(terminalErr, "dial")
+	}
+
+	var err error
+
+	withFreshRegisterer(func() {
+		err = startTunnelWithRetry(t.Context(), &Config{}, make(chan struct{}), dial,
+			testBaseDelay, testMaxDelay, identityJitter)
+	})
+
+	require.Error(t, err)
+	// A cockroachdb/errors Mark is a logical-identity match (message + type),
+	// not a chain-linked sentinel -- testify's ErrorIs uses the stdlib
+	// errors.Is, which does not know how to walk it. Check with the same
+	// package that produced the mark, matching how production code classifies.
+	assert.True(t, errors.Is(err, errNonRetryableStart), "err must classify as non-retryable")
+	assert.Equal(t, int32(1), calls.Load(), "a non-retryable error must not be retried")
+}
+
+func TestStartTunnelWithRetry_PostConnectionFailureNotRetried(t *testing.T) {
+	var calls atomic.Int32
+
+	postConnectionErr := errors.New("tunnel daemon: all connections lost")
+	dial := func(_ context.Context, cfg *Config) error {
+		calls.Add(1)
+		cfg.OnConnected()
+
+		return postConnectionErr
+	}
+
+	var err error
+
+	withFreshRegisterer(func() {
+		err = startTunnelWithRetry(t.Context(), &Config{}, make(chan struct{}), dial,
+			testBaseDelay, testMaxDelay, identityJitter)
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, postConnectionErr, err, "a failure after the tunnel connected must be returned unchanged")
+	assert.Equal(t, int32(1), calls.Load(), "a post-connection failure must not be retried by the bootstrap loop")
+}
+
+func TestStartTunnelWithRetry_ForwardsOnConnectedToCaller(t *testing.T) {
+	var callerNotified atomic.Bool
+
+	cfg := &Config{
+		OnConnected: func() { callerNotified.Store(true) },
+	}
+
+	dial := func(_ context.Context, attemptCfg *Config) error {
+		attemptCfg.OnConnected()
+
+		return errors.New("dies after connecting")
+	}
+
+	withFreshRegisterer(func() {
+		_ = startTunnelWithRetry(t.Context(), cfg, make(chan struct{}), dial,
+			testBaseDelay, testMaxDelay, identityJitter)
+	})
+
+	assert.True(t, callerNotified.Load(), "the caller-supplied OnConnected must still fire")
+}
+
+func TestStartTunnelWithRetry_DrainDuringBackoffBreaksLoop(t *testing.T) {
+	var calls atomic.Int32
+
+	dial := func(context.Context, *Config) error {
+		calls.Add(1)
+
+		return errFakeRetryable
+	}
+
+	drainC := make(chan struct{})
+	close(drainC)
+
+	var err error
+
+	// A large backoff proves the loop returned because of the drain signal,
+	// not because the timer happened to fire first.
+	withFreshRegisterer(func() {
+		err = startTunnelWithRetry(t.Context(), &Config{}, drainC, dial,
+			time.Hour, time.Hour, identityJitter)
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled, "a drain mid-backoff must resolve as a clean shutdown, not a failure")
+	assert.Equal(t, int32(1), calls.Load(), "the loop must not dial again after the drain fires")
+}
+
+func TestStartTunnelWithRetry_ContextCancelledDuringBackoffBreaksLoop(t *testing.T) {
+	var calls atomic.Int32
+
+	dial := func(context.Context, *Config) error {
+		calls.Add(1)
+
+		return errFakeRetryable
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// The context is still live for attempt 1 (proving the loop reaches the
+	// backoff wait, not the already-done short-circuit) and is only
+	// cancelled once the loop is parked in the select below the large
+	// backoff -- pinning the ctx.Done() interruption path specifically.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	var err error
+
+	withFreshRegisterer(func() {
+		err = startTunnelWithRetry(ctx, &Config{}, make(chan struct{}), dial,
+			time.Hour, time.Hour, identityJitter)
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(1), calls.Load(), "the loop must not dial again once the context is done")
+}
+
+func TestStartTunnelWithRetry_ContextAlreadyDoneSkipsRetry(t *testing.T) {
+	var calls atomic.Int32
+
+	dial := func(context.Context, *Config) error {
+		calls.Add(1)
+
+		return errFakeRetryable
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var err error
+
+	withFreshRegisterer(func() {
+		err = startTunnelWithRetry(ctx, &Config{}, make(chan struct{}), dial,
+			testBaseDelay, testMaxDelay, identityJitter)
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load(),
+		"a dial failure observed with an already-done context must not be retried")
+	// The raw dial error is not guaranteed to already be context.Canceled-
+	// flavored (cloudflared's own shutdown handling can wrap it differently
+	// depending on exactly where it was cancelled), but a shutdown must
+	// still read as one to main.go's "!errors.Is(err, context.Canceled)"
+	// exit(1) gate -- otherwise a SIGTERM landing in this exact window would
+	// spuriously exit non-zero and log an ERROR for what is a clean shutdown.
+	assert.ErrorIs(t, err, context.Canceled,
+		"a failure observed with an already-done context must read as a clean shutdown, not a crash")
+}
+
+// TestStartTunnelWithRetry_UsesInjectedJitter pins that the loop's sleep on
+// each attempt goes through the jitter function -- not the raw exponential
+// delay -- and that jitter is fed the correctly-doubling pre-jitter delay on
+// each successive attempt.
+func TestStartTunnelWithRetry_UsesInjectedJitter(t *testing.T) {
+	var calls atomic.Int32
+
+	dial := func(context.Context, *Config) error {
+		n := calls.Add(1)
+		if n < 3 {
+			return errFakeRetryable
+		}
+
+		return nil
+	}
+
+	var jitterInputs []time.Duration
+
+	jitter := func(d time.Duration) time.Duration {
+		jitterInputs = append(jitterInputs, d)
+
+		return time.Microsecond // near-instant regardless of d, keeps the test fast
+	}
+
+	var err error
+
+	withFreshRegisterer(func() {
+		err = startTunnelWithRetry(t.Context(), &Config{}, make(chan struct{}), dial,
+			testBaseDelay, testMaxDelay, jitter)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []time.Duration{testBaseDelay, 2 * testBaseDelay}, jitterInputs,
+		"jitter must see the doubling pre-jitter delay on each attempt, not a fixed value")
+}
+
+func TestNextBootstrapRetryDelay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		current time.Duration
+		max     time.Duration
+		want    time.Duration
+	}{
+		{name: "doubles under the cap", current: 2 * time.Second, max: 30 * time.Second, want: 4 * time.Second},
+		{name: "doubling exceeds the cap", current: 20 * time.Second, max: 30 * time.Second, want: 30 * time.Second},
+		{name: "already at the cap stays capped", current: 30 * time.Second, max: 30 * time.Second, want: 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, nextBootstrapRetryDelay(tt.current, tt.max))
+		})
+	}
+}
+
+// TestFullJitter_WithinRange pins the "full jitter" contract: the returned
+// wait is always in [0, ceiling]. Run many iterations since the function is
+// randomized -- a bug that only breaks the bound on some seeds still needs to
+// be caught.
+func TestFullJitter_WithinRange(t *testing.T) {
+	t.Parallel()
+
+	const ceiling = 30 * time.Second
+
+	for range 500 {
+		got := fullJitter(ceiling)
+
+		if got < 0 || got > ceiling {
+			t.Fatalf("fullJitter(%s) = %s, want in [0, %s]", ceiling, got, ceiling)
+		}
+	}
+}
+
+// TestFullJitter_ZeroCeilingReturnsZero guards the degenerate input: a zero
+// or negative ceiling must return zero rather than panicking (math/rand/v2's
+// N-family panics on a non-positive bound).
+func TestFullJitter_ZeroCeilingReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, time.Duration(0), fullJitter(0))
+	assert.Equal(t, time.Duration(0), fullJitter(-time.Second))
+}
+
+// fakeRegisterer is a minimal prometheus.Registerer whose Register always
+// returns a caller-supplied error, so tests can force a specific failure
+// without needing a genuine non-AlreadyRegisteredError condition out of the
+// real prometheus registry.
+type fakeRegisterer struct {
+	registerErr error
+}
+
+func (f fakeRegisterer) Register(prometheus.Collector) error { return f.registerErr }
+func (f fakeRegisterer) MustRegister(...prometheus.Collector) {
+	panic("fakeRegisterer.MustRegister is not exercised by these tests")
+}
+
+func (f fakeRegisterer) Unregister(prometheus.Collector) bool { return false }
+
+// TestRetrySafeRegisterer_SwallowsAlreadyRegistered pins the core behavior:
+// registering a fresh collector describing an already-registered metric
+// (same name/labels, different object -- exactly what a second
+// buildOrchestrator call produces) must not panic. Uses its own local
+// registry, not prometheus.DefaultRegisterer, so it is safe to parallelize.
+func TestRetrySafeRegisterer_SwallowsAlreadyRegistered(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	wrapped := retrySafeRegisterer{reg}
+
+	wrapped.MustRegister(prometheus.NewCounter(prometheus.CounterOpts{Name: "wt601_test_items_total", Help: "h"}))
+
+	assert.NotPanics(t, func() {
+		wrapped.MustRegister(prometheus.NewCounter(prometheus.CounterOpts{Name: "wt601_test_items_total", Help: "h"}))
+	})
+}
+
+// TestRetrySafeRegisterer_PanicsOnNonDuplicateError pins that the swallow is
+// scoped to AlreadyRegisteredError specifically: a genuine registration
+// failure (invalid descriptor, inconsistent labels, etc.) must still panic,
+// matching MustRegister's documented contract, not be silently dropped. Uses
+// a fake Registerer, not prometheus.DefaultRegisterer, so it is safe to
+// parallelize.
+func TestRetrySafeRegisterer_PanicsOnNonDuplicateError(t *testing.T) {
+	t.Parallel()
+
+	genuineErr := errors.New("boom: not a duplicate registration")
+	wrapped := retrySafeRegisterer{fakeRegisterer{registerErr: genuineErr}}
+
+	assert.PanicsWithError(t, genuineErr.Error(), func() {
+		wrapped.MustRegister(prometheus.NewCounter(prometheus.CounterOpts{Name: "wt601_test_items2_total", Help: "h"}))
+	})
+}
+
+// TestEnsureRetrySafeRegisterer_Idempotent pins that calling it more than
+// once (which happens on every bootstrap attempt after the first) is safe:
+// the registerer stays usable and does not nest wrappers indefinitely.
+//
+// NOT parallel: temporarily replaces prometheus.DefaultRegisterer.
+func TestEnsureRetrySafeRegisterer_Idempotent(t *testing.T) {
+	withFreshRegisterer(func() {
+		ensureRetrySafeRegisterer()
+		ensureRetrySafeRegisterer()
+		ensureRetrySafeRegisterer()
+
+		_, wrapped := prometheus.DefaultRegisterer.(retrySafeRegisterer)
+		assert.True(t, wrapped)
+
+		assert.NotPanics(t, func() {
+			prometheus.DefaultRegisterer.MustRegister(prometheus.NewCounter(prometheus.CounterOpts{Name: "wt601_test_items3_total", Help: "h"}))
+			prometheus.DefaultRegisterer.MustRegister(prometheus.NewCounter(prometheus.CounterOpts{Name: "wt601_test_items3_total", Help: "h"}))
+		})
+	})
+}
+
+// TestStartTunnelWithRetry_InstallsRetrySafeRegisterer pins the wiring: the
+// retry loop itself must install the fix, not just the pieces it is built
+// from -- a caller of StartTunnelWithRetry should never need to know this
+// detail exists.
+//
+// NOT parallel: temporarily replaces prometheus.DefaultRegisterer.
+func TestStartTunnelWithRetry_InstallsRetrySafeRegisterer(t *testing.T) {
+	dial := func(context.Context, *Config) error { return nil }
+
+	withFreshRegisterer(func() {
+		_, alreadyWrapped := prometheus.DefaultRegisterer.(retrySafeRegisterer)
+		require.False(t, alreadyWrapped, "test setup: registerer must start unwrapped")
+
+		err := startTunnelWithRetry(t.Context(), &Config{}, make(chan struct{}), dial,
+			testBaseDelay, testMaxDelay, identityJitter)
+		require.NoError(t, err)
+
+		_, wrapped := prometheus.DefaultRegisterer.(retrySafeRegisterer)
+		assert.True(t, wrapped, "startTunnelWithRetry must install the retry-safe registerer")
+	})
+}


### PR DESCRIPTION
# Pull Request

## Summary

The proxy treated any error from `tunnel.StartTunnel` as fatal and called `os.Exit(1)`, so a transient bootstrap-dial failure (cluster DNS not yet reachable right after a node reboot, the edge briefly unreachable) killed the process and left kubelet's CrashLoopBackOff growing to a five-minute wait long after the outage cleared. This retries the bootstrap dial with jittered capped backoff instead, so the pod stays up and reports NotReady while the condition clears on its own.

## Changes

- `internal/tunnel/retry.go`: new `StartTunnelWithRetry` wraps `StartTunnel` in a full-jitter exponential-backoff loop (2s doubling to a 30s cap, unbounded attempts), scoped to the window before the tunnel has ever registered a connection with the edge.
- `internal/tunnel/bootstrap.go`: `StartTunnel` now marks its two deterministic failure points, token parsing and protocol/TLS/config construction, as non-retryable, so a malformed token or an unsupported protocol setting still exits immediately instead of backing off on a failure that can never clear. `StartTunnel` also derives a per-attempt context and reuses a process-lifetime `Observer` (see Design notes) so a repeated call no longer leaks background goroutines or panics on Prometheus re-registration.
- `cmd/proxy/main.go`: `runTunnelMode` calls `StartTunnelWithRetry` instead of `StartTunnel`; a drain signal arriving during a backoff wait still shuts the pod down cleanly instead of retrying into the termination grace period.
- `README.md`, `docs/operations/troubleshooting.md`, `docs/guides/l7-proxy.md`, `docs/development/proxy-architecture.md`: document the new NotReady-during-retry behavior, how to tell an actively retrying pod from a stuck one, and how to tell a clearing outage from a rejected tunnel token.

## Design notes

**Why this is more than a retry loop around `StartTunnel`.** Before this change, `StartTunnel` ran exactly once per process, any error was fatal, so its implementation, and some of the vendored cloudflared code it calls into, quietly assumed "constructed once per process." A retry loop breaks that assumption on the very first retry, and three separate things had been built on it without anyone noticing, because nothing ever exercised a second call in the same process:

- `buildOrchestrator` and the vendored `supervisor.NewSupervisor` both unconditionally register cloudflared's own Prometheus collectors on the global `prometheus.DefaultRegisterer` on every call. A second call panics. This was already visible before this PR, as a test-suite quirk: `TestBuildOrchestrator_FullPath` was removed with a comment that cloudflared "registers a global metric twice and panics," worked around by only running error-path tests. That workaround was correct for what the test suite could do at the time, but it treated the symptom as a property of the test environment rather than a fact about the runtime. It meant nothing as long as `StartTunnel` only ever ran once, and would have panicked the first time a second bootstrap attempt actually happened. Fixed with a registerer wrapper that tolerates re-registering the same collector while still panicking on a genuine registration failure.
- `StartTunnel` spawns a goroutine to observe the first connection, and `buildOrchestrator` constructs several vendored objects that spawn their own background goroutines (a feature-selector refresh loop, an orchestrator proxy-close watcher, a DNS resolver refresh loop), all scoped to whatever context they're given. `StartTunnelWithRetry` reuses the same long-lived context across every attempt, so a failed attempt that never connects used to leave every one of those goroutines parked on that context until process shutdown: one leaked set per retry, unbounded for an outage long enough to matter, the exact scenario this issue is about. `StartTunnel` now derives a per-attempt context, cancelled the moment that specific call returns, and threads it through all of them instead.
- `connection.NewObserver` spawns an unconditional background goroutine with no way to stop it at all: no context parameter, no `Close()` method exposed by the vendored library, so it can't be fixed the same way. `buildTunnelConfig` now reuses one `Observer` for the process's lifetime instead of building a fresh one per call, which bounds the leak to a single goroutine total instead of one per retry. The trade-off, disclosed in the code rather than papered over: `Observer` has no way to unregister a sink, so each attempt's connection tracker stays registered as an event sink forever, small and fixed per attempt, but not bounded in total for a bootstrap loop retrying indefinitely. Sharing the tracker itself instead (avoiding even that) isn't safe: the vendored supervisor reads a shared tracker's connection history to decide protocol fallback, so one attempt's state would leak into another attempt's control flow, trading a bounded memory cost for an unbounded correctness one. A vendor patch giving `Observer` a proper `Close()`/`UnregisterSink` would close this cleanly; that's out of scope here, since it touches a separate repository (the cloudflared fork). Tracked as #606.

**Bootstrap-only scope.** The retry is scoped to the window before the tunnel has ever registered a connection with the edge. cloudflared reconnects on its own once a connection has been established; if `StartTunnel` still fails after that point, cloudflared has exhausted its own reconnect budget, and that failure is returned unchanged (still exits) rather than retried. The proxy's tunnel-connected readiness flag is a one-way latch by existing design, so silently retrying a post-connection failure would leave the pod reporting Ready while unable to serve any traffic, worse than the current exit.

**Rejected vs. unreachable tokens.** Classifying a well-formed but rejected tunnel token as terminal (distinct from "edge currently unreachable") turned out not to be reliable from this package. cloudflared's vendored supervisor consumes the permanent-vs-transient signal from the edge's registration RPC internally and never exposes it past its own reconnect loop, so telling "the edge rejected this token" apart from "the edge is temporarily unreachable" from the outside would mean matching cloudflared's internal error text, which is not a stable contract across vendor bumps. A token that fails to parse still exits immediately; a well-formed but rejected one now retries indefinitely with capped backoff, reporting NotReady and logging the error on every attempt instead. Documented in `troubleshooting.md` with the diagnostic steps.

**Jitter.** Backoff uses full jitter (a uniformly random wait in `[0, cap]`) rather than a fixed exponential delay, so replicas that hit the same failure at nearly the same time, every proxy replica dialing right after the same node reboot, don't retry in lockstep against the same recovering dependency.

**No new metric.** The existing `/readyz` plus a per-attempt ERROR log (attempt count, error, next backoff) is enough signal for now; a Prometheus counter for retry state can be added later if it turns out to be needed.

## Testing

- [x] All tests pass locally (`go test -race ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
- [x] Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
- [x] `go test -tags envtest -race ./internal/controller/...` passes (branch does not touch anything that suite covers, ran it anyway)
- [ ] Manual testing completed (if applicable): no live cluster in this environment; behavior is covered by the new unit tests in `internal/tunnel`

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [ ] CLAUDE.md updated (if workflow/standards changed): not applicable, no workflow or standards change

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [ ] Breaking changes documented (if any): none
- [x] Related issues referenced (if any)

## Additional Notes

`mkdocs build --strict` passes for the touched docs pages.

Closes #601
