### PR TITLE
chore(deps): update Go to 1.27.0 and golangci-lint to v2.13.2

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           # cache: true caches BOTH the module cache (~/go/pkg/mod) and the
           # build cache (~/.cache/go-build) keyed off go.sum. Issue #257.
           cache: true
@@ -78,7 +78,7 @@ jobs:
         # automatically when version is pinned (see action docs).
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.12.2
+          version: v2.13.2
           # --build-tags makes the linter compile the tag-gated test packages
           # (test/e2e, test/conformance, envtest suites) that a plain run
           # silently skips. Issue #402.
@@ -166,7 +166,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           # cache: true caches BOTH the module cache (~/go/pkg/mod) and
           # the build cache (~/.cache/go-build) keyed off go.sum. The
           # GOPATH/bin entry below picks up the setup-envtest binary

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.26.6'
+          go-version: '1.27.0'
           cache: true
 
       - name: Install kind

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,11 @@ linters:
   default: all
   disable:
     - depguard
+    # Requiring every struct field is wrong for this codebase either way:
+    # k8s API types (ObjectMeta, DeploymentSpec, ...) are built sparse by
+    # design. exhaustruct_v5 is the v2.13 successor enabled via default: all.
     - exhaustruct
+    - exhaustruct_v5
     - gochecknoinits
     - wsl
     - lll

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,7 +367,7 @@ Before writing any documentation:
 
 ## Build environment
 
-- **Go version**: tracked in `go.mod` (currently Go 1.26.x). Newer builtins like `new(expr)` are used freely — there is no fallback to `ptr.To` helpers.
+- **Go version**: tracked in `go.mod` (currently Go 1.27.x). Newer builtins like `new(expr)` are used freely — there is no fallback to `ptr.To` helpers.
 - **gopls quirk**: `gopls` versions older than the project's Go release sometimes flag `new(expr)` as `requires go1.26`. The real compiler accepts it; ignore that specific gopls noise.
 
 ## Design principles

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -4,7 +4,7 @@ This guide covers setting up a development environment for the Cloudflare Tunnel
 
 ## Prerequisites
 
-- Go 1.26.4 or later
+- Go 1.27.0 or later
 - kubectl configured with cluster access
 - A Kubernetes cluster (kind, minikube, or remote)
 - Cloudflare account with a tunnel configured

--- a/docs/gateway-api/_spec-audit/rows-HR.md
+++ b/docs/gateway-api/_spec-audit/rows-HR.md
@@ -5,7 +5,7 @@ Audited against vendored `sigs.k8s.io/gateway-api v1.6.1` (originally at v1.5.1;
 | ID | Keyword | Class | Status | Evidence | Notes |
 | --- | --- | --- | --- | --- | --- |
 | HR-01 | MUST | CTRL | MET | internal/proxy/router.go:677 extractHost | extractHost strips the port suffix before host match; port in Host header never participates. |
-| HR-02 | MUST | CTRL | MET | internal/proxy/handler.go:614-630 Director | Director preserves req.Host (restores X-Original-Host); no header mutation unless a URLRewrite/HeaderModifier filter is configured. |
+| HR-02 | MUST | CTRL | MET | internal/proxy/handler.go createReverseProxy Rewrite | The Rewrite func preserves req.Host (restores X-Original-Host); no header mutation unless a URLRewrite/HeaderModifier filter is configured. |
 | HR-03 | MUST | CTRL | MET | internal/controller/route_status.go (hostname inheritance) + docs/gateway-api/limitations.md:97 | Listener/Route hostname intersection enforced by routebinding validator; non-intersecting route hostnames are not bound/served. |
 | HR-04 | MUST | CRD | GAP | vendor httproute_types.go:125 (XValidation is `<gateway:experimental>`) | Rule-name uniqueness CEL rule is experimental-channel only; the shipped Standard CRD does not enforce it and neither does the controller. |
 | HR-05 | MUST | CTRL | MET | internal/proxy/router.go:510 computePriority + :22-30 priority consts | Tiered precedence: path-type > path-length > method > headers > queries, each tier dominating lower tiers; ties continue to next criterion. |

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/lexfrei/cloudflare-tunnel-gateway-controller
 
-go 1.26.6
+go 1.27.0
 
 require (
+	cel.dev/cel-go v0.32.0
 	github.com/cloudflare/cloudflare-go/v7 v7.9.0
 	github.com/cloudflare/cloudflared v0.0.0-20260722163246-3a2b45c2a511 // decorative, see replace + FIXME(#610) below
 	github.com/cockroachdb/errors v1.14.0
@@ -74,6 +75,7 @@ require (
 	github.com/go-openapi/swag/loading v0.28.0 // indirect
 	github.com/go-openapi/swag/mangling v0.28.0 // indirect
 	github.com/go-openapi/swag/netutils v0.28.0 // indirect
+	github.com/go-openapi/swag/pools v0.28.0 // indirect
 	github.com/go-openapi/swag/stringutils v0.28.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.28.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.28.0 // indirect
@@ -166,10 +168,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
 	zombiezen.com/go/capnproto2 v2.18.0+incompatible // indirect
 )
-
-require cel.dev/cel-go v0.32.0
-
-require github.com/go-openapi/swag/pools v0.28.0 // indirect
 
 // FIXME(#610): the require entry above is decorative, this unconditional replace
 // (no version on its left side) wins regardless of what version that line names.

--- a/internal/cfmetrics/errors.go
+++ b/internal/cfmetrics/errors.go
@@ -28,8 +28,7 @@ func ClassifyCloudflareError(err error) string {
 
 	// Check for typed errors from cloudflare-go SDK
 	// cloudflare.Error is an alias to apierror.Error in cloudflare-go v6
-	var apiErr *cloudflare.Error
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := errors.AsType[*cloudflare.Error](err); ok {
 		return classifyByStatusCode(apiErr.StatusCode)
 	}
 

--- a/internal/config/resolver_gateway.go
+++ b/internal/config/resolver_gateway.go
@@ -143,13 +143,11 @@ func (r *Resolver) resolveStatusConfig(
 	}
 
 	return &PerGatewayConfig{
-		ResolvedConfig: ResolvedConfig{
-			APIToken: apiToken,
-			// The tunnel lives in the token's account by construction.
-			AccountID:  parsed.AccountTag,
-			TunnelID:   parsed.TunnelID.String(),
-			ConfigName: "gatewayconfig:" + gwConfig.Namespace + "/" + gwConfig.Name,
-		},
+		APIToken: apiToken,
+		// The tunnel lives in the token's account by construction.
+		AccountID:         parsed.AccountTag,
+		TunnelID:          parsed.TunnelID.String(),
+		ConfigName:        "gatewayconfig:" + gwConfig.Namespace + "/" + gwConfig.Name,
 		TunnelToken:       token,
 		TunnelTokenSecret: tokenSecretName,
 		GatewayConfig:     gwConfig,

--- a/internal/controller/backendtlspolicy_controller.go
+++ b/internal/controller/backendtlspolicy_controller.go
@@ -938,7 +938,7 @@ func (r *BackendTLSPolicyReconciler) policiesForPeerChange(ctx context.Context, 
 		}
 
 		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKey{Namespace: peer.Namespace, Name: peer.Name},
+			Namespace: peer.Namespace, Name: peer.Name,
 		})
 	}
 
@@ -969,7 +969,7 @@ func (r *BackendTLSPolicyReconciler) policiesForConfigMapChange(ctx context.Cont
 		}
 
 		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKey{Namespace: policy.Namespace, Name: policy.Name},
+			Namespace: policy.Namespace, Name: policy.Name,
 		})
 	}
 
@@ -1045,7 +1045,7 @@ func (r *BackendTLSPolicyReconciler) policiesForRouteChange(ctx context.Context,
 		}
 
 		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKey{Namespace: policy.Namespace, Name: policy.Name},
+			Namespace: policy.Namespace, Name: policy.Name,
 		})
 	}
 
@@ -1087,7 +1087,7 @@ func (r *BackendTLSPolicyReconciler) policiesForGRPCRouteChange(ctx context.Cont
 		}
 
 		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKey{Namespace: policy.Namespace, Name: policy.Name},
+			Namespace: policy.Namespace, Name: policy.Name,
 		})
 	}
 

--- a/internal/controller/gateway_client_cert_test.go
+++ b/internal/controller/gateway_client_cert_test.go
@@ -377,7 +377,7 @@ func TestGatewayClientCertSentinels_AreStable(t *testing.T) {
 
 // Compile-time use of the fake client.Client interface so the import isn't
 // pruned when sentinel tests grow.
-var _ client.Client = (client.Client)(nil)
+var _ client.Client = client.Client(nil)
 
 func TestBuildClientCertResolvedRefsCondition_NilErr_TrueResolvedRefs(t *testing.T) {
 	t.Parallel()

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -862,7 +862,7 @@ func (r *GatewayReconciler) listenerSetToGateways(
 	}
 
 	return []reconcile.Request{{
-		NamespacedName: types.NamespacedName{Name: parent.Name, Namespace: parent.Namespace},
+		Name: parent.Name, Namespace: parent.Namespace,
 	}}
 }
 
@@ -905,10 +905,8 @@ func (r *GatewayReconciler) getAllManagedGateways(ctx context.Context) []reconci
 		gw := &gatewayList.Items[i]
 		if classNames[string(gw.Spec.GatewayClassName)] {
 			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      gw.Name,
-					Namespace: gw.Namespace,
-				},
+				Name:      gw.Name,
+				Namespace: gw.Namespace,
 			})
 		}
 	}
@@ -951,9 +949,9 @@ func (r *GatewayReconciler) gatewayConfigToGateways(ctx context.Context, obj cli
 			continue
 		}
 
-		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+		requests = append(requests, reconcile.Request{
 			Name: gateway.Name, Namespace: gateway.Namespace,
-		}})
+		})
 	}
 
 	return requests
@@ -1015,10 +1013,8 @@ func (r *GatewayReconciler) referenceGrantToGateways(
 		// Check if this Gateway references Secrets in the ReferenceGrant's namespace
 		if r.gatewayReferencesSecretsInNamespace(gateway, grant.Namespace) {
 			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      gateway.Name,
-					Namespace: gateway.Namespace,
-				},
+				Name:      gateway.Name,
+				Namespace: gateway.Namespace,
 			})
 		}
 	}

--- a/internal/controller/gateway_infra_reconciler.go
+++ b/internal/controller/gateway_infra_reconciler.go
@@ -229,8 +229,8 @@ func (r *GatewayInfraReconciler) ensureGeneratedAuthSecret(
 	}
 
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: gateway.Namespace},
-		Data:       map[string][]byte{generatedAuthTokenKey: []byte(token)},
+		Name: name, Namespace: gateway.Namespace,
+		Data: map[string][]byte{generatedAuthTokenKey: []byte(token)},
 	}
 
 	if err := controllerutil.SetControllerReference(gateway, secret, r.Scheme); err != nil {
@@ -449,7 +449,7 @@ func (r *GatewayInfraReconciler) applyDeployment(
 	desired := render.ProxyDeployment(input)
 
 	existing := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace},
+		Name: desired.Name, Namespace: desired.Namespace,
 	}
 
 	operation, err := controllerutil.CreateOrUpdate(ctx, r.Client, existing, func() error {
@@ -489,7 +489,7 @@ func (r *GatewayInfraReconciler) applyService(
 	desired := render.ConfigService(input)
 
 	existing := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace},
+		Name: desired.Name, Namespace: desired.Namespace,
 	}
 
 	operation, err := controllerutil.CreateOrUpdate(ctx, r.Client, existing, func() error {
@@ -530,9 +530,7 @@ func (r *GatewayInfraReconciler) applyNetworkPolicy(
 	// name matches DeploymentName like every other rendered object.
 	if !r.RenderNetworkPolicy {
 		return controllerutil.OperationResultNone, r.deleteIfOwned(ctx, gateway, &networkingv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: render.NetworkPolicyName(gateway), Namespace: gateway.Namespace,
-			},
+			Name: render.NetworkPolicyName(gateway), Namespace: gateway.Namespace,
 		})
 	}
 
@@ -543,7 +541,7 @@ func (r *GatewayInfraReconciler) applyNetworkPolicy(
 	})
 
 	existing := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace},
+		Name: desired.Name, Namespace: desired.Namespace,
 	}
 
 	operation, err := controllerutil.CreateOrUpdate(ctx, r.Client, existing, func() error {
@@ -574,14 +572,12 @@ func (r *GatewayInfraReconciler) applyAutoscaler(
 	desired := render.Autoscaler(input)
 	if desired == nil {
 		return controllerutil.OperationResultNone, r.deleteIfOwned(ctx, gateway, &autoscalingv2.HorizontalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: render.DeploymentName(gateway), Namespace: gateway.Namespace,
-			},
+			Name: render.DeploymentName(gateway), Namespace: gateway.Namespace,
 		})
 	}
 
 	existing := &autoscalingv2.HorizontalPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{Name: desired.Name, Namespace: desired.Namespace},
+		Name: desired.Name, Namespace: desired.Namespace,
 	}
 
 	operation, err := controllerutil.CreateOrUpdate(ctx, r.Client, existing, func() error {
@@ -620,18 +616,18 @@ func (r *GatewayInfraReconciler) applyAutoscaler(
 // never reachable by the foreign controller.
 func (r *GatewayInfraReconciler) cleanupRendered(ctx context.Context, gateway *gatewayv1.Gateway) error {
 	objects := []client.Object{
-		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		&appsv1.Deployment{
 			Name: render.DeploymentName(gateway), Namespace: gateway.Namespace,
-		}},
-		&corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		},
+		&corev1.Service{
 			Name: render.ConfigServiceName(gateway), Namespace: gateway.Namespace,
-		}},
-		&autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{
+		},
+		&autoscalingv2.HorizontalPodAutoscaler{
 			Name: render.DeploymentName(gateway), Namespace: gateway.Namespace,
-		}},
-		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{
+		},
+		&networkingv1.NetworkPolicy{
 			Name: render.NetworkPolicyName(gateway), Namespace: gateway.Namespace,
-		}},
+		},
 	}
 
 	for _, obj := range objects {
@@ -735,9 +731,9 @@ func (r *GatewayInfraReconciler) namespaceInfraGateways(
 			continue
 		}
 
-		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+		requests = append(requests, reconcile.Request{
 			Name: gateway.Name, Namespace: gateway.Namespace,
-		}})
+		})
 	}
 
 	return requests

--- a/internal/controller/gatewayclass_controller.go
+++ b/internal/controller/gatewayclass_controller.go
@@ -353,6 +353,6 @@ func gatewayClassForGateway(_ context.Context, obj client.Object) []reconcile.Re
 	}
 
 	return []reconcile.Request{
-		{NamespacedName: types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}},
+		{Name: string(gateway.Spec.GatewayClassName)},
 	}
 }

--- a/internal/controller/gatewayclassconfig_controller.go
+++ b/internal/controller/gatewayclassconfig_controller.go
@@ -252,7 +252,7 @@ func (r *GatewayClassConfigReconciler) secretToConfigs(
 
 		if SecretMatchesConfig(secret, cfg) {
 			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: cfg.Name},
+				Name: cfg.Name,
 			})
 		}
 	}

--- a/internal/controller/listenerset_controller.go
+++ b/internal/controller/listenerset_controller.go
@@ -1112,7 +1112,7 @@ func (r *ListenerSetReconciler) secretToListenerSets(
 		}
 
 		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{Name: listenerSet.Name, Namespace: listenerSet.Namespace},
+			Name: listenerSet.Name, Namespace: listenerSet.Namespace,
 		})
 	}
 
@@ -1151,7 +1151,7 @@ func (r *ListenerSetReconciler) referenceGrantToListenerSets(
 		}
 
 		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{Name: listenerSet.Name, Namespace: listenerSet.Namespace},
+			Name: listenerSet.Name, Namespace: listenerSet.Namespace,
 		})
 	}
 
@@ -1239,10 +1239,8 @@ func (r *ListenerSetReconciler) gatewayToListenerSets(
 		ls := &sets.Items[i]
 		if listenerSetTargetsGateway(ls, gateway) {
 			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      ls.Name,
-					Namespace: ls.Namespace,
-				},
+				Name:      ls.Name,
+				Namespace: ls.Namespace,
 			})
 		}
 	}

--- a/internal/controller/listenerset_route_mapper.go
+++ b/internal/controller/listenerset_route_mapper.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -45,10 +44,8 @@ func findRoutesAttachedToListenerSet(
 		}
 
 		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      route.GetName(),
-				Namespace: route.GetNamespace(),
-			},
+			Name:      route.GetName(),
+			Namespace: route.GetNamespace(),
 		})
 	}
 

--- a/internal/controller/mappers.go
+++ b/internal/controller/mappers.go
@@ -432,10 +432,8 @@ func FindRoutesForService(
 		}
 
 		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKey{
-				Name:      route.GetName(),
-				Namespace: route.GetNamespace(),
-			},
+			Name:      route.GetName(),
+			Namespace: route.GetNamespace(),
 		})
 	}
 
@@ -464,10 +462,8 @@ func FindRoutesForExternalBackend(
 		}
 
 		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKey{
-				Name:      route.GetName(),
-				Namespace: route.GetNamespace(),
-			},
+			Name:      route.GetName(),
+			Namespace: route.GetNamespace(),
 		})
 	}
 
@@ -501,10 +497,8 @@ func FindRoutesForEndpointSlice(
 		}
 
 		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKey{
-				Name:      route.GetName(),
-				Namespace: route.GetNamespace(),
-			},
+			Name:      route.GetName(),
+			Namespace: route.GetNamespace(),
 		})
 	}
 
@@ -536,10 +530,8 @@ func FindRoutesForReferenceGrant(
 
 		if slices.Contains(crossNsBackends, targetNamespace) {
 			requests = append(requests, reconcile.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      route.GetName(),
-					Namespace: route.GetNamespace(),
-				},
+				Name:      route.GetName(),
+				Namespace: route.GetNamespace(),
 			})
 		}
 	}
@@ -760,10 +752,8 @@ func FindRoutesForGateway(
 
 			if string(ref.Name) == gateway.Name && refNamespace == gateway.Namespace {
 				requests = append(requests, reconcile.Request{
-					NamespacedName: client.ObjectKey{
-						Name:      route.GetName(),
-						Namespace: route.GetNamespace(),
-					},
+					Name:      route.GetName(),
+					Namespace: route.GetNamespace(),
 				})
 
 				break
@@ -791,10 +781,8 @@ func FilterAcceptedRoutes(
 	for _, route := range routes {
 		if IsRouteAcceptedByGateway(ctx, cli, validator, controllerName, route, views) {
 			requests = append(requests, reconcile.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      route.GetName(),
-					Namespace: route.GetNamespace(),
-				},
+				Name:      route.GetName(),
+				Namespace: route.GetNamespace(),
 			})
 		}
 	}

--- a/internal/controller/proxy_auth_secret.go
+++ b/internal/controller/proxy_auth_secret.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cockroachdb/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -103,8 +102,8 @@ func ensureProxyAuthSecret(
 	}
 
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
-		Data:       map[string][]byte{dataKey: []byte(token)},
+		Name: key.Name, Namespace: key.Namespace,
+		Data: map[string][]byte{dataKey: []byte(token)},
 	}
 
 	if err := c.Create(ctx, secret); err != nil {

--- a/internal/proxy/external_backend_path_test.go
+++ b/internal/proxy/external_backend_path_test.go
@@ -60,7 +60,7 @@ func handlerForBackendURL(t *testing.T, backendURL string) *proxy.Handler {
 
 // TestHandler_ExternalBackendBasePath_Joined proves the backend URL's base path
 // (an ExternalBackend's spec.path, resolved into the backend URL) is prepended
-// to the request path on the wire. Without the Director honoring backendURL.Path
+// to the request path on the wire. Without the rewrite honoring backendURL.Path
 // the backend would see "/users" instead of "/v1/users".
 func TestHandler_ExternalBackendBasePath_Joined(t *testing.T) {
 	t.Parallel()
@@ -82,7 +82,7 @@ func TestHandler_ExternalBackendBasePath_Joined(t *testing.T) {
 
 // TestHandler_ExternalBackendBasePath_OverTunnelWriter exercises the same
 // path-join through the cloudflared HTTP/2 response writer contract (per the
-// project's tunnel-transport testing rule), proving the Director rewrite holds
+// project's tunnel-transport testing rule), proving the backend-URL rewrite holds
 // on the production write path, not only with httptest's recorder.
 func TestHandler_ExternalBackendBasePath_OverTunnelWriter(t *testing.T) {
 	t.Parallel()
@@ -110,7 +110,7 @@ func TestHandler_ExternalBackendBasePath_OverTunnelWriter(t *testing.T) {
 // into the backend URL) merges that query into the dialed request. Request
 // parameters take precedence: a key present in the request keeps its request
 // value, and only base keys absent from the request are appended. Without the
-// Director honoring backendURL.RawQuery the base query is silently dropped.
+// rewrite honoring backendURL.RawQuery the base query is silently dropped.
 func TestHandler_ExternalBackendBaseQuery_Merged(t *testing.T) {
 	t.Parallel()
 
@@ -175,7 +175,7 @@ func TestHandler_ExternalBackendBaseQuery_Merged(t *testing.T) {
 
 // TestHandler_ExternalBackendBaseQuery_OverTunnelWriter exercises the query
 // merge through the cloudflared HTTP/2 response writer contract (per the
-// project's tunnel-transport testing rule), proving the Director merge holds on
+// project's tunnel-transport testing rule), proving the base-query merge holds on
 // the production write path, not only with httptest's recorder.
 func TestHandler_ExternalBackendBaseQuery_OverTunnelWriter(t *testing.T) {
 	t.Parallel()

--- a/internal/proxy/filter.go
+++ b/internal/proxy/filter.go
@@ -62,7 +62,7 @@ const maxMirrorBodySize = 1 << 20 // 1 MiB
 type matchedPrefixKey struct{}
 
 // hostRewrittenHeader is an internal header set by URL rewrite filters
-// to signal the Director not to overwrite the Host header.
+// to signal the rewrite not to overwrite the Host header.
 // It is removed before the request is sent to the backend.
 const hostRewrittenHeader = "X-Proxy-Host-Rewritten"
 
@@ -276,7 +276,7 @@ func NewURLRewriter(config *URLRewriteConfig) Filter {
 func (f *urlRewriter) ProcessRequest(req *http.Request) *http.Response {
 	if f.config.Hostname != nil {
 		req.Host = *f.config.Hostname
-		// Mark host as rewritten so the Director does not overwrite it.
+		// Mark host as rewritten so the rewrite does not overwrite it.
 		req.Header.Set(hostRewrittenHeader, "true")
 	}
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -696,7 +696,17 @@ func (h *Handler) proxyToBackend(writer http.ResponseWriter, req *http.Request, 
 // backend-error metrics.
 func (h *Handler) createReverseProxy(backendURL *url.URL, protocol BackendProtocol, backendTLS *BackendTLSConfig, filters []Filter, headerTimeout time.Duration, hostname string) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
+		Rewrite: func(proxyReq *httputil.ProxyRequest) {
+			req := proxyReq.Out
+			restoreForwardingHeaders(proxyReq)
+
+			// Undo stdlib's pre-Rewrite query normalization (url.ParseQuery
+			// re-encode: drops semicolon-separated params, reorders the
+			// rest). Route matching — query matches included — already ran
+			// on the inbound request, so the outbound query is pure backend
+			// payload and belongs to it byte-for-byte.
+			req.URL.RawQuery = proxyReq.In.URL.RawQuery
+
 			req.URL.Scheme = backendURL.Scheme
 			req.URL.Host = backendURL.Host
 			applyBackendBasePath(req.URL, backendURL.Path, backendURL.RawQuery)
@@ -720,10 +730,6 @@ func (h *Handler) createReverseProxy(backendURL *url.URL, protocol BackendProtoc
 			}
 
 			req.Header.Del("X-Original-Host")
-
-			if _, ok := req.Header["User-Agent"]; !ok {
-				req.Header.Set("User-Agent", "")
-			}
 		},
 		Transport:    h.backendTransport(backendURL.Host, protocol, backendTLS, headerTimeout),
 		ErrorHandler: h.proxyErrorHandler(hostname),
@@ -735,10 +741,44 @@ func (h *Handler) createReverseProxy(backendURL *url.URL, protocol BackendProtoc
 	}
 }
 
+// restoreForwardingHeaders puts the inbound Forwarded / X-Forwarded-* headers
+// back on the outbound request and appends the immediate peer to
+// X-Forwarded-For. httputil.ReverseProxy strips all four from pr.Out before
+// calling Rewrite — anti-spoofing for proxies that mint their own values via
+// SetXForwarded. This proxy's upstream hop is the Cloudflare edge (or an
+// in-cluster hop), whose forwarding headers carry the real client IP and
+// scheme, so they must reach the backend intact. SetXForwarded is the wrong
+// tool here: it discards the inbound chain and invents X-Forwarded-Host/Proto
+// from the local request.
+func restoreForwardingHeaders(proxyReq *httputil.ProxyRequest) {
+	inHeader, outHeader := proxyReq.In.Header, proxyReq.Out.Header
+
+	for _, name := range []string{"Forwarded", "X-Forwarded-Host", "X-Forwarded-Proto"} {
+		if vals := inHeader.Values(name); len(vals) > 0 {
+			outHeader[name] = slices.Clone(vals)
+		}
+	}
+
+	xff := strings.Join(inHeader.Values("X-Forwarded-For"), ", ")
+
+	clientIP, _, err := net.SplitHostPort(proxyReq.In.RemoteAddr)
+	if err == nil {
+		if xff != "" {
+			xff += ", "
+		}
+
+		xff += clientIP
+	}
+
+	if xff != "" {
+		outHeader.Set("X-Forwarded-For", xff)
+	}
+}
+
 // applyBackendBasePath prepends a backend base path (e.g. an ExternalBackend's
 // spec.path) to target's path, joining with exactly one slash — the single-host
 // join httputil.NewSingleHostReverseProxy performs that the hand-written
-// Director (and the WebSocket upgrade builder) otherwise skip. It also merges
+// Rewrite func (and the WebSocket upgrade builder) otherwise skip. It also merges
 // the base path's query parameters (the "x=1" in a spec.path of "/v1?x=1") into
 // target's query via mergeBackendBaseQuery. A base of "" or "/" with no query —
 // the form every Service / ServiceImport backend URL takes — is a no-op, so only

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -104,6 +104,203 @@ func TestNewHandler_WSTimeoutOptions(t *testing.T) {
 	}
 }
 
+// TestHandler_ForwardedHeadersReachBackend pins the forwarding-header
+// contract of the reverse-proxy leg: the Cloudflare edge stamps
+// X-Forwarded-For / X-Forwarded-Proto (and clients may send Forwarded or
+// X-Forwarded-Host) on the inbound request, and backends rely on them for
+// client IP and original scheme. The proxy must pass all of them through
+// and append the immediate peer to X-Forwarded-For.
+//
+// This guards the httputil.ReverseProxy Rewrite path: stdlib strips all
+// four headers from the outbound request before Rewrite runs, so losing
+// the explicit restoration silently blinds every backend to the real
+// client.
+func TestHandler_ForwardedHeadersReachBackend(t *testing.T) {
+	t.Parallel()
+
+	edgeHeaders := map[string]string{
+		"X-Forwarded-For":   "203.0.113.7",
+		"X-Forwarded-Proto": "https",
+		"X-Forwarded-Host":  "app.example.com",
+		"Forwarded":         "for=203.0.113.7;proto=https",
+	}
+
+	tests := []struct {
+		name       string
+		inbound    map[string]string
+		remoteAddr string
+		want       map[string]string
+	}{
+		{
+			// The tunnel-and-edge shape with an in-cluster hop: chain
+			// survives, peer appended.
+			name:       "edge headers plus parseable peer",
+			inbound:    edgeHeaders,
+			remoteAddr: "192.0.2.1:1234",
+			want: map[string]string{
+				"X-Forwarded-For":   "203.0.113.7, 192.0.2.1",
+				"X-Forwarded-Proto": "https",
+				"X-Forwarded-Host":  "app.example.com",
+				"Forwarded":         "for=203.0.113.7;proto=https",
+			},
+		},
+		{
+			// Standalone mode, direct client, no upstream hop: the peer
+			// becomes the whole chain.
+			name:       "no inbound headers",
+			inbound:    nil,
+			remoteAddr: "192.0.2.1:1234",
+			want: map[string]string{
+				"X-Forwarded-For":   "192.0.2.1",
+				"X-Forwarded-Proto": "",
+				"X-Forwarded-Host":  "",
+				"Forwarded":         "",
+			},
+		},
+		{
+			// A request without a parseable host:port RemoteAddr (possible on
+			// synthetic in-process requests): nothing is appended and the
+			// edge-stamped chain passes through verbatim.
+			name:       "unparseable remote addr",
+			inbound:    edgeHeaders,
+			remoteAddr: "",
+			want: map[string]string{
+				"X-Forwarded-For":   "203.0.113.7",
+				"X-Forwarded-Proto": "https",
+				"X-Forwarded-Host":  "app.example.com",
+				"Forwarded":         "for=203.0.113.7;proto=https",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got http.Header
+
+			backend := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+				got = req.Header.Clone()
+				writer.WriteHeader(http.StatusOK)
+			}))
+			defer backend.Close()
+
+			router := proxy.NewRouter()
+			cfg := &proxy.Config{
+				Version: 1,
+				Rules: []proxy.RouteRule{{
+					Hostnames: []string{"app.example.com"},
+					Backends:  []proxy.BackendRef{{URL: backend.URL, Weight: 1}},
+				}},
+			}
+			require.NoError(t, router.UpdateConfig(cfg))
+
+			handler := proxy.NewHandler(router)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+			for name, value := range tt.inbound {
+				req.Header.Set(name, value)
+			}
+
+			req.RemoteAddr = tt.remoteAddr
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+
+			for name, value := range tt.want {
+				assert.Equal(t, value, got.Get(name), "header %s", name)
+			}
+		})
+	}
+}
+
+// TestHandler_QueryStringPassesThroughVerbatim pins raw-query passthrough:
+// the backend must receive the client's query byte-for-byte. Route matching
+// (query matches included) runs on the inbound request before the reverse
+// proxy is invoked, so the outbound query is pure backend payload — and
+// backends that parse semicolon-separated parameters (or any non-canonical
+// encoding) break if a hop re-encodes it.
+//
+// The pin guards the httputil.ReverseProxy Rewrite path: stdlib normalizes
+// Out.URL.RawQuery through url.ParseQuery before the callback runs, which
+// silently drops semicolon-separated parameters. The pin fails loudly if a
+// future stdlib bump widens that normalization.
+func TestHandler_QueryStringPassesThroughVerbatim(t *testing.T) {
+	t.Parallel()
+
+	const rawQuery = "a=1;b=2&c=3"
+
+	var gotQuery string
+
+	backend := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		gotQuery = req.URL.RawQuery
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	router := proxy.NewRouter()
+	cfg := &proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{{
+			Hostnames: []string{"app.example.com"},
+			Backends:  []proxy.BackendRef{{URL: backend.URL, Weight: 1}},
+		}},
+	}
+	require.NoError(t, router.UpdateConfig(cfg))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/path?"+rawQuery, nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, rawQuery, gotQuery,
+		"query string must reach the backend unmodified — re-encoding drops "+
+			"semicolon-separated parameters and reorders the rest")
+}
+
+// TestHandler_NoDefaultUserAgentInjected pins the third piece of the
+// forwarding contract: a client that sends no User-Agent must not have Go's
+// default ("Go-http-client/1.1") injected on the backend leg. The
+// suppression lives in stdlib after the Rewrite callback; this pin guards
+// against a stdlib relocation of that block.
+func TestHandler_NoDefaultUserAgentInjected(t *testing.T) {
+	t.Parallel()
+
+	var gotUserAgent string
+
+	backend := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		gotUserAgent = req.Header.Get("User-Agent")
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	router := proxy.NewRouter()
+	cfg := &proxy.Config{
+		Version: 1,
+		Rules: []proxy.RouteRule{{
+			Hostnames: []string{"app.example.com"},
+			Backends:  []proxy.BackendRef{{URL: backend.URL, Weight: 1}},
+		}},
+	}
+	require.NoError(t, router.UpdateConfig(cfg))
+
+	handler := proxy.NewHandler(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://app.example.com/", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.Empty(t, gotUserAgent,
+		"a request without User-Agent must reach the backend without one injected")
+}
+
 func TestHandler_NoMatchReturns404(t *testing.T) {
 	t.Parallel()
 
@@ -604,7 +801,7 @@ func TestHandler_PruneTransportsRemovesStaleHostFromSyncMap(t *testing.T) {
 	assert.False(t, loaded, "transport for backend A should be pruned after config update removed it")
 }
 
-func TestHandler_URLRewriteHostnamePreservedByDirector(t *testing.T) {
+func TestHandler_URLRewriteHostnamePreservedByProxy(t *testing.T) {
 	t.Parallel()
 
 	receivedHost := make(chan string, 1)
@@ -651,7 +848,7 @@ func TestHandler_URLRewriteHostnamePreservedByDirector(t *testing.T) {
 
 	host := <-receivedHost
 	assert.Equal(t, "rewritten.example.com", host,
-		"Director should preserve the rewritten hostname, not overwrite it with the backend host")
+		"the proxy rewrite should preserve the rewritten hostname, not overwrite it with the backend host")
 }
 
 func TestHandler_AllZeroWeightBackendsReturns500(t *testing.T) {

--- a/internal/proxy/handler_websocket.go
+++ b/internal/proxy/handler_websocket.go
@@ -215,7 +215,7 @@ func buildBackendUpgradeRequest(req *http.Request, backendURL *url.URL) *http.Re
 	}
 	// Prepend the backend's base path and merge its query (e.g. an
 	// ExternalBackend's spec.path "/v1?x=1"), matching the non-WebSocket
-	// Director; a no-op for Service/ServiceImport URLs.
+	// rewrite; a no-op for Service/ServiceImport URLs.
 	applyBackendBasePath(outReq.URL, backendURL.Path, backendURL.RawQuery)
 	outReq.RequestURI = ""
 	outReq.Host = backendURL.Host

--- a/internal/proxy/handler_websocket_basepath_internal_test.go
+++ b/internal/proxy/handler_websocket_basepath_internal_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestBuildBackendUpgradeRequest_BasePath proves a WebSocket upgrade to a
 // backend whose URL carries a base path (an ExternalBackend's spec.path) joins
-// that base onto the request path, matching the non-WebSocket Director. A
+// that base onto the request path, matching the non-WebSocket rewrite. A
 // backend URL without a base path forwards the request path unchanged.
 func TestBuildBackendUpgradeRequest_BasePath(t *testing.T) {
 	t.Parallel()
@@ -62,7 +62,7 @@ func TestBuildBackendUpgradeRequest_BasePath(t *testing.T) {
 // TestBuildBackendUpgradeRequest_BaseQuery proves a WebSocket upgrade to a
 // backend whose URL carries a query (an ExternalBackend's spec.path of the form
 // "/v1?x=1") merges that query into the upgrade request, matching the
-// non-WebSocket Director. Request parameters take precedence over base ones.
+// non-WebSocket rewrite. Request parameters take precedence over base ones.
 func TestBuildBackendUpgradeRequest_BaseQuery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -2997,5 +2997,5 @@ func roundTripWSEcho(t *testing.T, proxySrv *httptest.Server, payload string) {
 	require.NoError(t, err, "reading the echoed frame back must succeed")
 	assert.Equal(t, payload, string(buf[:n]),
 		"echo round-trip through proxy must preserve payload verbatim — "+
-			"any difference proves the Director / transport corrupted the upgrade")
+			"any difference proves the rewrite / transport corrupted the upgrade")
 }

--- a/internal/render/hpa.go
+++ b/internal/render/hpa.go
@@ -3,7 +3,6 @@ package render
 import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Autoscaler renders the per-Gateway HorizontalPodAutoscaler when
@@ -32,12 +31,10 @@ func Autoscaler(input *Input) *autoscalingv2.HorizontalPodAutoscaler {
 	// hot-loop), the apiserver does NOT default HPA Behavior, so omitting it
 	// causes no drift — the convergence envtest's no-op re-apply confirms this.
 	return &autoscalingv2.HorizontalPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        DeploymentName(input.Gateway),
-			Namespace:   input.Gateway.Namespace,
-			Labels:      resourceLabels(input.Gateway),
-			Annotations: resourceAnnotations(input.Gateway),
-		},
+		Name:        DeploymentName(input.Gateway),
+		Namespace:   input.Gateway.Namespace,
+		Labels:      resourceLabels(input.Gateway),
+		Annotations: resourceAnnotations(input.Gateway),
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: "apps/v1",

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -243,16 +243,14 @@ func ProxyDeployment(input *Input) *appsv1.Deployment {
 	podAnnotations[authTokenHashAnnotation] = hashToken(input.AuthToken)
 
 	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      DeploymentName(input.Gateway),
-			Namespace: input.Gateway.Namespace,
-			Labels:    resourceLabels(input.Gateway),
-			// A fresh resourceAnnotations call (not podAnnotations): the
-			// Deployment object's OWN annotations must NOT carry the pod
-			// template's rotation-hash entries, and resourceAnnotations returns
-			// an independent map so this cannot alias the mutated podAnnotations.
-			Annotations: resourceAnnotations(input.Gateway),
-		},
+		Name:      DeploymentName(input.Gateway),
+		Namespace: input.Gateway.Namespace,
+		Labels:    resourceLabels(input.Gateway),
+		// A fresh resourceAnnotations call (not podAnnotations): the
+		// Deployment object's OWN annotations must NOT carry the pod
+		// template's rotation-hash entries, and resourceAnnotations returns
+		// an independent map so this cannot alias the mutated podAnnotations.
+		Annotations: resourceAnnotations(input.Gateway),
 		Spec: appsv1.DeploymentSpec{
 			Replicas: replicaCount(input.Config),
 			Selector: &metav1.LabelSelector{MatchLabels: selectorLabels(input.Gateway)},
@@ -358,10 +356,8 @@ func proxyEnv(input *Input) []corev1.EnvVar {
 			Name: "TUNNEL_TOKEN",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: input.Config.Spec.TunnelTokenSecretRef.Name,
-					},
-					Key: input.Config.Spec.TunnelTokenSecretRef.KeyOr(tunnelTokenKey),
+					Name: input.Config.Spec.TunnelTokenSecretRef.Name,
+					Key:  input.Config.Spec.TunnelTokenSecretRef.KeyOr(tunnelTokenKey),
 				},
 			},
 		},
@@ -379,8 +375,8 @@ func proxyEnv(input *Input) []corev1.EnvVar {
 		Name: "PROXY_AUTH_TOKEN",
 		ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: authName},
-				Key:                  authKey,
+				Name: authName,
+				Key:  authKey,
 			},
 		},
 	})
@@ -451,12 +447,10 @@ var (
 
 func httpProbe(path string, spec probeSpec) *corev1.Probe {
 	return &corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path:   path,
-				Port:   intstr.FromString(configPortName),
-				Scheme: corev1.URISchemeHTTP,
-			},
+		HTTPGet: &corev1.HTTPGetAction{
+			Path:   path,
+			Port:   intstr.FromString(configPortName),
+			Scheme: corev1.URISchemeHTTP,
 		},
 		InitialDelaySeconds: spec.initialDelay,
 		PeriodSeconds:       spec.period,
@@ -473,12 +467,10 @@ func httpProbe(path string, spec probeSpec) *corev1.Probe {
 // not-yet-ready pods — their readiness depends on that very config.
 func ConfigService(input *Input) *corev1.Service {
 	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        ConfigServiceName(input.Gateway),
-			Namespace:   input.Gateway.Namespace,
-			Labels:      resourceLabels(input.Gateway),
-			Annotations: resourceAnnotations(input.Gateway),
-		},
+		Name:        ConfigServiceName(input.Gateway),
+		Namespace:   input.Gateway.Namespace,
+		Labels:      resourceLabels(input.Gateway),
+		Annotations: resourceAnnotations(input.Gateway),
 		Spec: corev1.ServiceSpec{
 			Type:                     corev1.ServiceTypeClusterIP,
 			ClusterIP:                corev1.ClusterIPNone,
@@ -519,12 +511,10 @@ func ProxyNetworkPolicy(input NetworkPolicyInput) *networkingv1.NetworkPolicy {
 	}
 
 	return &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        NetworkPolicyName(input.Gateway),
-			Namespace:   input.Gateway.Namespace,
-			Labels:      resourceLabels(input.Gateway),
-			Annotations: resourceAnnotations(input.Gateway),
-		},
+		Name:        NetworkPolicyName(input.Gateway),
+		Namespace:   input.Gateway.Namespace,
+		Labels:      resourceLabels(input.Gateway),
+		Annotations: resourceAnnotations(input.Gateway),
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: selectorLabels(input.Gateway)},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},

--- a/internal/tunnel/origin.go
+++ b/internal/tunnel/origin.go
@@ -67,7 +67,7 @@ func (p *GatewayOriginProxy) ProxyHTTP(
 		req = tracedReq.Clone(tracedReq.Context())
 		req.Header.Set("Connection", "Upgrade")
 		req.Header.Set("Upgrade", "websocket")
-		req.Header.Set("Sec-Websocket-Version", "13")
+		req.Header.Set("Sec-WebSocket-Version", "13")
 		req.ContentLength = 0
 		req.Body = nil
 

--- a/internal/tunnel/origin_test.go
+++ b/internal/tunnel/origin_test.go
@@ -209,7 +209,7 @@ func TestGatewayOriginProxy_ProxyHTTP_HTTPNoMatchStays404(t *testing.T) {
 // headers from the request before invoking OriginProxy.ProxyHTTP — the
 // upgrade is signalled instead via the third (`isWebsocket bool`) parameter.
 // Native cloudflared re-injects `Connection: Upgrade`, `Upgrade: websocket`,
-// and `Sec-Websocket-Version: 13` before forwarding to origin (see
+// and `Sec-WebSocket-Version: 13` before forwarding to origin (see
 // vendor/github.com/cloudflare/cloudflared/proxy/proxy.go:proxyHTTPRequest).
 //
 // Our L7 handler routes the request through the custom
@@ -231,7 +231,7 @@ func TestGatewayOriginProxy_ProxyHTTP_WebSocketReinjectsHeaders(t *testing.T) {
 	handler := http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 		gotConnection = req.Header.Get("Connection")
 		gotUpgrade = req.Header.Get("Upgrade")
-		gotWSVersion = req.Header.Get("Sec-Websocket-Version")
+		gotWSVersion = req.Header.Get("Sec-WebSocket-Version")
 	})
 
 	proxy := tunnel.NewGatewayOriginProxy(handler, nil)
@@ -258,7 +258,7 @@ func TestGatewayOriginProxy_ProxyHTTP_WebSocketReinjectsHeaders(t *testing.T) {
 		"isWebsocket=true MUST re-inject Upgrade: websocket so the backend "+
 			"completes the RFC 6455 handshake instead of returning 400")
 	assert.Equal(t, "13", gotWSVersion,
-		"Sec-Websocket-Version: 13 is the only WebSocket version this proxy "+
+		"Sec-WebSocket-Version: 13 is the only WebSocket version this proxy "+
 			"path supports; native cloudflared pins it the same way")
 }
 


### PR DESCRIPTION
# Pull Request

## Summary

Move the toolchain to Go 1.27.0 and golangci-lint v2.13.2. The bumps gate each other: a linter built with go1.26 refuses to load a `go 1.27` module, and v2.13 is the first line built on go1.27. So they land together, with the code changes the new toolchain demands. Supersedes #655, #656 and #658.

## Changes

- Go 1.27.0 in `go.mod` and CI workflows, golangci-lint v2.13.2 in CI. `go mod tidy` on 1.27 also merges the split require blocks.
- Disable `exhaustruct_v5`, the renamed successor of the already-disabled `exhaustruct` that `default: all` silently re-enables. Requiring every struct field is wrong for sparse-by-design k8s API types.
- Go 1.27 modernizations: promoted-field composite literals, `errors.AsType`, RFC 6455 spelling of `Sec-WebSocket-Version` (wire-identical, `http.Header` canonicalizes both spellings to the same key).
- Migrate the proxy from the deprecated `ReverseProxy.Director` to `Rewrite`. Rewrite mode strips `Forwarded`/`X-Forwarded-*` and re-encodes the query string before the callback runs; the new code restores both, so the data plane stays byte-identical. Behind the Cloudflare edge those headers carry the real client IP and scheme, and the query belongs to the backend verbatim. Three new handler tests pin the forwarding-header, raw-query and User-Agent contracts.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable)

Gateway API conformance and the custom e2e suite pass on a fresh kind cluster against a live Cloudflare Tunnel. The envtest-tagged controller suite passes against a real apiserver.

## Documentation

- [x] README updated (if needed): no changes needed, README states no Go version
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

`docs/development/setup.md` now says Go 1.27.0: 1.26 can no longer build the module.

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any): none
- [x] Related issues referenced (if any): none

## Additional Notes

The `Director` to `Rewrite` migration is the only part with data-plane exposure. Every behavioral difference between the two stdlib modes was checked against the Go 1.27 `reverseproxy.go` source, and each restored contract has a dedicated test.
