### PR TITLE
ci: bound every workflow job with a timeout

### DIFF
--- a/.github/workflows/docs-validate.yaml
+++ b/.github/workflows/docs-validate.yaml
@@ -15,6 +15,7 @@ jobs:
   validate:
     name: Validate Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,6 +35,7 @@ jobs:
   deploy:
     name: Deploy Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       version: ${{ steps.version.outputs.version }}
       alias: ${{ steps.version.outputs.alias }}

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -30,6 +30,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -46,6 +47,7 @@ jobs:
     needs: validate
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -45,6 +45,7 @@ jobs:
   apply:
     name: Apply derived labels
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/pr-privileged.yaml
+++ b/.github/workflows/pr-privileged.yaml
@@ -14,6 +14,7 @@ jobs:
   upload-sarif:
     name: Upload Security Results
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >-
       github.event.workflow_run.event == 'pull_request'
     steps:
@@ -55,6 +56,7 @@ jobs:
   notify:
     name: Notify PR
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,6 +16,7 @@ jobs:
   save-pr-metadata:
     name: Save PR Metadata
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Save PR number
         run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
@@ -31,6 +32,7 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout PR code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -55,6 +57,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout PR code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -101,6 +104,7 @@ jobs:
   lint-workflows:
     name: Lint Workflows
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout PR code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -138,9 +142,23 @@ jobs:
       - name: Run shellcheck (composite action inline shell)
         run: ./hack/lint-action-shell.sh
 
+      - name: Every workflow job carries a timeout
+        run: |
+          set -euo pipefail
+          missing=0
+          for f in .github/workflows/*.y*ml; do
+            jobs="$(yq '.jobs | to_entries[] | select(.value.uses == null and .value["timeout-minutes"] == null) | .key' "${f}")"
+            for job in ${jobs}; do
+              echo "::error file=${f}::job '${job}' has no timeout-minutes"
+              missing=1
+            done
+          done
+          exit "${missing}"
+
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout PR code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -194,6 +212,11 @@ jobs:
     name: Build and Push (${{ matrix.component }}/${{ matrix.arch }})
     needs: [security, lint, lint-workflows, test]
     runs-on: ${{ matrix.runner }}
+    # ttl.sh sometimes stalls outright or slows a push to tens of minutes;
+    # without a bound a stalled leg holds the runner for the six-hour default.
+    # A push slower than this budget fails and needs a rerun once the
+    # registry recovers.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -289,6 +312,7 @@ jobs:
     name: Merge Manifests (${{ matrix.component }})
     runs-on: ubuntu-latest
     needs: build-and-push
+    timeout-minutes: 20
     strategy:
       matrix:
         include:
@@ -373,6 +397,7 @@ jobs:
   lint-chart:
     name: Lint Chart
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout PR code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -518,6 +543,8 @@ jobs:
     name: Build Chart
     runs-on: ubuntu-latest
     needs: [security, lint, lint-workflows, test, lint-chart]
+    # Same ttl.sh budget as the image legs: the chart push stalls the same way.
+    timeout-minutes: 60
     steps:
       - name: Checkout PR code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
   lint-chart:
     name: Lint Chart
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -162,6 +163,7 @@ jobs:
   build-and-push:
     name: Build and Push (${{ matrix.component }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -260,6 +262,7 @@ jobs:
     name: Merge Manifests (${{ matrix.component }})
     runs-on: ubuntu-latest
     needs: build-and-push
+    timeout-minutes: 20
     outputs:
       version: ${{ steps.version.outputs.version }}
     strategy:
@@ -384,6 +387,7 @@ jobs:
     name: Publish Helm Chart
     runs-on: ubuntu-latest
     needs: [build-and-push, lint-chart]
+    timeout-minutes: 20
     outputs:
       version: ${{ steps.version.outputs.version }}
     env:
@@ -617,6 +621,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [merge-manifests, publish-chart]
+    timeout-minutes: 15
     env:
       CHART_NAME: cloudflare-tunnel-gateway-controller
       CHART_OCI_REPO: ghcr.io/${{ github.repository_owner }}/charts/cloudflare-tunnel-gateway-controller

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -45,6 +45,7 @@ jobs:
   reflow:
     name: Reflow paragraphs test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -67,6 +68,7 @@ jobs:
   pr-labels:
     name: PR-labels mapping test (from PR checkout)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # Why this job exists separately from pr-labels.yaml's own
@@ -82,6 +84,7 @@ jobs:
   check-404-redirect:
     name: 404 redirect test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -93,6 +96,7 @@ jobs:
   check-doc-links:
     name: Doc-link guard test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 


### PR DESCRIPTION
## Summary

Every workflow job now carries a `timeout-minutes`, and `lint-workflows` fails a PR that adds a job without one. A stalled ttl.sh push held four image legs and the chart push for close to an hour with no progress; without a bound such a leg keeps the runner for the six-hour default.

## Changes

- Job budgets sized well above cold-cache durations: an hour for the ttl.sh image and chart pushes, twenty minutes for manifest merges, chart publishing and the docs deploy, a few minutes for linters and label sync.
- A `lint-workflows` step that lists every job without `timeout-minutes` (skipping reusable-workflow jobs, which cannot carry one) and fails closed if `yq` is missing.
- Trade-off stated in the commit: a ttl.sh push that would eventually succeed after tens of minutes now fails and needs a rerun once the registry recovers.

## Testing

- [x] All tests pass locally (`go test ./...`): no Go changes, workflow YAML only
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`): not applicable, `actionlint` clean on all workflows
- [x] Markdown linting passes (`markdownlint **/*.md`): no Markdown changes
- [x] Manual testing completed (if applicable): the guard step exercised three ways, a clean tree exits 0, a job without a timeout exits 1 with an annotation, a missing `yq` exits non-zero instead of passing silently

## Documentation

- [x] README updated (if needed): not needed, CI-internal change with no user-observable surface
- [x] Code comments added for complex logic: the two ttl.sh budget comments explain the choice
- [x] CLAUDE.md updated (if workflow/standards changed): not needed

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any): none
- [x] Related issues referenced (if any): none

## Additional Notes

Conformance and e2e suites are not rerun for this PR: the change is workflow YAML only, the binaries are identical to master, and master's tree passed both suites today (86 pass / 76 skip / 0 fail conformance, 30/0 e2e). Named improvements left out on purpose: a tighter push budget than 60 minutes (the observed stall distribution is bimodal, 1 to 4 min or 48 to 75 min), and moving the guard into `hack/` with its own test.
