### PR TITLE
docs(readme): add Gateway API conformance badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Release](https://img.shields.io/github/v/release/lexfrei/cloudflare-tunnel-gateway-controller)](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/releases)
 [![CI](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/actions/workflows/pr.yaml/badge.svg)](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/actions/workflows/pr.yaml)
 [![Docs](https://img.shields.io/badge/docs-cf.k8s.lex.la-blue)](https://cf.k8s.lex.la)
+[![Gateway API Conformance](https://img.shields.io/badge/Gateway%20Conformance%20v1.6.1-Conformant-green)](https://gateway-api.sigs.k8s.io/docs/implementations/list/#lexfreis-cloudflare-tunnel-gateway-controller)
 
 Kubernetes controller implementing Gateway API for Cloudflare Tunnel.
 


### PR DESCRIPTION
## Summary

Listed as a conformant Gateway API implementation for v1.6.1 now that the upstream report merged. This adds the badge to the README.

## Changes

- Conformance badge in the README, linking to the entry in the upstream implementations list

## Testing

- [x] Markdown linting passes (`markdownlint-cli2 'README.md'`)
- [x] Badge image and list URL both return 200

No code changed, so Go tests and linters don't apply.

## Documentation

- [x] README updated

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code

Closes #428
