### PR TITLE
ci: pin tool installs, scope job permissions, verify PR artifacts by digest

### DIFF
--- a/.github/workflows/pr-privileged.yaml
+++ b/.github/workflows/pr-privileged.yaml
@@ -119,5 +119,5 @@ jobs:
               issue_number: prNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## Container images available\n\n**Controller (amd64 + arm64):**\n\`\`\`bash\npodman pull ${ctrlTag}\n\`\`\`\n\n**Proxy (amd64 + arm64):**\n\`\`\`bash\npodman pull ${proxyTag}\n\`\`\`\n\n## Helm chart available\n\n**Install chart:**\n\`\`\`bash\nhelm install test oci://ttl.sh/cloudflare-tunnel-gateway-controller --version ${chartVersion}\n\`\`\`\n\n> **Note:** Rebuilt on every commit. ttl.sh keeps them for about an hour; the CI run's artifacts hold the same build for a day.`
+              body: `## Container images available\n\n**Controller (amd64 + arm64):**\n\`\`\`bash\npodman pull ${ctrlTag}\n\`\`\`\n\n**Proxy (amd64 + arm64):**\n\`\`\`bash\npodman pull ${proxyTag}\n\`\`\`\n\n## Helm chart available\n\n**Install chart:**\n\`\`\`bash\nhelm install test oci://ttl.sh/cloudflare-tunnel-gateway-controller --version ${chartVersion}\n\`\`\`\n\n> **Note:** Rebuilt on every commit. The \`-1d\` in these tags sets no lifetime -- ttl.sh reads one only from a tag that is entirely a duration -- so they expire on ttl.sh's own schedule. Re-run this PR's CI to republish.`
             })

--- a/.github/workflows/pr-privileged.yaml
+++ b/.github/workflows/pr-privileged.yaml
@@ -119,5 +119,5 @@ jobs:
               issue_number: prNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## Container images available\n\n**Controller (amd64 + arm64):**\n\`\`\`bash\npodman pull ${ctrlTag}\n\`\`\`\n\n**Proxy (amd64 + arm64):**\n\`\`\`bash\npodman pull ${proxyTag}\n\`\`\`\n\n## Helm chart available\n\n**Install chart:**\n\`\`\`bash\nhelm install test oci://ttl.sh/cloudflare-tunnel-gateway-controller --version ${chartVersion}\n\`\`\`\n\n> **Note:** Images and chart are rebuilt on every commit and expire after 24 hours (hosted on ttl.sh).`
+              body: `## Container images available\n\n**Controller (amd64 + arm64):**\n\`\`\`bash\npodman pull ${ctrlTag}\n\`\`\`\n\n**Proxy (amd64 + arm64):**\n\`\`\`bash\npodman pull ${proxyTag}\n\`\`\`\n\n## Helm chart available\n\n**Install chart:**\n\`\`\`bash\nhelm install test oci://ttl.sh/cloudflare-tunnel-gateway-controller --version ${chartVersion}\n\`\`\`\n\n> **Note:** Rebuilt on every commit. ttl.sh keeps them for about an hour; the CI run's artifacts hold the same build for a day.`
             })

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -332,6 +332,13 @@ jobs:
           - component: proxy
             image: ttl.sh/cf-tunnel-gateway-proxy
     steps:
+      # Only for hack/verify-manifest-children.sh, which the reference export
+      # below runs; nothing else in this job reads the checkout.
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          sparse-checkout: hack
+
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -351,8 +358,10 @@ jobs:
           IMAGE_NAME="${{ matrix.image }}"
           TAG="pr-${PR_NUMBER}-1d"
           # pr-N-1d is a human alias that later runs overwrite. The run-scoped
-          # tag names this run, and nothing in this repo's CI writes it a
-          # second time, so the digest read back from it is this run's build.
+          # tag is narrower -- nothing in this repo's CI writes it twice -- but
+          # ttl.sh is unauthenticated and the run id is public, so it is not a
+          # name only this job can write. What it resolves to is checked in
+          # `Export image reference` rather than trusted.
           RUN_TAG="pr-${PR_NUMBER}-run-${{ github.run_id }}"
 
           # Build image references array
@@ -394,12 +403,22 @@ jobs:
           set -euo pipefail
 
           PR_NUMBER="${{ github.event.pull_request.number }}"
+          IMAGE_NAME="${{ matrix.image }}"
           mkdir -p /tmp/refs
           digest="$(docker buildx imagetools inspect \
-            "${{ matrix.image }}:pr-${PR_NUMBER}-run-${{ github.run_id }}" \
+            "${IMAGE_NAME}:pr-${PR_NUMBER}-run-${{ github.run_id }}" \
             --format '{{.Manifest.Digest}}')"
-          echo "${{ matrix.image }}@${digest}" \
-            > "/tmp/refs/${{ matrix.component }}.ref"
+          ref="${IMAGE_NAME}@${digest}"
+
+          # Resolving that tag is the one step here that trusts the registry,
+          # so re-read what it gave us by digest -- the index checked below is
+          # then exactly the one this reference names -- and require it to list
+          # every per-arch image this run pushed. An index substituted in the
+          # gap between the manifest push and this read cannot.
+          docker buildx imagetools inspect "${ref}" --raw > /tmp/index.json
+          hack/verify-manifest-children.sh /tmp/index.json /tmp/digests
+
+          echo "${ref}" > "/tmp/refs/${{ matrix.component }}.ref"
           cat "/tmp/refs/${{ matrix.component }}.ref"
 
       - name: Upload image reference

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -98,9 +98,9 @@ jobs:
 
   # Lint shell scripts and GitHub Actions workflows. actionlint validates the
   # workflow YAML and runs shellcheck on inline `run:` blocks; the standalone
-  # shellcheck pass covers hack/*.sh. Both tools are installed at a pinned,
-  # Renovate-tracked version into /usr/local/bin (ahead of the runner's
-  # /usr/bin) so actionlint picks up the pinned shellcheck for inline blocks.
+  # shellcheck pass covers hack/*.sh. shellcheck is installed at a pinned,
+  # Renovate-tracked version into /usr/local/bin, ahead of the runner's
+  # /usr/bin, so actionlint picks up the pinned one for inline blocks.
   lint-workflows:
     name: Lint Workflows
     runs-on: ubuntu-latest
@@ -108,6 +108,14 @@ jobs:
     steps:
       - name: Checkout PR code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # actionlint is built from source below, so the toolchain that builds it
+      # is pinned here rather than left to whatever the runner image ships.
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.27.1'
+          cache: false
 
       - name: Install shellcheck and actionlint
         run: |
@@ -118,6 +126,12 @@ jobs:
           # renovate: datasource=github-releases depName=rhysd/actionlint
           ACTIONLINT_VERSION="v1.7.12"
 
+          # actionlint is Go, so the checksum database attests it. shellcheck
+          # is Haskell and its releases carry no checksum or signature file,
+          # so it stays a plain download (#723).
+          go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
           tmp="$(mktemp -d)"
 
           curl --retry 5 --retry-delay 1 -sSLo "${tmp}/shellcheck.tar.xz" \
@@ -125,13 +139,8 @@ jobs:
           tar -xJf "${tmp}/shellcheck.tar.xz" -C "${tmp}"
           sudo install "${tmp}/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
 
-          curl --retry 5 --retry-delay 1 -sSLo "${tmp}/actionlint.tar.gz" \
-            "https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz"
-          tar -xzf "${tmp}/actionlint.tar.gz" -C "${tmp}" actionlint
-          sudo install "${tmp}/actionlint" /usr/local/bin/actionlint
-
           shellcheck --version
-          actionlint --version
+          "$(go env GOPATH)/bin/actionlint" --version
 
       - name: Run shellcheck (hack scripts)
         run: shellcheck hack/*.sh
@@ -188,7 +197,9 @@ jobs:
 
       - name: Setup envtest
         run: |
-          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+          # renovate: datasource=go depName=sigs.k8s.io/controller-runtime/tools/setup-envtest
+          SETUP_ENVTEST_VERSION="v0.24.1"
+          go install "sigs.k8s.io/controller-runtime/tools/setup-envtest@${SETUP_ENVTEST_VERSION}"
           setup-envtest use
 
       - name: Run tests
@@ -426,25 +437,27 @@ jobs:
           # hard-errors with "plugin source does not support verification".
           # Disable it explicitly — the flag is needed for the source type,
           # not because the plugin is unsigned.
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
+          # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
+          HELM_UNITTEST_VERSION="v1.1.2"
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git \
+            --version "${HELM_UNITTEST_VERSION}" --verify=false
 
           # JSON schema validator
-          pip install check-jsonschema
+          # renovate: datasource=pypi depName=check-jsonschema
+          CHECK_JSONSCHEMA_VERSION="0.38.0"
+          pip install "check-jsonschema==${CHECK_JSONSCHEMA_VERSION}"
 
-          # Artifact Hub CLI — extracted from upstream image so the tag binds
-          # both version and content digest (Renovate's docker datasource
-          # auto-bumps the tag without a separate sha256 line to drift).
+          # Artifact Hub CLI, extracted from the upstream image.
           # renovate: datasource=docker depName=artifacthub/ah
-          AH_VERSION="v1.23.0"
-          docker create --name ah-tmp "artifacthub/ah:${AH_VERSION}"
+          AH_IMAGE="artifacthub/ah:v1.23.0@sha256:e5d2a2cdef85aac4928e8176ffaad24746c5fe961d64ff6856f7222957095356"
+          docker create --name ah-tmp "${AH_IMAGE}"
           sudo docker cp ah-tmp:/usr/local/bin/ah /usr/local/bin/ah
           docker rm ah-tmp
           sudo chmod +x /usr/local/bin/ah
 
-          # helm-docs — same rationale as ah above.
           # renovate: datasource=docker depName=jnorwood/helm-docs
-          HELM_DOCS_VERSION="v1.14.2"
-          docker create --name helm-docs-tmp "jnorwood/helm-docs:${HELM_DOCS_VERSION}"
+          HELM_DOCS_IMAGE="jnorwood/helm-docs:v1.14.2@sha256:7e562b49ab6b1dbc50c3da8f2dd6ffa8a5c6bba327b1c6335cc15ce29267979c"
+          docker create --name helm-docs-tmp "${HELM_DOCS_IMAGE}"
           sudo docker cp helm-docs-tmp:/usr/bin/helm-docs /usr/local/bin/helm-docs
           docker rm helm-docs-tmp
           sudo chmod +x /usr/local/bin/helm-docs

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -350,6 +350,10 @@ jobs:
           PR_NUMBER="${{ github.event.pull_request.number }}"
           IMAGE_NAME="${{ matrix.image }}"
           TAG="pr-${PR_NUMBER}-1d"
+          # pr-N-1d is a human alias that later runs overwrite. The run-scoped
+          # tag names this run, and nothing in this repo's CI writes it a
+          # second time, so the digest read back from it is this run's build.
+          RUN_TAG="pr-${PR_NUMBER}-run-${{ github.run_id }}"
 
           # Build image references array
           images=()
@@ -365,6 +369,7 @@ jobs:
           for attempt in 1 2 3; do
             if docker buildx imagetools create \
               --tag "${IMAGE_NAME}:${TAG}" \
+              --tag "${IMAGE_NAME}:${RUN_TAG}" \
               "${images[@]}"; then
               ok=1
               break
@@ -380,6 +385,30 @@ jobs:
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
           docker buildx imagetools inspect "${{ matrix.image }}:pr-${PR_NUMBER}-1d"
+
+      # The tag this job just wrote is mutable and anonymous -- anyone can
+      # overwrite it on ttl.sh. Publish the manifest-list digest so local
+      # verification can address the image by content instead.
+      - name: Export image reference
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          mkdir -p /tmp/refs
+          digest="$(docker buildx imagetools inspect \
+            "${{ matrix.image }}:pr-${PR_NUMBER}-run-${{ github.run_id }}" \
+            --format '{{.Manifest.Digest}}')"
+          echo "${{ matrix.image }}@${digest}" \
+            > "/tmp/refs/${{ matrix.component }}.ref"
+          cat "/tmp/refs/${{ matrix.component }}.ref"
+
+      - name: Upload image reference
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: image-ref-${{ matrix.component }}
+          path: /tmp/refs/*
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Generate build summary
         run: |
@@ -696,6 +725,27 @@ jobs:
           [[ "${ok}" -eq 1 ]]
 
           echo "Chart pushed to: oci://ttl.sh/cloudflare-tunnel-gateway-controller:${CHART_VERSION}"
+
+      # The commit rides along with the chart so a consumer can bind the
+      # artifact to the revision it was built from.
+      - name: Assemble chart bundle
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          CHART_VERSION="0.0.0-pr.${PR_NUMBER}-1d"
+
+          mkdir -p /tmp/bundle
+          cp "cloudflare-tunnel-gateway-controller-${CHART_VERSION}.tgz" /tmp/bundle/
+          echo "${{ github.event.pull_request.head.sha }}" > /tmp/bundle/head-sha.txt
+
+      - name: Upload chart bundle artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ci-chart-bundle
+          path: /tmp/bundle/*
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Generate chart summary
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -430,7 +430,8 @@ jobs:
             echo "podman pull ${IMAGE_TAG}"
             echo '```'
             echo ""
-            echo "> **Note:** Image expires in 24 hours (ttl.sh)"
+            echo "> **Note:** ttl.sh keeps this image for about an hour. The CI run's"
+            echo "> artifacts hold the same build for a day."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Lint and test Helm chart
@@ -763,5 +764,6 @@ jobs:
             echo "helm install test oci://ttl.sh/cloudflare-tunnel-gateway-controller --version ${CHART_VERSION}"
             echo '```'
             echo ""
-            echo "> **Note:** Chart expires in 24 hours (ttl.sh)"
+            echo "> **Note:** ttl.sh keeps this chart for about an hour. The CI run's"
+            echo "> artifacts hold the same build for a day."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -412,11 +412,12 @@ jobs:
 
           # Resolving that tag is the one step here that trusts the registry,
           # so re-read what it gave us by digest -- the index checked below is
-          # then exactly the one this reference names -- and require it to list
-          # every per-arch image this run pushed. An index substituted in the
-          # gap between the manifest push and this read cannot.
+          # then exactly the one this reference names -- and require it to have
+          # been assembled out of the images this run pushed. An index
+          # substituted in the gap between the manifest push and this read
+          # cannot have been.
           docker buildx imagetools inspect "${ref}" --raw > /tmp/index.json
-          hack/verify-manifest-children.sh /tmp/index.json /tmp/digests
+          hack/verify-manifest-children.sh "${IMAGE_NAME}" /tmp/index.json /tmp/digests
 
           echo "${ref}" > "/tmp/refs/${{ matrix.component }}.ref"
           cat "/tmp/refs/${{ matrix.component }}.ref"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -450,8 +450,9 @@ jobs:
             echo "podman pull ${IMAGE_TAG}"
             echo '```'
             echo ""
-            echo "> **Note:** ttl.sh keeps this image for about an hour. The CI run's"
-            echo "> artifacts hold the same build for a day."
+            echo "> **Note:** The \`-1d\` suffix sets no lifetime -- ttl.sh reads one"
+            echo "> only from a tag that is entirely a duration -- so this image expires"
+            echo "> on ttl.sh's own schedule. Re-run this workflow to republish it."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Lint and test Helm chart
@@ -784,6 +785,7 @@ jobs:
             echo "helm install test oci://ttl.sh/cloudflare-tunnel-gateway-controller --version ${CHART_VERSION}"
             echo '```'
             echo ""
-            echo "> **Note:** ttl.sh keeps this chart for about an hour. The CI run's"
-            echo "> artifacts hold the same build for a day."
+            echo "> **Note:** The \`-1d\` suffix sets no lifetime -- ttl.sh reads one"
+            echo "> only from a tag that is entirely a duration. This run also attaches"
+            echo "> the packaged chart as an artifact, kept for one day."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -412,10 +412,11 @@ jobs:
 
           # Resolving that tag is the one step here that trusts the registry,
           # so re-read what it gave us by digest -- the index checked below is
-          # then exactly the one this reference names -- and require it to have
-          # been assembled out of the images this run pushed. An index
-          # substituted in the gap between the manifest push and this read
-          # cannot have been.
+          # then exactly the one this reference names -- and require its
+          # manifests to be exactly the ones this run pushed. Exactly, not
+          # merely including: what gets deployed is selected by platform later,
+          # so an index that keeps ours and adds one more would otherwise hand
+          # over the extra.
           docker buildx imagetools inspect "${ref}" --raw > /tmp/index.json
           hack/verify-manifest-children.sh "${IMAGE_NAME}" /tmp/index.json /tmp/digests
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Floor for the whole workflow; each job below widens it to exactly what its
+# own steps need. Nothing but the two cosign steps mints Sigstore tokens.
 permissions:
-  contents: write
-  packages: write
-  id-token: write
+  contents: read
 
 jobs:
   # Lint and test Helm chart (runs in parallel with build-and-push)
@@ -20,6 +20,8 @@ jobs:
     name: Lint Chart
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -48,25 +50,27 @@ jobs:
           # hard-errors with "plugin source does not support verification".
           # Disable it explicitly — the flag is needed for the source type,
           # not because the plugin is unsigned.
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
+          # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
+          HELM_UNITTEST_VERSION="v1.1.2"
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git \
+            --version "${HELM_UNITTEST_VERSION}" --verify=false
 
           # JSON schema validator
-          pip install check-jsonschema
+          # renovate: datasource=pypi depName=check-jsonschema
+          CHECK_JSONSCHEMA_VERSION="0.38.0"
+          pip install "check-jsonschema==${CHECK_JSONSCHEMA_VERSION}"
 
-          # Artifact Hub CLI — extracted from upstream image so the tag binds
-          # both version and content digest (Renovate's docker datasource
-          # auto-bumps the tag without a separate sha256 line to drift).
+          # Artifact Hub CLI, extracted from the upstream image.
           # renovate: datasource=docker depName=artifacthub/ah
-          AH_VERSION="v1.23.0"
-          docker create --name ah-tmp "artifacthub/ah:${AH_VERSION}"
+          AH_IMAGE="artifacthub/ah:v1.23.0@sha256:e5d2a2cdef85aac4928e8176ffaad24746c5fe961d64ff6856f7222957095356"
+          docker create --name ah-tmp "${AH_IMAGE}"
           sudo docker cp ah-tmp:/usr/local/bin/ah /usr/local/bin/ah
           docker rm ah-tmp
           sudo chmod +x /usr/local/bin/ah
 
-          # helm-docs — same rationale as ah above.
           # renovate: datasource=docker depName=jnorwood/helm-docs
-          HELM_DOCS_VERSION="v1.14.2"
-          docker create --name helm-docs-tmp "jnorwood/helm-docs:${HELM_DOCS_VERSION}"
+          HELM_DOCS_IMAGE="jnorwood/helm-docs:v1.14.2@sha256:7e562b49ab6b1dbc50c3da8f2dd6ffa8a5c6bba327b1c6335cc15ce29267979c"
+          docker create --name helm-docs-tmp "${HELM_DOCS_IMAGE}"
           sudo docker cp helm-docs-tmp:/usr/bin/helm-docs /usr/local/bin/helm-docs
           docker rm helm-docs-tmp
           sudo chmod +x /usr/local/bin/helm-docs
@@ -164,6 +168,10 @@ jobs:
     name: Build and Push (${{ matrix.component }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    # ghcr push only; the images are signed one job later.
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -263,6 +271,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     strategy:
@@ -388,6 +400,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-push, lint-chart]
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     env:
@@ -422,12 +438,9 @@ jobs:
 
       - name: Install yq
         run: |
-          # yq — extracted from upstream image so the tag binds both version
-          # and content digest (Renovate's docker datasource auto-bumps the
-          # tag without a separate sha256 line to drift).
           # renovate: datasource=docker depName=mikefarah/yq
-          YQ_VERSION="4.53.6"
-          docker create --name yq-tmp "mikefarah/yq:${YQ_VERSION}"
+          YQ_IMAGE="mikefarah/yq:4.53.6@sha256:cfc4eee658595834ef304eadb0c3ea721f3b7cb6404ad8b7cb909cc5b5145b23"
+          docker create --name yq-tmp "${YQ_IMAGE}"
           sudo docker cp yq-tmp:/usr/bin/yq /usr/local/bin/yq
           docker rm yq-tmp
           sudo chmod +x /usr/local/bin/yq
@@ -622,6 +635,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [merge-manifests, publish-chart]
     timeout-minutes: 15
+    # Creates the release and uploads the chart tarball to it.
+    permissions:
+      contents: write
     env:
       CHART_NAME: cloudflare-tunnel-gateway-controller
       CHART_OCI_REPO: ghcr.io/${{ github.repository_owner }}/charts/cloudflare-tunnel-gateway-controller

--- a/.github/workflows/scheduled-e2e.yaml
+++ b/.github/workflows/scheduled-e2e.yaml
@@ -31,12 +31,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-    env:
-      CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-      CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-      CF_TUNNEL_ID: ${{ secrets.CF_TUNNEL_ID }}
-      CF_TUNNEL_TOKEN: ${{ secrets.CF_TUNNEL_TOKEN }}
-      CF_TUNNEL_HOSTNAME: ${{ secrets.CF_TUNNEL_HOSTNAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -47,6 +41,10 @@ jobs:
           go-version: '1.27.1'
           cache: true
 
+      # Built from source rather than downloaded as a release asset: the Go
+      # checksum database then attests the module contents, which a curl of an
+      # unverified binary does not, and which a checksum literal in this file
+      # would only do until the next version bump silently outran it.
       - name: Install kind
         run: |
           set -euo pipefail
@@ -54,23 +52,47 @@ jobs:
           # renovate: datasource=github-releases depName=kubernetes-sigs/kind
           KIND_VERSION="v0.33.0"
 
-          curl --retry 5 --retry-delay 1 -sSLo /tmp/kind \
-            "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
-          sudo install /tmp/kind /usr/local/bin/kind
-          kind version
+          # A blip reaching proxy.golang.org would otherwise fail the run and
+          # file a failing-test issue; the e2e retry below covers the suite
+          # steps only.
+          for attempt in 1 2 3; do
+            if go install "sigs.k8s.io/kind@${KIND_VERSION}"; then
+              break
+            fi
+            [[ "${attempt}" -lt 3 ]] || exit 1
+            echo "go install failed (attempt ${attempt}); retrying in 5s..."
+            sleep 5
+          done
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          "$(go env GOPATH)/bin/kind" version
 
       # The setup script builds images, creates a kind cluster, deploys the
       # controller against the live test tunnel, and runs the e2e suite.
       # A failure here can be a transient (registry hiccup, edge blip), so the
       # first attempt is continue-on-error and a full second attempt decides.
+      # The Cloudflare credentials are scoped to these two steps: they are the
+      # only ones that need them, and the toolchain installs above have no
+      # business being able to read them.
       - name: Setup cluster and run e2e (attempt 1)
         id: attempt1
         continue-on-error: true
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_TUNNEL_ID: ${{ secrets.CF_TUNNEL_ID }}
+          CF_TUNNEL_TOKEN: ${{ secrets.CF_TUNNEL_TOKEN }}
+          CF_TUNNEL_HOSTNAME: ${{ secrets.CF_TUNNEL_HOSTNAME }}
         run: ./hack/conformance-setup.sh --test-e2e
 
       - name: Setup cluster and run e2e (attempt 2)
         id: attempt2
         if: steps.attempt1.outcome == 'failure'
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_TUNNEL_ID: ${{ secrets.CF_TUNNEL_ID }}
+          CF_TUNNEL_TOKEN: ${{ secrets.CF_TUNNEL_TOKEN }}
+          CF_TUNNEL_HOSTNAME: ${{ secrets.CF_TUNNEL_HOSTNAME }}
         run: ./hack/conformance-setup.sh --test-e2e
 
       # continue-on-error reports a failed attempt 1 as a green step, so a

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -16,6 +16,8 @@ on:
       - hack/conformance-setup_test.sh
       - hack/verify-ci-bundle.sh
       - hack/pull-ci-image.sh
+      - hack/verify-manifest-children.sh
+      - .github/workflows/pr.yaml
       # labels.yml is included so the drift-pin tests
       # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
       # when labels.yml changes. Cost: the reflow job also fires on
@@ -38,6 +40,8 @@ on:
       - hack/conformance-setup_test.sh
       - hack/verify-ci-bundle.sh
       - hack/pull-ci-image.sh
+      - hack/verify-manifest-children.sh
+      - .github/workflows/pr.yaml
       # labels.yml is included so the drift-pin tests
       # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
       # when labels.yml changes. Cost: the reflow job also fires on

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -14,6 +14,8 @@ on:
       - hack/check-doc-links_test.sh
       - hack/conformance-setup.sh
       - hack/conformance-setup_test.sh
+      - hack/verify-ci-bundle.sh
+      - hack/pull-ci-image.sh
       # labels.yml is included so the drift-pin tests
       # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
       # when labels.yml changes. Cost: the reflow job also fires on
@@ -34,6 +36,8 @@ on:
       - hack/check-doc-links_test.sh
       - hack/conformance-setup.sh
       - hack/conformance-setup_test.sh
+      - hack/verify-ci-bundle.sh
+      - hack/pull-ci-image.sh
       # labels.yml is included so the drift-pin tests
       # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
       # when labels.yml changes. Cost: the reflow job also fires on

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -12,6 +12,8 @@ on:
       - docs/404.html
       - hack/check-doc-links.sh
       - hack/check-doc-links_test.sh
+      - hack/conformance-setup.sh
+      - hack/conformance-setup_test.sh
       # labels.yml is included so the drift-pin tests
       # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
       # when labels.yml changes. Cost: the reflow job also fires on
@@ -30,6 +32,8 @@ on:
       - docs/404.html
       - hack/check-doc-links.sh
       - hack/check-doc-links_test.sh
+      - hack/conformance-setup.sh
+      - hack/conformance-setup_test.sh
       # labels.yml is included so the drift-pin tests
       # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
       # when labels.yml changes. Cost: the reflow job also fires on
@@ -103,3 +107,16 @@ jobs:
       # Pins hack/check-doc-links.sh (the live gate runs in pr.yaml's lint job).
       - name: Run doc-link guard tests
         run: bash hack/check-doc-links_test.sh
+
+  conformance-setup:
+    name: Conformance-setup guard test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Pins the prerequisite block of hack/conformance-setup.sh. The suite
+      # stubs uname, so both the macOS and the Linux branch are exercised here
+      # on a Linux runner.
+      - name: Run conformance-setup guard tests
+        run: bash hack/conformance-setup_test.sh

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -17,6 +17,7 @@ on:
       - hack/verify-ci-bundle.sh
       - hack/pull-ci-image.sh
       - hack/verify-manifest-children.sh
+      - hack/find-ci-run.sh
       - .github/workflows/pr.yaml
       # labels.yml is included so the drift-pin tests
       # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run
@@ -41,6 +42,7 @@ on:
       - hack/verify-ci-bundle.sh
       - hack/pull-ci-image.sh
       - hack/verify-manifest-children.sh
+      - hack/find-ci-run.sh
       - .github/workflows/pr.yaml
       # labels.yml is included so the drift-pin tests
       # (TYPE_TO_KIND/SCOPE_TO_AREA/SIZE_BUCKETS ↔ labels.yml) re-run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -581,9 +581,9 @@ Official Gateway API conformance suite (`sigs.k8s.io/gateway-api/conformance` v1
 # Setup + run the custom e2e suite (smoke-level; lighter than --test)
 ./hack/conformance-setup.sh --test-e2e
 
-# Verify a PR's CI artifact: skip the local build, deploy the PR's published
-# ttl.sh chart+images (the chart already pins the ttl.sh image refs). Add --test
-# to also run the suite. ttl.sh artifacts expire 24h after the PR's CI ran.
+# Verify a PR's CI artifact: skip the local build, deploy the chart and images
+# PR #N's CI run published, resolved by digest from that run (needs gh + jq).
+# Add --test to also run the suite. The run's artifacts are kept for one day.
 ./hack/conformance-setup.sh --use-ci-images <PR-number>
 
 # Run all conformance tests on existing cluster (CONFORMANCE_TUNNEL_HOSTNAME is required)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -287,6 +287,20 @@ Conformance tests validate that the controller implements the Gateway API specif
 - Cloudflare Tunnel configured and working
 - GatewayClass `cloudflare-tunnel` created
 
+`hack/conformance-setup.sh` builds that cluster for you. It needs `docker`, `kind`, `helm`, `kubectl` and `go`; on macOS it also needs `colima`, which is where the docker daemon comes from there. Other hosts use their native daemon and are not asked for it.
+
+### Deploying a Pull Request's CI Build
+
+`hack/conformance-setup.sh --use-ci-images <PR>` deploys what that PR's CI already built instead of building locally. It additionally needs `gh` (authenticated for this repository) and `jq`.
+
+The chart comes from the CI run's own artifacts and the images are pulled by the digest that run recorded, so nothing on this path is addressed by a tag. That matters because CI also publishes to `ttl.sh`, an anonymous registry where the PR tag is writable by anyone, and the cluster this script builds holds real Cloudflare credentials.
+
+A digest binds content, not trust. On a fork PR the artifacts are produced by the fork's own copy of `pr.yaml`, so the recorded digest is exactly as trustworthy as the PR author. Read the fork's diff before any un-sandboxed run that holds real credentials, the same as before.
+
+The run is chosen by the PR's current head commit, and only a successful `pull_request` run for that exact commit is accepted — a run for an earlier head is refused rather than silently deployed. `hack/verify-ci-bundle.sh` then checks the downloaded artifacts before anything reaches the cluster: both image references must be digest-pinned, the recorded commit must match the head being verified, and the chart must carry that PR's version. Any mismatch aborts before the cluster is created.
+
+Two independent clocks limit how long a PR stays deployable this way. The chart and the recorded digests are GitHub Actions artifacts, kept for one day. The images live on `ttl.sh`, which derives a tag's lifetime from the tag itself and only when the whole tag is a bare duration; `pr-<N>-1d` is not, so those images get the service's default lifetime, which the repository does not control and which is shorter. Whichever expires first, the fix is the same: re-run the PR's CI.
+
 ### Running E2E Tests
 
 E2E tests run against a live kind cluster with Cloudflare Tunnel and L7 proxy deployed. `E2E_TUNNEL_HOSTNAME` is required — the suite fails fast without it. `hack/conformance-setup.sh` threads it automatically from `.env` or the exported environment (`CF_TUNNEL_HOSTNAME`); set it explicitly when running `go test` by hand.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -299,7 +299,7 @@ A digest binds content, not trust. On a fork PR the artifacts are produced by th
 
 The run is chosen by the PR's current head commit, and only a successful `pull_request` run for that exact commit is accepted — a run for an earlier head is refused rather than silently deployed. `hack/verify-ci-bundle.sh` then checks the downloaded artifacts before anything reaches the cluster: both image references must be digest-pinned, the recorded commit must match the head being verified, and the chart must carry that PR's version. Any mismatch aborts before the cluster is created.
 
-Two independent clocks limit how long a PR stays deployable this way. The chart and the recorded digests are GitHub Actions artifacts, kept for one day. The images live on `ttl.sh`, which derives a tag's lifetime from the tag itself and only when the whole tag is a bare duration; `pr-<N>-1d` is not, so those images get the service's default lifetime, which the repository does not control and which is shorter. Whichever expires first, the fix is the same: re-run the PR's CI.
+Two independent clocks limit how long a PR stays deployable this way. The chart and the recorded digests are GitHub Actions artifacts, kept for one day. The images live on `ttl.sh`, which derives a tag's lifetime from the tag itself and only when the whole tag is a bare duration; `pr-<N>-1d` is not, so those images expire on whatever default the service applies, which this repository does not control. The artifacts outliving the images would not help either way, because `controller.ref` records a digest rather than the image: once ttl.sh drops the blobs, the reference points at nothing. Whichever runs out first, the fix is the same: re-run the PR's CI.
 
 ### Running E2E Tests
 

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -283,17 +283,17 @@ fi
 
 # --- Step 1b: Pull the CI images (needs the daemon from Step 1) ---
 # Deliberately ahead of Step 2, which deletes the operator's existing test
-# clusters. The GitHub artifacts verified above live for a day; the images
-# they point at live on ttl.sh for about an hour, so "artifacts present,
-# images gone" is the common failure for this flag and it must not cost a
-# cluster to discover.
+# clusters. The artifacts verified above record digests, not images, so they
+# outliving the images buys nothing: once ttl.sh drops the blobs those
+# references point at nothing. "Artifacts present, images gone" is the failure
+# this flag hits, and it must not cost a cluster to discover.
 if [[ -n "${CI_PR_NUMBER}" ]]; then
   info "Pulling PR #${CI_PR_NUMBER}'s images by digest..."
   ci_arch="$(go env GOARCH)"
   "${REPO_ROOT}/hack/pull-ci-image.sh" "${CI_CONTROLLER_REF}" "${CONTROLLER_IMAGE}" "${ci_arch}" \
-    || die "Cannot pull ${CI_CONTROLLER_REF}. ttl.sh keeps images for about an hour -- re-run PR #${CI_PR_NUMBER}'s CI to republish."
+    || die "Cannot pull ${CI_CONTROLLER_REF}. The image is gone from ttl.sh -- re-run PR #${CI_PR_NUMBER}'s CI to republish."
   "${REPO_ROOT}/hack/pull-ci-image.sh" "${CI_PROXY_REF}" "${PROXY_IMAGE}" "${ci_arch}" \
-    || die "Cannot pull ${CI_PROXY_REF}. ttl.sh keeps images for about an hour -- re-run PR #${CI_PR_NUMBER}'s CI to republish."
+    || die "Cannot pull ${CI_PROXY_REF}. The image is gone from ttl.sh -- re-run PR #${CI_PR_NUMBER}'s CI to republish."
 fi
 
 # --- Step 2: Delete old v2-test-* clusters ---

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -2,7 +2,7 @@
 # conformance-setup.sh — Reproducible setup for Gateway API conformance tests.
 #
 # This script:
-#   1. Ensures colima is running
+#   1. Ensures colima is running (macOS only)
 #   2. Deletes old v2-test-* kind clusters
 #   3. Creates a fresh kind cluster with random suffix
 #   4. Installs Gateway API CRDs (channel selectable via --channel)
@@ -28,10 +28,10 @@
 #   - .env file in repo root with: CF_API_TOKEN, CF_ACCOUNT_ID, CF_TUNNEL_ID,
 #     CF_TUNNEL_TOKEN, CF_TUNNEL_HOSTNAME (the edge hostname routing to the tunnel);
 #     alternatively (CI) the same variables already exported in the environment
-#   - colima (macOS only), docker, kind, helm, kubectl, go installed
+#   - docker, kind, helm, kubectl, go installed; colima additionally on macOS
 #
-# In GitHub Actions (GITHUB_ACTIONS=true) the colima requirement is skipped:
-# the runner's native docker daemon is used directly.
+# colima is the macOS docker backend; every other host uses its native docker
+# daemon directly and is not asked for it.
 
 set -euo pipefail
 
@@ -168,11 +168,12 @@ if [[ "${RUN_TESTS}" == "true" && "${RUN_E2E}" == "true" ]]; then
 fi
 
 # --- Pre-flight checks ---
-# colima is the macOS docker backend; GitHub Actions runners have a native
-# docker daemon, so the requirement (and the start step below) is skipped there.
+# colima is the macOS docker backend. Every other host -- Linux workstation,
+# GitHub Actions runner -- has a native docker daemon, so the requirement (and
+# the start step below) applies to macOS only.
 info "Checking prerequisites..."
 TOOLS=(docker kind helm kubectl go)
-if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+if [[ "$(uname -s)" == "Darwin" ]]; then
   TOOLS+=(colima)
 fi
 for tool in "${TOOLS[@]}"; do
@@ -223,8 +224,8 @@ if [[ -n "${CI_PR_NUMBER}" ]]; then
     || die "Chart ${CI_CHART_VERSION} not found on ttl.sh. ttl.sh artifacts expire after 24h (the '1d' tag) — re-run PR #${CI_PR_NUMBER}'s CI to republish."
 fi
 
-# --- Step 1: Ensure colima is running (macOS only; CI uses native docker) ---
-if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+# --- Step 1: Ensure colima is running (macOS only) ---
+if [[ "$(uname -s)" == "Darwin" ]]; then
   info "Checking colima..."
   if ! colima status >/dev/null 2>&1; then
     info "Starting colima..."

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -6,10 +6,10 @@
 #   2. Deletes old v2-test-* kind clusters
 #   3. Creates a fresh kind cluster with random suffix
 #   4. Installs Gateway API CRDs (channel selectable via --channel)
-#   5. Builds controller + proxy images          (skipped in --use-ci-images mode)
-#   6. Loads images into kind                     (skipped in --use-ci-images mode)
+#   5. Builds controller + proxy images   (pulled by digest in --use-ci-images)
+#   6. Loads images into kind
 #   7. Creates secrets from .env
-#   8. Deploys controller via helm               (local chart, or PR's ttl.sh chart)
+#   8. Deploys controller via helm        (local chart, or the PR run's chart)
 #   9. Waits for readiness
 #  10. Optionally runs conformance tests
 #
@@ -19,8 +19,9 @@
 #   ./hack/conformance-setup.sh --channel standard # install standard-channel CRDs
 #                                                  # (default: experimental)
 #   ./hack/conformance-setup.sh --skip-build     # skip image build (reuse existing)
-#   ./hack/conformance-setup.sh --use-ci-images N  # deploy PR #N's published ttl.sh
-#                                                  # chart+images (no local build)
+#   ./hack/conformance-setup.sh --use-ci-images N  # deploy the chart and images
+#                                                  # PR #N's CI run published
+#                                                  # (no local build)
 #   ./hack/conformance-setup.sh --test-e2e       # setup + run the custom e2e suite
 #                                                  # (smoke-level; lighter than --test)
 #
@@ -28,7 +29,8 @@
 #   - .env file in repo root with: CF_API_TOKEN, CF_ACCOUNT_ID, CF_TUNNEL_ID,
 #     CF_TUNNEL_TOKEN, CF_TUNNEL_HOSTNAME (the edge hostname routing to the tunnel);
 #     alternatively (CI) the same variables already exported in the environment
-#   - docker, kind, helm, kubectl, go installed; colima additionally on macOS
+#   - docker, kind, helm, kubectl, go installed; colima additionally on macOS;
+#     gh and jq additionally for --use-ci-images
 #
 # colima is the macOS docker backend; every other host uses its native docker
 # daemon directly and is not asked for it.
@@ -60,6 +62,10 @@ CI_PR_NUMBER=""
 # gatewayAPIChannel=standard (it reads the channel annotation off the installed
 # CRDs and rejects a mix of channels).
 CHANNEL="experimental"
+# Set once the kind cluster is up. Failures before that (credential check,
+# CI-bundle verification) have no pod state to dump, and a "Cluster
+# unreachable" banner on top of their own message reads like a second fault.
+CLUSTER_CREATED=false
 
 # --- Helpers ---
 info()  { echo "==> $*"; }
@@ -127,8 +133,9 @@ dump_diagnostics() {
 
 on_exit() {
   local exit_code=$1
+  [[ -n "${CI_BUNDLE_DIR:-}" ]] && rm -rf "${CI_BUNDLE_DIR}"
   # 130 = operator interrupt (Ctrl-C), not a failure worth a dump.
-  if [[ "${exit_code}" -ne 0 && "${exit_code}" -ne 130 ]]; then
+  if [[ "${exit_code}" -ne 0 && "${exit_code}" -ne 130 && "${CLUSTER_CREATED}" == "true" ]]; then
     dump_diagnostics
   fi
 }
@@ -176,6 +183,9 @@ TOOLS=(docker kind helm kubectl go)
 if [[ "$(uname -s)" == "Darwin" ]]; then
   TOOLS+=(colima)
 fi
+if [[ -n "${CI_PR_NUMBER}" ]]; then
+  TOOLS+=(gh jq)
+fi
 for tool in "${TOOLS[@]}"; do
   check_tool "${tool}"
 done
@@ -215,13 +225,50 @@ if [[ "${token_http_code}" != "200" ]]; then
   die "CF_API_TOKEN cannot read tunnel ${CF_TUNNEL_ID} (HTTP ${token_http_code:-no-response}). Refresh the token (Cloudflare dashboard -> account -> Cloudflare Tunnel -> Edit) before re-running."
 fi
 
-# --- CI-images mode: fail fast if the PR chart is gone before building a cluster ---
+# --- CI-images mode: fetch and verify the run's artifacts before building a cluster ---
+# The images and chart CI pushes to ttl.sh sit behind a mutable, anonymous tag:
+# anything that can write that tag gets to run inside a cluster holding the
+# Cloudflare credentials created below. So nothing here is addressed by tag.
+# The chart comes from the run's own artifacts, the images are pulled by the
+# digest that run recorded, and both are bound to the commit under review.
 if [[ -n "${CI_PR_NUMBER}" ]]; then
-  CI_CHART_VERSION="0.0.0-pr.${CI_PR_NUMBER}-1d"
-  info "Checking ttl.sh chart for PR #${CI_PR_NUMBER} (${CI_CHART_VERSION})..."
-  helm show chart "oci://ttl.sh/cloudflare-tunnel-gateway-controller" \
-    --version "${CI_CHART_VERSION}" >/dev/null 2>&1 \
-    || die "Chart ${CI_CHART_VERSION} not found on ttl.sh. ttl.sh artifacts expire after 24h (the '1d' tag) — re-run PR #${CI_PR_NUMBER}'s CI to republish."
+  info "Resolving PR #${CI_PR_NUMBER}'s CI run..."
+  CI_HEAD_SHA="$(gh pr view "${CI_PR_NUMBER}" --json headRefOid --jq '.headRefOid')" \
+    || die "Cannot read PR #${CI_PR_NUMBER} (is gh authenticated for this repo?)"
+
+  # Every condition is deliberate: a run for an older head builds a different
+  # diff than the one being reviewed, a failed run may have published half its
+  # artifacts, and only the pull_request event builds the PR's own code.
+  CI_RUN_ID="$(gh api "repos/{owner}/{repo}/actions/runs?head_sha=${CI_HEAD_SHA}&per_page=100" \
+    | jq --raw-output --arg sha "${CI_HEAD_SHA}" '
+        [ .workflow_runs[]
+          | select(.name == "PR Checks and Build")
+          | select(.event == "pull_request")
+          | select(.conclusion == "success")
+          | select(.head_sha == $sha)
+        ] | sort_by(.created_at) | last | .id // empty')" \
+    || die "Querying workflow runs for head ${CI_HEAD_SHA} failed (gh api actions/runs)"
+  [[ -n "${CI_RUN_ID}" ]] \
+    || die "No successful 'PR Checks and Build' run for PR #${CI_PR_NUMBER} at head ${CI_HEAD_SHA}. Re-run its CI; a run for an earlier head is not accepted."
+
+  CI_BUNDLE_DIR="$(mktemp -d)"
+  trap 'on_exit $?' EXIT
+  info "Downloading artifacts from run ${CI_RUN_ID} into ${CI_BUNDLE_DIR}..."
+  for ci_artifact in ci-chart-bundle image-ref-controller image-ref-proxy; do
+    gh run download "${CI_RUN_ID}" --name "${ci_artifact}" --dir "${CI_BUNDLE_DIR}" \
+      || die "Artifact ${ci_artifact} is missing or expired on run ${CI_RUN_ID}. CI artifacts are kept for one day — re-run PR #${CI_PR_NUMBER}'s CI."
+  done
+
+  ci_bundle="$("${REPO_ROOT}/hack/verify-ci-bundle.sh" \
+    "${CI_BUNDLE_DIR}" "${CI_PR_NUMBER}" "${CI_HEAD_SHA}")" \
+    || die "PR #${CI_PR_NUMBER}'s CI artifacts failed verification; nothing was deployed."
+
+  CI_CONTROLLER_REF="$(sed -n 's/^controller_ref=//p' <<< "${ci_bundle}")"
+  CI_PROXY_REF="$(sed -n 's/^proxy_ref=//p' <<< "${ci_bundle}")"
+  CI_CHART_TGZ="$(sed -n 's/^chart_tgz=//p' <<< "${ci_bundle}")"
+  info "Verified PR #${CI_PR_NUMBER} at ${CI_HEAD_SHA}:"
+  info "  ${CI_CONTROLLER_REF}"
+  info "  ${CI_PROXY_REF}"
 fi
 
 # --- Step 1: Ensure colima is running (macOS only) ---
@@ -231,6 +278,21 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     info "Starting colima..."
     colima start
   fi
+fi
+
+# --- Step 1b: Pull the CI images (needs the daemon from Step 1) ---
+# Deliberately ahead of Step 2, which deletes the operator's existing test
+# clusters. The GitHub artifacts verified above live for a day; the images
+# they point at live on ttl.sh for about an hour, so "artifacts present,
+# images gone" is the common failure for this flag and it must not cost a
+# cluster to discover.
+if [[ -n "${CI_PR_NUMBER}" ]]; then
+  info "Pulling PR #${CI_PR_NUMBER}'s images by digest..."
+  ci_arch="$(go env GOARCH)"
+  "${REPO_ROOT}/hack/pull-ci-image.sh" "${CI_CONTROLLER_REF}" "${CONTROLLER_IMAGE}" "${ci_arch}" \
+    || die "Cannot pull ${CI_CONTROLLER_REF}. ttl.sh keeps images for about an hour -- re-run PR #${CI_PR_NUMBER}'s CI to republish."
+  "${REPO_ROOT}/hack/pull-ci-image.sh" "${CI_PROXY_REF}" "${PROXY_IMAGE}" "${ci_arch}" \
+    || die "Cannot pull ${CI_PROXY_REF}. ttl.sh keeps images for about an hour -- re-run PR #${CI_PR_NUMBER}'s CI to republish."
 fi
 
 # --- Step 2: Delete old v2-test-* clusters ---
@@ -252,7 +314,9 @@ KINDEOF
 kubectl --context "${KUBE_CONTEXT}" cluster-info --request-timeout=5s >/dev/null 2>&1 \
   || die "Cannot connect to cluster '${KUBE_CONTEXT}'"
 
-# From here on the cluster exists -- capture its state if anything fails.
+# From here on a failure has pod state worth dumping. In --use-ci-images mode
+# the same trap is already armed; this flag is what turns the dump on.
+CLUSTER_CREATED=true
 trap 'on_exit $?' EXIT
 
 # --- Step 4: Install Gateway API CRDs (channel selectable via --channel) ---
@@ -261,9 +325,9 @@ kubectl --context "${KUBE_CONTEXT}" apply \
   --server-side --force-conflicts \
   --filename "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/${CHANNEL}-install.yaml"
 
-# --- Step 5: Build images ---
+# --- Step 5: Build images (CI-images mode pulled them in Step 1b) ---
 if [[ -n "${CI_PR_NUMBER}" ]]; then
-  info "Using CI images from PR #${CI_PR_NUMBER} (ttl.sh) — skipping local build + kind load"
+  info "Using PR #${CI_PR_NUMBER}'s images, pulled in Step 1b"
 elif [[ "${SKIP_BUILD}" == "false" ]]; then
   info "Building controller image..."
   docker build --tag "${CONTROLLER_IMAGE}" --file Containerfile .
@@ -275,13 +339,11 @@ else
 fi
 
 # --- Step 6: Load images into kind ---
-# In --use-ci-images mode there are no local images; kind nodes pull from
-# ttl.sh at pod start (the PR chart ships pullPolicy=Always).
-if [[ -z "${CI_PR_NUMBER}" ]]; then
-  info "Loading images into kind cluster..."
-  kind load docker-image "${CONTROLLER_IMAGE}" --name "${CLUSTER_NAME}"
-  kind load docker-image "${PROXY_IMAGE}" --name "${CLUSTER_NAME}"
-fi
+# Both modes load from the local docker daemon, so the kind nodes never reach
+# out to a registry and cannot be served something else at pod start.
+info "Loading images into kind cluster..."
+kind load docker-image "${CONTROLLER_IMAGE}" --name "${CLUSTER_NAME}"
+kind load docker-image "${PROXY_IMAGE}" --name "${CLUSTER_NAME}"
 
 # --- Step 7: Create namespace and secrets ---
 info "Creating namespace '${NAMESPACE}'..."
@@ -308,12 +370,11 @@ kubectl --context "${KUBE_CONTEXT}" create secret generic cloudflare-tunnel-toke
   | kubectl --context "${KUBE_CONTEXT}" apply --filename -
 
 # --- Step 8: Deploy via helm ---
-# Default: install the local chart and point it at the locally-built images.
-# --use-ci-images: install the PR's published ttl.sh chart, which already
-# carries the ttl.sh image refs + pullPolicy=Always baked into its values.yaml,
-# so no --set image.* overrides are needed (or wanted) in that mode.
+# Default: install the local chart. --use-ci-images: install the chart tarball
+# the run published. Either way the image overrides below point at the images
+# already loaded into the nodes, so the CI chart's own ttl.sh refs and its
+# pullPolicy=Always never take effect.
 HELM_CHART_REF="${REPO_ROOT}/charts/cloudflare-tunnel-gateway-controller"
-HELM_VERSION_ARGS=()
 HELM_IMAGE_ARGS=(
   --set image.repository="${CONTROLLER_IMAGE%%:*}"
   --set image.tag="${CONTROLLER_IMAGE##*:}"
@@ -323,9 +384,7 @@ HELM_IMAGE_ARGS=(
   --set proxy.image.pullPolicy=Never
 )
 if [[ -n "${CI_PR_NUMBER}" ]]; then
-  HELM_CHART_REF="oci://ttl.sh/cloudflare-tunnel-gateway-controller"
-  HELM_VERSION_ARGS=(--version "${CI_CHART_VERSION}")
-  HELM_IMAGE_ARGS=()
+  HELM_CHART_REF="${CI_CHART_TGZ}"
 fi
 
 # proxy.tunnel.protocol=http2 is mandatory in both modes: the chart defaults to
@@ -341,18 +400,15 @@ fi
 # so the edge rejects them by Host and the intended Host rides X-Original-Host
 # instead. The proxy ignores that header unless this value is set, which is why
 # it belongs here and nowhere near a production values file.
-# The "${arr[@]+...}" idiom expands an empty array to nothing without tripping
-# `set -u` on bash < 4.4 (stock macOS ships 3.2).
 info "Deploying controller via helm..."
 helm upgrade --install "${RELEASE_NAME}" \
   "${HELM_CHART_REF}" \
-  "${HELM_VERSION_ARGS[@]+"${HELM_VERSION_ARGS[@]}"}" \
   --kube-context "${KUBE_CONTEXT}" \
   --namespace "${NAMESPACE}" \
   --set gatewayClassConfig.create=true \
   --set gatewayClassConfig.tunnelID="${CF_TUNNEL_ID}" \
   --set gatewayClassConfig.cloudflareCredentialsSecretRef.name=cloudflare-credentials \
-  "${HELM_IMAGE_ARGS[@]+"${HELM_IMAGE_ARGS[@]}"}" \
+  "${HELM_IMAGE_ARGS[@]}" \
   --set proxy.tunnelTokenSecretRef.name=cloudflare-tunnel-token \
   --set proxy.tunnel.protocol=http2 \
   --set proxy.allowXOriginalHost=true \

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -6,7 +6,8 @@
 #   2. Deletes old v2-test-* kind clusters
 #   3. Creates a fresh kind cluster with random suffix
 #   4. Installs Gateway API CRDs (channel selectable via --channel)
-#   5. Builds controller + proxy images   (pulled by digest in --use-ci-images)
+#   5. Builds controller + proxy images   (--use-ci-images pulls them by
+#                                          digest in Step 1b instead)
 #   6. Loads images into kind
 #   7. Creates secrets from .env
 #   8. Deploys controller via helm        (local chart, or the PR run's chart)

--- a/hack/conformance-setup.sh
+++ b/hack/conformance-setup.sh
@@ -234,23 +234,10 @@ fi
 # digest that run recorded, and both are bound to the commit under review.
 if [[ -n "${CI_PR_NUMBER}" ]]; then
   info "Resolving PR #${CI_PR_NUMBER}'s CI run..."
-  CI_HEAD_SHA="$(gh pr view "${CI_PR_NUMBER}" --json headRefOid --jq '.headRefOid')" \
-    || die "Cannot read PR #${CI_PR_NUMBER} (is gh authenticated for this repo?)"
-
-  # Every condition is deliberate: a run for an older head builds a different
-  # diff than the one being reviewed, a failed run may have published half its
-  # artifacts, and only the pull_request event builds the PR's own code.
-  CI_RUN_ID="$(gh api "repos/{owner}/{repo}/actions/runs?head_sha=${CI_HEAD_SHA}&per_page=100" \
-    | jq --raw-output --arg sha "${CI_HEAD_SHA}" '
-        [ .workflow_runs[]
-          | select(.name == "PR Checks and Build")
-          | select(.event == "pull_request")
-          | select(.conclusion == "success")
-          | select(.head_sha == $sha)
-        ] | sort_by(.created_at) | last | .id // empty')" \
-    || die "Querying workflow runs for head ${CI_HEAD_SHA} failed (gh api actions/runs)"
-  [[ -n "${CI_RUN_ID}" ]] \
-    || die "No successful 'PR Checks and Build' run for PR #${CI_PR_NUMBER} at head ${CI_HEAD_SHA}. Re-run its CI; a run for an earlier head is not accepted."
+  ci_run="$("${REPO_ROOT}/hack/find-ci-run.sh" "${CI_PR_NUMBER}")" \
+    || die "Cannot resolve a CI run for PR #${CI_PR_NUMBER}; nothing was deployed."
+  CI_HEAD_SHA="$(sed -n 's/^head_sha=//p' <<< "${ci_run}")"
+  CI_RUN_ID="$(sed -n 's/^run_id=//p' <<< "${ci_run}")"
 
   CI_BUNDLE_DIR="$(mktemp -d)"
   trap 'on_exit $?' EXIT

--- a/hack/conformance-setup_test.sh
+++ b/hack/conformance-setup_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# conformance-setup_test.sh — tests for conformance-setup.sh.
+#
+# Pins the colima prerequisite as a macOS requirement rather than a "not in CI"
+# requirement, so a Linux host with a native docker daemon gets past the tool
+# check. Plain bash and temp dirs, no test framework.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+setup="${script_dir}/conformance-setup.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+fail=0
+
+pass() { echo "ok   - $1"; }
+flunk() { echo "FAIL - $1"; fail=1; }
+
+# --- conformance-setup.sh prerequisite block -------------------------------
+#
+# The script is copied into a throwaway REPO_ROOT so the checkout's own .env
+# can never satisfy the credential check, and run with a PATH that holds
+# nothing but no-op stubs plus the system coreutils. colima is deliberately
+# absent from that PATH on both hosts, and `uname` is stubbed, so the same
+# assertions hold whether the suite runs on Linux or macOS.
+sandbox="${tmp}/sandbox"
+stubs="${tmp}/stubs"
+mkdir -p "${sandbox}/hack" "${stubs}"
+cp "${setup}" "${sandbox}/hack/"
+
+for stub in docker kind helm kubectl go; do
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${stubs}/${stub}"
+  chmod +x "${stubs}/${stub}"
+done
+
+# run_prereq <uname-s-output> -> stdout+stderr of the script, exit code ignored
+run_prereq() {
+  local kernel="$1"
+  cat > "${stubs}/uname" <<STUB
+#!/usr/bin/env bash
+if [[ "\$1" == "-s" ]]; then echo ${kernel}; fi
+exit 0
+STUB
+  chmod +x "${stubs}/uname"
+  # GITHUB_ACTIONS and the CF_* variables are cleared explicitly: the suite
+  # itself runs in Actions, where inheriting them would skip the very branch
+  # under test and satisfy the credential check from the ambient environment.
+  PATH="${stubs}:/usr/bin:/bin" \
+  GITHUB_ACTIONS='' CF_API_TOKEN='' CF_ACCOUNT_ID='' CF_TUNNEL_ID='' \
+  CF_TUNNEL_TOKEN='' CF_TUNNEL_HOSTNAME='' \
+    bash "${sandbox}/hack/conformance-setup.sh" 2>&1 || true
+}
+
+linux_out="$(run_prereq Linux)"
+if grep --quiet "colima is not installed" <<< "${linux_out}"; then
+  flunk "Linux host must not require colima"
+else
+  pass "Linux host does not require colima"
+fi
+# Getting as far as the credential check is what proves the tool check passed;
+# without it "no colima error" would also be true of a script that died earlier.
+if grep --quiet ".env file not found" <<< "${linux_out}"; then
+  pass "Linux host reaches the credential check"
+else
+  flunk "Linux host reaches the credential check (got: ${linux_out##*$'\n'})"
+fi
+
+darwin_out="$(run_prereq Darwin)"
+if grep --quiet "colima is not installed" <<< "${darwin_out}"; then
+  pass "macOS host still requires colima"
+else
+  flunk "macOS host still requires colima"
+fi
+
+if [[ "${fail}" -ne 0 ]]; then
+  echo "conformance-setup tests FAILED"
+  exit 1
+fi
+echo "conformance-setup tests passed"

--- a/hack/conformance-setup_test.sh
+++ b/hack/conformance-setup_test.sh
@@ -254,23 +254,78 @@ fi
 #
 # The merge job reads its manifest-list digest back from a run-scoped tag on
 # ttl.sh, which has no authentication and whose run id is public for as long as
-# the run is visible. These cases pin that the index that tag resolves to is
-# checked against the per-arch images the job actually pushed, so a substituted
-# index cannot be published as this run's reference.
+# the run is. These cases pin that the index that tag resolves to was assembled
+# out of the images the job actually pushed, so a substituted index cannot be
+# published as this run's reference.
+#
+# The fixtures follow the production shape: what /tmp/digests names is the
+# digest of a per-arch OCI index, and what the published index lists is that
+# index's children -- the platform manifest and its attestation -- because
+# `imagetools create` flattens index sources.
 
 children="${script_dir}/verify-manifest-children.sh"
 
 amd64_pushed="$(printf '1%.0s' {1..64})"
 arm64_pushed="$(printf '2%.0s' {1..64})"
+amd64_child="$(printf '3%.0s' {1..64})"
+amd64_attest="$(printf '4%.0s' {1..64})"
+arm64_child="$(printf '5%.0s' {1..64})"
+arm64_attest="$(printf '6%.0s' {1..64})"
+plain_pushed="$(printf '7%.0s' {1..64})"
 
-# The merge job names each pushed image by an empty file in /tmp/digests.
 mkdir -p "${tmp}/pushed"
 touch "${tmp}/pushed/${amd64_pushed}" "${tmp}/pushed/${arm64_pushed}"
 
-# check_children <expected-exit> <label> <index> <digests-dir>
+# The script reads each pushed digest back from the registry; the stub serves
+# one fixture per digest and fails on anything it was not given.
+children_stub_dir="${tmp}/childstubs"
+srcidx="${tmp}/srcidx"
+mkdir -p "${children_stub_dir}" "${srcidx}"
+cat > "${children_stub_dir}/docker" <<'STUB'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "${arg}" in
+    *@sha256:*)
+      fixture="${FIXTURE_DIR}/${arg##*@sha256:}.json"
+      [[ -f "${fixture}" ]] || exit 1
+      cat "${fixture}"
+      exit 0
+      ;;
+  esac
+done
+exit 1
+STUB
+chmod +x "${children_stub_dir}/docker"
+
+# source_index <file> <platform-digest> <arch> <attestation-digest>
+source_index() {
+  printf '{"manifests":[{"digest":"sha256:%s","platform":{"os":"linux","architecture":"%s"}},{"digest":"sha256:%s","annotations":{"vnd.docker.reference.type":"attestation-manifest"},"platform":{"os":"unknown","architecture":"unknown"}}]}' \
+    "$2" "$3" "$4" > "$1"
+}
+
+# published_index <file> <digest>...
+published_index() {
+  local out="$1"; shift
+  {
+    printf '{"manifests":['
+    local sep="" digest
+    for digest in "$@"; do
+      printf '%s{"digest":"sha256:%s"}' "${sep}" "${digest}"
+      sep=","
+    done
+    printf ']}'
+  } > "${out}"
+}
+
+source_index "${srcidx}/${amd64_pushed}.json" "${amd64_child}" amd64 "${amd64_attest}"
+source_index "${srcidx}/${arm64_pushed}.json" "${arm64_child}" arm64 "${arm64_attest}"
+
+# check_children <expected-exit> <label> <published-index> <digests-dir>
 check_children() {
-  local expected="$1" label="$2" index="$3" dir="$4" actual=0
-  bash "${children}" "${index}" "${dir}" >/dev/null 2>&1 || actual=$?
+  local expected="$1" label="$2" published="$3" dir="$4" actual=0
+  PATH="${children_stub_dir}:/usr/bin:/bin" FIXTURE_DIR="${srcidx}" \
+    bash "${children}" ttl.sh/cf-tunnel-gateway-ctrl "${published}" "${dir}" \
+    >/dev/null 2>&1 || actual=$?
   if [[ "${actual}" -eq "${expected}" ]]; then
     pass "${label} (exit ${actual})"
   else
@@ -278,38 +333,63 @@ check_children() {
   fi
 }
 
-index_with_arches "${tmp}/children-ok.json" "${amd64_pushed}:amd64" "${arm64_pushed}:arm64"
+published_index "${tmp}/children-ok.json" \
+  "${amd64_child}" "${amd64_attest}" "${arm64_child}" "${arm64_attest}"
 check_children 0 "an index assembled from this job's images is accepted" \
   "${tmp}/children-ok.json" "${tmp}/pushed"
 
 # The exposure: between the push and the read-back anyone can repoint the tag,
 # and the digest read back would then be theirs -- well-formed, digest-pinned,
 # and not this build.
-index_with_arches "${tmp}/children-sub.json" \
-  "$(printf '9%.0s' {1..64}):amd64" "$(printf '8%.0s' {1..64}):arm64"
+published_index "${tmp}/children-sub.json" \
+  "$(printf '8%.0s' {1..64})" "$(printf '9%.0s' {1..64})"
 check_children 1 "a substituted index is rejected" \
   "${tmp}/children-sub.json" "${tmp}/pushed"
 
-index_with_arches "${tmp}/children-partial.json" \
-  "${amd64_pushed}:amd64" "$(printf '8%.0s' {1..64}):arm64"
-check_children 1 "an index missing one pushed manifest is rejected" \
+published_index "${tmp}/children-partial.json" "${amd64_child}" "${amd64_attest}"
+check_children 1 "an index missing a pushed image's manifests is rejected" \
   "${tmp}/children-partial.json" "${tmp}/pushed"
 
-# buildx attaches provenance and SBOM manifests of its own, so the check is
-# containment rather than set equality.
-printf '{"manifests":[{"digest":"sha256:%s","platform":{"os":"linux","architecture":"amd64"}},{"digest":"sha256:%s","platform":{"os":"linux","architecture":"arm64"}},{"digest":"sha256:%s","platform":{"os":"unknown","architecture":"unknown"}}]}' \
-  "${amd64_pushed}" "${arm64_pushed}" "$(printf '7%.0s' {1..64})" \
-  > "${tmp}/children-attest.json"
-check_children 0 "attestation manifests do not trip the check" \
-  "${tmp}/children-attest.json" "${tmp}/pushed"
+# Dropping just the attestation is still an index this job did not assemble.
+published_index "${tmp}/children-noattest.json" \
+  "${amd64_child}" "${amd64_attest}" "${arm64_child}"
+check_children 1 "an index missing an attestation manifest is rejected" \
+  "${tmp}/children-noattest.json" "${tmp}/pushed"
 
-# An empty directory would make the containment loop vacuously true, and every
-# index would pass.
+# A build with provenance off pushes a plain manifest rather than an index, and
+# then the pushed digest is itself what has to appear.
+mkdir -p "${tmp}/pushed-plain"
+touch "${tmp}/pushed-plain/${plain_pushed}"
+printf '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","layers":[]}' \
+  > "${srcidx}/${plain_pushed}.json"
+published_index "${tmp}/children-plain.json" "${plain_pushed}"
+check_children 0 "a plain manifest is matched by its own digest" \
+  "${tmp}/children-plain.json" "${tmp}/pushed-plain"
+check_children 1 "a plain manifest absent from the index is rejected" \
+  "${tmp}/children-ok.json" "${tmp}/pushed-plain"
+
+# A pushed digest the registry will not serve must stop the job rather than be
+# skipped: a source that cannot be read is a source that cannot be vouched for.
+unreadable_pushed="$(printf 'b%.0s' {1..64})"
+mkdir -p "${tmp}/pushed-unreadable"
+touch "${tmp}/pushed-unreadable/${unreadable_pushed}"
+check_children 1 "a pushed digest that cannot be read is rejected" \
+  "${tmp}/children-ok.json" "${tmp}/pushed-unreadable"
+
+# ...and specifically because the read failed, not because the digest happened
+# to be absent. With the source digest itself listed, only the failed read is
+# left to reject it.
+published_index "${tmp}/children-unreadable.json" "${unreadable_pushed}"
+check_children 1 "an unreadable source is rejected even when its own digest is listed" \
+  "${tmp}/children-unreadable.json" "${tmp}/pushed-unreadable"
+
+# An empty directory would make the loop vacuously true, and every index would
+# pass.
 mkdir -p "${tmp}/nodigests"
 check_children 1 "an empty digest set is rejected" \
   "${tmp}/children-ok.json" "${tmp}/nodigests"
 
-check_children 1 "an unreadable index is rejected" \
+check_children 1 "an unreadable published index is rejected" \
   "${tmp}/absent-index.json" "${tmp}/pushed"
 
 # The check only protects anything if the workflow runs it. Matching the
@@ -322,6 +402,18 @@ if grep --quiet --extended-regexp \
 else
   flunk "pr.yaml verifies the manifest list it publishes"
 fi
+
+# ...and the suite only guards them if editing them triggers it. Both paths
+# blocks, since the pull_request one gates the PR and the push one gates master.
+for guarded in hack/verify-manifest-children.sh .github/workflows/pr.yaml; do
+  occurrences="$(grep --count --fixed-strings "      - ${guarded}" \
+    "${repo_root}/.github/workflows/scripts.yaml" || true)"
+  if [[ "${occurrences}" -eq 2 ]]; then
+    pass "scripts.yaml runs on changes to ${guarded}"
+  else
+    flunk "scripts.yaml runs on changes to ${guarded} (${occurrences} of 2 paths blocks)"
+  fi
+done
 
 if [[ "${fail}" -ne 0 ]]; then
   echo "conformance-setup tests FAILED"

--- a/hack/conformance-setup_test.sh
+++ b/hack/conformance-setup_test.sh
@@ -165,9 +165,9 @@ else
   flunk "conformance-setup.sh invokes the bundle verifier"
 fi
 
-# ttl.sh drops the images long before the run's artifacts expire, so the pull
-# is the likely failure and it must happen before the script deletes the
-# operator's existing clusters.
+# The pull is the step that depends on a registry outside this repository's
+# control, so it must happen before the script deletes the operator's existing
+# clusters.
 pull_line="$(grep --line-number --fixed-strings 'pull-ci-image.sh' "${setup}" | head -1 | cut -d: -f1)"
 delete_line="$(grep --line-number 'kind delete cluster' "${setup}" | head -1 | cut -d: -f1)"
 if [[ -n "${pull_line}" && -n "${delete_line}" && "${pull_line}" -lt "${delete_line}" ]]; then

--- a/hack/conformance-setup_test.sh
+++ b/hack/conformance-setup_test.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
-# conformance-setup_test.sh — tests for conformance-setup.sh.
+# conformance-setup_test.sh — tests for conformance-setup.sh and the CI-bundle
+# verifier it calls.
 #
-# Pins the colima prerequisite as a macOS requirement rather than a "not in CI"
-# requirement, so a Linux host with a native docker daemon gets past the tool
-# check. Plain bash and temp dirs, no test framework.
+# Two properties are pinned here. The colima prerequisite is a macOS
+# requirement rather than a "not in CI" requirement, so a Linux host with a
+# native docker daemon gets past the tool check. And what --use-ci-images
+# deploys is addressed by digest and bound to the reviewed commit: a mutable
+# tag or a bundle from another revision must stop the run. Plain bash and temp
+# dirs, no test framework.
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 setup="${script_dir}/conformance-setup.sh"
+verifier="${script_dir}/verify-ci-bundle.sh"
+puller="${script_dir}/pull-ci-image.sh"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
@@ -71,6 +77,176 @@ if grep --quiet "colima is not installed" <<< "${darwin_out}"; then
   pass "macOS host still requires colima"
 else
   flunk "macOS host still requires colima"
+fi
+
+# --- verify-ci-bundle.sh ---------------------------------------------------
+
+ctrl_ref="ttl.sh/cf-tunnel-gateway-ctrl@sha256:$(printf 'a%.0s' {1..64})"
+proxy_ref="ttl.sh/cf-tunnel-gateway-proxy@sha256:$(printf 'b%.0s' {1..64})"
+head_sha="$(printf 'c%.0s' {1..40})"
+
+# make_bundle <dir> <pr> [head-sha]
+make_bundle() {
+  local dir="$1" pr="$2" sha="${3:-${head_sha}}"
+  mkdir -p "${dir}"
+  printf '%s\n' "${ctrl_ref}" > "${dir}/controller.ref"
+  printf '%s\n' "${proxy_ref}" > "${dir}/proxy.ref"
+  printf '%s\n' "${sha}" > "${dir}/head-sha.txt"
+  : > "${dir}/cloudflare-tunnel-gateway-controller-0.0.0-pr.${pr}-1d.tgz"
+}
+
+# check_bundle <expected-exit> <label> <dir>
+check_bundle() {
+  local expected="$1" label="$2" dir="$3" actual=0
+  bash "${verifier}" "${dir}" 720 "${head_sha}" >/dev/null 2>&1 || actual=$?
+  if [[ "${actual}" -eq "${expected}" ]]; then
+    pass "${label} (exit ${actual})"
+  else
+    flunk "${label}: expected exit ${expected}, got ${actual}"
+  fi
+}
+
+make_bundle "${tmp}/good" 720
+check_bundle 0 "complete bundle accepted" "${tmp}/good"
+
+out="$(bash "${verifier}" "${tmp}/good" 720 "${head_sha}" || true)"
+if grep --quiet "^controller_ref=${ctrl_ref}$" <<< "${out}" \
+  && grep --quiet "^proxy_ref=${proxy_ref}$" <<< "${out}" \
+  && grep --quiet "^head_sha=${head_sha}$" <<< "${out}"; then
+  pass "verifier echoes the references it validated"
+else
+  flunk "verifier echoes the references it validated"
+fi
+
+# The exposure the whole path exists to close: a mutable tag standing in for a
+# content address.
+make_bundle "${tmp}/tag" 720
+printf 'ttl.sh/cf-tunnel-gateway-ctrl:pr-720-1d\n' > "${tmp}/tag/controller.ref"
+check_bundle 1 "a tag in place of a digest is rejected" "${tmp}/tag"
+
+# Each file is bound to its own image: swapping the two would run the
+# controller binary in the proxy Deployment.
+make_bundle "${tmp}/swap" 720
+printf '%s\n' "${proxy_ref}" > "${tmp}/swap/controller.ref"
+check_bundle 1 "the two CI image references are not swappable" "${tmp}/swap"
+
+# A digest binds content, not provenance: a well-formed reference to an image
+# nobody here built must not pass.
+make_bundle "${tmp}/foreign" 720
+printf 'ghcr.io/someone-else/cf-tunnel-gateway-ctrl@sha256:%s\n' "$(printf 'a%.0s' {1..64})" \
+  > "${tmp}/foreign/controller.ref"
+check_bundle 1 "a digest on a foreign registry is rejected" "${tmp}/foreign"
+
+make_bundle "${tmp}/short" 720
+printf 'ttl.sh/cf-tunnel-gateway-proxy@sha256:%s\n' "$(printf 'a%.0s' {1..63})" \
+  > "${tmp}/short/proxy.ref"
+check_bundle 1 "a truncated digest is rejected" "${tmp}/short"
+
+make_bundle "${tmp}/noref" 720
+rm -f "${tmp}/noref/proxy.ref"
+check_bundle 1 "a missing reference file is rejected" "${tmp}/noref"
+
+# Artifacts built from a revision other than the one being verified.
+make_bundle "${tmp}/othersha" 720 "$(printf 'd%.0s' {1..40})"
+check_bundle 1 "a bundle built from another commit is rejected" "${tmp}/othersha"
+
+# A bundle downloaded from another PR's run carries that PR's chart version.
+make_bundle "${tmp}/otherpr" 721
+check_bundle 1 "a bundle from another PR is rejected" "${tmp}/otherpr"
+
+check_bundle 1 "a missing bundle directory is rejected" "${tmp}/absent"
+
+# --- wiring ----------------------------------------------------------------
+# The verifier only protects anything if the setup script actually runs it.
+if grep --quiet "verify-ci-bundle.sh" "${setup}"; then
+  pass "conformance-setup.sh invokes the bundle verifier"
+else
+  flunk "conformance-setup.sh invokes the bundle verifier"
+fi
+
+# ttl.sh drops the images long before the run's artifacts expire, so the pull
+# is the likely failure and it must happen before the script deletes the
+# operator's existing clusters.
+pull_line="$(grep --line-number --fixed-strings 'pull-ci-image.sh' "${setup}" | head -1 | cut -d: -f1)"
+delete_line="$(grep --line-number 'kind delete cluster' "${setup}" | head -1 | cut -d: -f1)"
+if [[ -n "${pull_line}" && -n "${delete_line}" && "${pull_line}" -lt "${delete_line}" ]]; then
+  pass "CI images are pulled before any cluster is deleted"
+else
+  flunk "CI images are pulled before any cluster is deleted (pull ${pull_line:-none}, delete ${delete_line:-none})"
+fi
+
+# --- pull-ci-image.sh --------------------------------------------------------
+#
+# `kind load docker-image` saves the local tag and imports it with
+# --all-platforms, so whatever carries that tag must be one platform. These
+# cases pin that the puller resolves the host's manifest out of the index
+# rather than tagging the index itself.
+
+pull_stub_dir="${tmp}/pullstubs"
+mkdir -p "${pull_stub_dir}"
+cat > "${pull_stub_dir}/docker" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "buildx" ]]; then
+  [[ -f "${FIXTURE_INDEX}" ]] || exit 1
+  cat "${FIXTURE_INDEX}"
+  exit 0
+fi
+echo "$*" >> "${DOCKER_LOG}"
+STUB
+chmod +x "${pull_stub_dir}/docker"
+
+index_with_arches() {
+  local out="$1"; shift
+  {
+    printf '{"manifests":['
+    local sep=""
+    for entry in "$@"; do
+      printf '%s{"digest":"sha256:%s","platform":{"os":"linux","architecture":"%s"}}' \
+        "${sep}" "$(printf '%s' "${entry%%:*}" | head -c 64)" "${entry##*:}"
+      sep=","
+    done
+    printf ']}'
+  } > "${out}"
+}
+
+# run_pull <fixture> <arch> -> exit code; DOCKER_LOG holds the recorded calls
+run_pull() {
+  local fixture="$1" arch="$2"
+  : > "${tmp}/docker.log"
+  PATH="${pull_stub_dir}:/usr/bin:/bin" FIXTURE_INDEX="${fixture}" DOCKER_LOG="${tmp}/docker.log" \
+    bash "${puller}" "ttl.sh/cf-tunnel-gateway-ctrl@sha256:$(printf 'e%.0s' {1..64})" controller:dev "${arch}" \
+    >/dev/null 2>&1
+}
+
+amd64_digest="$(printf 'a%.0s' {1..64})"
+arm64_digest="$(printf 'b%.0s' {1..64})"
+index_with_arches "${tmp}/index.json" "${amd64_digest}:amd64" "${arm64_digest}:arm64"
+
+if run_pull "${tmp}/index.json" amd64; then
+  pass "the host platform's manifest is pulled from a multi-arch index"
+else
+  flunk "the host platform's manifest is pulled from a multi-arch index"
+fi
+# Tagging the index instead of the platform manifest is the bug: ctr then
+# demands blobs for an architecture this host never fetched.
+if grep --quiet "pull ttl.sh/cf-tunnel-gateway-ctrl@sha256:${amd64_digest}$" "${tmp}/docker.log" \
+  && grep --quiet "tag ttl.sh/cf-tunnel-gateway-ctrl@sha256:${amd64_digest} controller:dev$" "${tmp}/docker.log"; then
+  pass "the local tag points at one platform, not at the index"
+else
+  flunk "the local tag points at one platform, not at the index (log: $(tr '\n' '; ' < "${tmp}/docker.log"))"
+fi
+
+index_with_arches "${tmp}/index-arm.json" "${arm64_digest}:arm64"
+if run_pull "${tmp}/index-arm.json" amd64; then
+  flunk "an index without the host platform is rejected"
+else
+  pass "an index without the host platform is rejected"
+fi
+
+if run_pull "${tmp}/absent.json" amd64; then
+  flunk "an unreadable index is rejected"
+else
+  pass "an unreadable index is rejected"
 fi
 
 if [[ "${fail}" -ne 0 ]]; then

--- a/hack/conformance-setup_test.sh
+++ b/hack/conformance-setup_test.sh
@@ -14,6 +14,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 setup="${script_dir}/conformance-setup.sh"
 verifier="${script_dir}/verify-ci-bundle.sh"
 puller="${script_dir}/pull-ci-image.sh"
+repo_root="$(cd "${script_dir}/.." && pwd)"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
@@ -247,6 +248,79 @@ if run_pull "${tmp}/absent.json" amd64; then
   flunk "an unreadable index is rejected"
 else
   pass "an unreadable index is rejected"
+fi
+
+# --- verify-manifest-children.sh -------------------------------------------
+#
+# The merge job reads its manifest-list digest back from a run-scoped tag on
+# ttl.sh, which has no authentication and whose run id is public for as long as
+# the run is visible. These cases pin that the index that tag resolves to is
+# checked against the per-arch images the job actually pushed, so a substituted
+# index cannot be published as this run's reference.
+
+children="${script_dir}/verify-manifest-children.sh"
+
+amd64_pushed="$(printf '1%.0s' {1..64})"
+arm64_pushed="$(printf '2%.0s' {1..64})"
+
+# The merge job names each pushed image by an empty file in /tmp/digests.
+mkdir -p "${tmp}/pushed"
+touch "${tmp}/pushed/${amd64_pushed}" "${tmp}/pushed/${arm64_pushed}"
+
+# check_children <expected-exit> <label> <index> <digests-dir>
+check_children() {
+  local expected="$1" label="$2" index="$3" dir="$4" actual=0
+  bash "${children}" "${index}" "${dir}" >/dev/null 2>&1 || actual=$?
+  if [[ "${actual}" -eq "${expected}" ]]; then
+    pass "${label} (exit ${actual})"
+  else
+    flunk "${label}: expected exit ${expected}, got ${actual}"
+  fi
+}
+
+index_with_arches "${tmp}/children-ok.json" "${amd64_pushed}:amd64" "${arm64_pushed}:arm64"
+check_children 0 "an index assembled from this job's images is accepted" \
+  "${tmp}/children-ok.json" "${tmp}/pushed"
+
+# The exposure: between the push and the read-back anyone can repoint the tag,
+# and the digest read back would then be theirs -- well-formed, digest-pinned,
+# and not this build.
+index_with_arches "${tmp}/children-sub.json" \
+  "$(printf '9%.0s' {1..64}):amd64" "$(printf '8%.0s' {1..64}):arm64"
+check_children 1 "a substituted index is rejected" \
+  "${tmp}/children-sub.json" "${tmp}/pushed"
+
+index_with_arches "${tmp}/children-partial.json" \
+  "${amd64_pushed}:amd64" "$(printf '8%.0s' {1..64}):arm64"
+check_children 1 "an index missing one pushed manifest is rejected" \
+  "${tmp}/children-partial.json" "${tmp}/pushed"
+
+# buildx attaches provenance and SBOM manifests of its own, so the check is
+# containment rather than set equality.
+printf '{"manifests":[{"digest":"sha256:%s","platform":{"os":"linux","architecture":"amd64"}},{"digest":"sha256:%s","platform":{"os":"linux","architecture":"arm64"}},{"digest":"sha256:%s","platform":{"os":"unknown","architecture":"unknown"}}]}' \
+  "${amd64_pushed}" "${arm64_pushed}" "$(printf '7%.0s' {1..64})" \
+  > "${tmp}/children-attest.json"
+check_children 0 "attestation manifests do not trip the check" \
+  "${tmp}/children-attest.json" "${tmp}/pushed"
+
+# An empty directory would make the containment loop vacuously true, and every
+# index would pass.
+mkdir -p "${tmp}/nodigests"
+check_children 1 "an empty digest set is rejected" \
+  "${tmp}/children-ok.json" "${tmp}/nodigests"
+
+check_children 1 "an unreadable index is rejected" \
+  "${tmp}/absent-index.json" "${tmp}/pushed"
+
+# The check only protects anything if the workflow runs it. Matching the
+# invocation rather than the name: the job's checkout step names the script in
+# a comment, which would satisfy a bare filename grep on its own.
+if grep --quiet --extended-regexp \
+  '^[[:space:]]*hack/verify-manifest-children\.sh ' \
+  "${repo_root}/.github/workflows/pr.yaml"; then
+  pass "pr.yaml verifies the manifest list it publishes"
+else
+  flunk "pr.yaml verifies the manifest list it publishes"
 fi
 
 if [[ "${fail}" -ne 0 ]]; then

--- a/hack/conformance-setup_test.sh
+++ b/hack/conformance-setup_test.sh
@@ -350,6 +350,17 @@ published_index "${tmp}/children-partial.json" "${amd64_child}" "${amd64_attest}
 check_children 1 "an index missing a pushed image's manifests is rejected" \
   "${tmp}/children-partial.json" "${tmp}/pushed"
 
+# Keeping every one of this job's manifests is not enough. `pull-ci-image.sh`
+# selects what to deploy by platform, and the verifier constrains no platform,
+# so an index that relabels this job's amd64 child and puts a foreign manifest
+# in the linux/amd64 slot would pass a subset check and still get a substituted
+# image deployed. The published set has to match exactly.
+published_index "${tmp}/children-extra.json" \
+  "${amd64_child}" "${amd64_attest}" "${arm64_child}" "${arm64_attest}" \
+  "$(printf 'e%.0s' {1..64})"
+check_children 1 "an index carrying a manifest this job did not push is rejected" \
+  "${tmp}/children-extra.json" "${tmp}/pushed"
+
 # Dropping just the attestation is still an index this job did not assemble.
 published_index "${tmp}/children-noattest.json" \
   "${amd64_child}" "${amd64_attest}" "${arm64_child}"
@@ -388,6 +399,24 @@ check_children 1 "an unreadable source is rejected even when its own digest is l
 mkdir -p "${tmp}/nodigests"
 check_children 1 "an empty digest set is rejected" \
   "${tmp}/children-ok.json" "${tmp}/nodigests"
+
+# ...including against an empty index, where the two sets would otherwise
+# compare equal and the comparison alone would wave it through.
+published_index "${tmp}/children-empty.json"
+check_children 1 "an empty digest set is rejected against an empty index" \
+  "${tmp}/children-empty.json" "${tmp}/nodigests"
+
+# The exit code alone does not pin that guard: with it removed the empty set
+# still fails, but as a pipefail from `grep` finding nothing. What the guard is
+# worth is the operator being told which of the two inputs was empty.
+empty_err="$(PATH="${children_stub_dir}:/usr/bin:/bin" FIXTURE_DIR="${srcidx}" \
+  bash "${children}" ttl.sh/cf-tunnel-gateway-ctrl \
+  "${tmp}/children-empty.json" "${tmp}/nodigests" 2>&1 || true)"
+if grep --quiet "no pushed digests to check" <<< "${empty_err}"; then
+  pass "an empty digest set is refused by name, not by a pipeline error"
+else
+  flunk "an empty digest set is refused by name (got: ${empty_err##*$'\n'})"
+fi
 
 check_children 1 "an unreadable published index is rejected" \
   "${tmp}/absent-index.json" "${tmp}/pushed"

--- a/hack/conformance-setup_test.sh
+++ b/hack/conformance-setup_test.sh
@@ -250,6 +250,19 @@ else
   pass "an unreadable index is rejected"
 fi
 
+# A plain manifest has no `.manifests`, and jq must not hard-error on iterating
+# null before the script gets to say what is actually wrong with the reference.
+printf '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","layers":[]}' \
+  > "${tmp}/index-plain.json"
+plain_err="$(PATH="${pull_stub_dir}:/usr/bin:/bin" FIXTURE_INDEX="${tmp}/index-plain.json" \
+  DOCKER_LOG="${tmp}/docker.log" bash "${puller}" \
+  "ttl.sh/cf-tunnel-gateway-ctrl@sha256:$(printf 'e%.0s' {1..64})" controller:dev amd64 2>&1 || true)"
+if grep --quiet "carries no linux/amd64 manifest" <<< "${plain_err}"; then
+  pass "a plain manifest gets the script's own diagnosis, not a jq error"
+else
+  flunk "a plain manifest gets the script's own diagnosis (got: ${plain_err##*$'\n'})"
+fi
+
 # --- verify-manifest-children.sh -------------------------------------------
 #
 # The merge job reads its manifest-list digest back from a run-scoped tag on
@@ -443,6 +456,117 @@ for guarded in hack/verify-manifest-children.sh .github/workflows/pr.yaml; do
     flunk "scripts.yaml runs on changes to ${guarded} (${occurrences} of 2 paths blocks)"
   fi
 done
+
+# --- find-ci-run.sh ---------------------------------------------------------
+#
+# This is the trust root of --use-ci-images: whatever run it names has its
+# artifacts deployed into a cluster holding live Cloudflare credentials. Each
+# filter is pinned separately, because dropping any one of them silently widens
+# what is accepted rather than breaking anything visible.
+
+finder="${script_dir}/find-ci-run.sh"
+
+gh_stub_dir="${tmp}/ghstubs"
+mkdir -p "${gh_stub_dir}"
+cat > "${gh_stub_dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  pr)  [[ -n "${FIXTURE_HEAD:-}" ]] || exit 1; echo "${FIXTURE_HEAD}" ;;
+  api) cat "${FIXTURE_RUNS}" ;;
+  *)   exit 1 ;;
+esac
+STUB
+chmod +x "${gh_stub_dir}/gh"
+
+ci_head="$(printf 'a%.0s' {1..40})"
+ci_old_head="$(printf 'f%.0s' {1..40})"
+
+# runs_fixture <file> <entry>...  where entry is name|event|conclusion|sha|created|id
+runs_fixture() {
+  local out="$1"; shift
+  {
+    printf '{"workflow_runs":['
+    local sep="" e
+    for e in "$@"; do
+      IFS='|' read -r name event concl sha created id <<< "${e}"
+      printf '%s{"name":"%s","event":"%s","conclusion":"%s","head_sha":"%s","created_at":"%s","id":%s}' \
+        "${sep}" "${name}" "${event}" "${concl}" "${sha}" "${created}" "${id}"
+      sep=","
+    done
+    printf ']}'
+  } > "${out}"
+}
+
+# check_finder <expected-exit> <label> <runs-fixture> [expected-stdout-substring]
+check_finder() {
+  local expected="$1" label="$2" fixture="$3" want="${4:-}" actual=0 out
+  out="$(PATH="${gh_stub_dir}:/usr/bin:/bin" FIXTURE_HEAD="${ci_head}" FIXTURE_RUNS="${fixture}" \
+    bash "${finder}" 733 2>&1)" || actual=$?
+  if [[ "${actual}" -ne "${expected}" ]]; then
+    flunk "${label}: expected exit ${expected}, got ${actual}"
+  elif [[ -n "${want}" ]] && ! grep --quiet --fixed-strings "${want}" <<< "${out}"; then
+    flunk "${label}: output lacks '${want}' (got: ${out##*$'\n'})"
+  else
+    pass "${label} (exit ${actual})"
+  fi
+}
+
+good_run="PR Checks and Build|pull_request|success|${ci_head}|2026-09-05T10:00:00Z|111"
+
+runs_fixture "${tmp}/runs-ok.json" "${good_run}"
+check_finder 0 "a successful pull_request run at this head is accepted" \
+  "${tmp}/runs-ok.json" "run_id=111"
+
+# A failed run may have published only some of its artifacts.
+runs_fixture "${tmp}/runs-failed.json" \
+  "PR Checks and Build|pull_request|failure|${ci_head}|2026-09-05T10:00:00Z|111"
+check_finder 1 "a failed run is refused" "${tmp}/runs-failed.json" "No successful"
+
+# Only the pull_request event builds the PR's own code.
+runs_fixture "${tmp}/runs-dispatch.json" \
+  "PR Checks and Build|workflow_dispatch|success|${ci_head}|2026-09-05T10:00:00Z|111"
+check_finder 1 "a workflow_dispatch run is refused" "${tmp}/runs-dispatch.json" "No successful"
+
+runs_fixture "${tmp}/runs-push.json" \
+  "PR Checks and Build|push|success|${ci_head}|2026-09-05T10:00:00Z|111"
+check_finder 1 "a push run is refused" "${tmp}/runs-push.json" "No successful"
+
+# A run for an older head built a different diff than the one under review.
+runs_fixture "${tmp}/runs-oldhead.json" \
+  "PR Checks and Build|pull_request|success|${ci_old_head}|2026-09-05T10:00:00Z|111"
+check_finder 1 "a run for an earlier head is refused" "${tmp}/runs-oldhead.json" "No successful"
+
+# Another workflow's run carries none of the artifacts this flag needs.
+runs_fixture "${tmp}/runs-otherwf.json" \
+  "Scripts|pull_request|success|${ci_head}|2026-09-05T10:00:00Z|111"
+check_finder 1 "another workflow's run is refused" "${tmp}/runs-otherwf.json" "No successful"
+
+# Re-running CI must win over the run it replaced.
+runs_fixture "${tmp}/runs-two.json" \
+  "PR Checks and Build|pull_request|success|${ci_head}|2026-09-05T10:00:00Z|111" \
+  "PR Checks and Build|pull_request|success|${ci_head}|2026-09-05T12:00:00Z|222"
+check_finder 0 "the newest successful run wins" "${tmp}/runs-two.json" "run_id=222"
+
+runs_fixture "${tmp}/runs-none.json"
+check_finder 1 "an empty run list is refused" "${tmp}/runs-none.json" "No successful"
+
+# The head the artifacts are bound to is the one the caller must verify against.
+check_finder 0 "the resolved head is reported to the caller" \
+  "${tmp}/runs-ok.json" "head_sha=${ci_head}"
+
+if [[ "$(PATH="${gh_stub_dir}:/usr/bin:/bin" FIXTURE_HEAD="${ci_head}" \
+  FIXTURE_RUNS="${tmp}/runs-ok.json" bash "${finder}" not-a-number 2>&1 || true)" == *"must be numeric"* ]]; then
+  pass "a non-numeric PR number is refused"
+else
+  flunk "a non-numeric PR number is refused"
+fi
+
+# The finder only protects anything if the setup script uses it.
+if grep --quiet --extended-regexp '\$\{REPO_ROOT\}/hack/find-ci-run\.sh' "${setup}"; then
+  pass "conformance-setup.sh resolves the run through the finder"
+else
+  flunk "conformance-setup.sh resolves the run through the finder"
+fi
 
 if [[ "${fail}" -ne 0 ]]; then
   echo "conformance-setup tests FAILED"

--- a/hack/find-ci-run.sh
+++ b/hack/find-ci-run.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# find-ci-run.sh — pick the CI run whose artifacts may be deployed for a PR.
+#
+# This is the trust root of `conformance-setup.sh --use-ci-images`: whatever run
+# this names has its artifacts unpacked and deployed into a cluster that holds
+# live Cloudflare credentials. Every filter is load-bearing, and dropping one
+# widens what is accepted without breaking anything visible:
+#
+#   name         another workflow's run carries none of these artifacts
+#   event        only `pull_request` builds the PR's own code
+#   conclusion   a failed run may have published only some of its artifacts
+#   head_sha     a run for an older head built a different diff than the one
+#                under review
+#
+# Newest wins, so re-running CI supersedes the run it replaced.
+#
+# Usage: find-ci-run.sh <pr-number>
+# Prints `key=value` lines for the caller on success.
+
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[[ $# -eq 1 ]] || die "usage: $0 <pr-number>"
+
+pr_number="$1"
+[[ "${pr_number}" =~ ^[0-9]+$ ]] || die "PR number must be numeric, got '${pr_number}'"
+
+head_sha="$(gh pr view "${pr_number}" --json headRefOid --jq '.headRefOid')" \
+  || die "Cannot read PR #${pr_number} (is gh authenticated for this repo?)"
+[[ -n "${head_sha}" ]] || die "PR #${pr_number} reports no head commit"
+
+run_id="$(gh api "repos/{owner}/{repo}/actions/runs?head_sha=${head_sha}&per_page=100" \
+  | jq --raw-output --arg sha "${head_sha}" '
+      [ .workflow_runs[]
+        | select(.name == "PR Checks and Build")
+        | select(.event == "pull_request")
+        | select(.conclusion == "success")
+        | select(.head_sha == $sha)
+      ] | sort_by(.created_at) | last | .id // empty')" \
+  || die "Querying workflow runs for head ${head_sha} failed (gh api actions/runs)"
+
+[[ -n "${run_id}" ]] \
+  || die "No successful 'PR Checks and Build' run for PR #${pr_number} at head ${head_sha}. Re-run its CI; a run for an earlier head is not accepted."
+
+echo "head_sha=${head_sha}"
+echo "run_id=${run_id}"

--- a/hack/pull-ci-image.sh
+++ b/hack/pull-ci-image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# pull-ci-image.sh — pull one CI image for this host's platform and tag it.
+#
+# `kind load docker-image` runs `docker save | ctr images import
+# --all-platforms`. If the local tag carries a multi-arch index, ctr demands
+# blobs for every platform in it, including the ones this host never fetched,
+# and the import dies on the first foreign manifest. So resolve the host's own
+# manifest out of the index the caller already verified and pull that: what
+# ends up under the local tag is a single platform.
+#
+# The index digest stays the root of trust -- the platform digest is read out
+# of that index, not resolved from a tag.
+#
+# Usage: pull-ci-image.sh <repo@sha256:index-digest> <local-tag> <goarch>
+
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[[ $# -eq 3 ]] || die "usage: $0 <image-ref> <local-tag> <goarch>"
+
+ref="$1"
+local_tag="$2"
+arch="$3"
+
+index="$(docker buildx imagetools inspect "${ref}" --raw)" \
+  || die "cannot read the image index for ${ref}"
+
+digest="$(jq --raw-output --arg arch "${arch}" '
+    .manifests[]
+    | select(.platform.os == "linux" and .platform.architecture == $arch)
+    | .digest' <<< "${index}")"
+[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+  || die "${ref} carries no linux/${arch} manifest"
+
+docker pull "${ref%@*}@${digest}"
+docker tag "${ref%@*}@${digest}" "${local_tag}"

--- a/hack/pull-ci-image.sh
+++ b/hack/pull-ci-image.sh
@@ -27,7 +27,7 @@ index="$(docker buildx imagetools inspect "${ref}" --raw)" \
   || die "cannot read the image index for ${ref}"
 
 digest="$(jq --raw-output --arg arch "${arch}" '
-    .manifests[]
+    .manifests[]?
     | select(.platform.os == "linux" and .platform.architecture == $arch)
     | .digest' <<< "${index}")"
 [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \

--- a/hack/verify-ci-bundle.sh
+++ b/hack/verify-ci-bundle.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# verify-ci-bundle.sh — validate the artifacts a PR's CI run published before
+# anything is deployed from them.
+#
+# The bundle is assembled by hack/conformance-setup.sh --use-ci-images from
+# three artifacts of one "PR Checks and Build" run:
+#   controller.ref / proxy.ref   image references, digest-pinned
+#   head-sha.txt                 commit the run built
+#   <chart>.tgz                  the packaged chart
+#
+# Everything downstream deploys what these files name, with the maintainer's
+# Cloudflare credentials mounted into it. A reference that is not digest-pinned
+# would put a mutable ttl.sh tag back on that path, so it has to stop the run
+# rather than degrade quietly.
+#
+# Usage: verify-ci-bundle.sh <bundle-dir> <pr-number> <expected-head-sha>
+# Prints `key=value` lines for the caller on success.
+
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[[ $# -eq 3 ]] || die "usage: $0 <bundle-dir> <pr-number> <expected-head-sha>"
+
+bundle_dir="$1"
+pr_number="$2"
+expected_head_sha="$3"
+
+[[ -d "${bundle_dir}" ]] || die "bundle directory ${bundle_dir} does not exist"
+[[ "${pr_number}" =~ ^[0-9]+$ ]] || die "PR number must be numeric, got '${pr_number}'"
+
+read_ref() {
+  local name="$1" image="$2" file="${bundle_dir}/$1" value
+  [[ -f "${file}" ]] || die "${name} missing from the CI bundle"
+  value="$(tr -d '[:space:]' < "${file}")"
+  # Both halves are pinned. The digest half must be a full content address, so
+  # "repo:tag" and a short digest fail. The repository half must be the one
+  # image this file is for: a valid digest on someone else's registry must not
+  # be deployed with real credentials, and the two CI images must not be
+  # swappable, which would run the controller binary in the proxy Deployment.
+  [[ "${value}" =~ ^"${image}"@sha256:[0-9a-f]{64}$ ]] \
+    || die "${name} is not a digest-pinned reference to ${image}: '${value}'"
+  printf '%s' "${value}"
+}
+
+controller_ref="$(read_ref controller.ref ttl.sh/cf-tunnel-gateway-ctrl)"
+proxy_ref="$(read_ref proxy.ref ttl.sh/cf-tunnel-gateway-proxy)"
+
+head_sha_file="${bundle_dir}/head-sha.txt"
+[[ -f "${head_sha_file}" ]] || die "head-sha.txt missing from the CI bundle"
+head_sha="$(tr -d '[:space:]' < "${head_sha_file}")"
+# Binds the artifacts to the commit, not just the run that claims to have
+# built them: a bundle whose chart was packaged from another revision is the
+# case this refuses.
+[[ "${head_sha}" == "${expected_head_sha}" ]] \
+  || die "CI bundle was built from ${head_sha:-nothing}, expected ${expected_head_sha}"
+
+chart_version="0.0.0-pr.${pr_number}-1d"
+chart_tgz="${bundle_dir}/cloudflare-tunnel-gateway-controller-${chart_version}.tgz"
+[[ -f "${chart_tgz}" ]] || die "chart ${chart_tgz##*/} missing from the CI bundle"
+
+echo "head_sha=${head_sha}"
+echo "controller_ref=${controller_ref}"
+echo "proxy_ref=${proxy_ref}"
+echo "chart_tgz=${chart_tgz}"

--- a/hack/verify-manifest-children.sh
+++ b/hack/verify-manifest-children.sh
@@ -1,46 +1,59 @@
 #!/usr/bin/env bash
-# verify-manifest-children.sh — assert a published manifest index still lists
-# the per-arch images the build job pushed.
+# verify-manifest-children.sh — assert a published manifest index was assembled
+# out of the images this build job pushed.
 #
 # The merge job reads its manifest-list digest back from a tag, and ttl.sh has
 # no authentication while the run id in that tag is public for as long as the
-# run is. In the seconds between the push and the read-back, anyone can repoint
-# that tag; the digest read back would then be theirs, and every check
-# downstream would pass it, because it really is a well-formed content address
+# run is. In the seconds between the manifest push and the read-back, anyone can
+# repoint that tag. The digest read back would then be theirs, and every check
+# downstream would accept it, because it really is a well-formed content address
 # to a real image. It is just not this build.
 #
-# The per-arch digests are the part an attacker cannot reproduce, so the index
-# has to carry all of them. Containment rather than set equality: buildx
-# attaches provenance and SBOM manifests of its own.
+# What `/tmp/digests` names is not what the published index lists. Provenance is
+# on, so each per-arch build pushes an OCI index of its own -- a platform
+# manifest plus an attestation manifest -- and `imagetools create` flattens
+# index sources, so the published index carries those children and never the
+# source digests. Each pushed digest is therefore resolved to its own index, and
+# it is that index's children that have to appear.
 #
-# Usage: verify-manifest-children.sh <index-json> <digests-dir>
-# <digests-dir> holds one empty file per pushed image, named by its bare digest
-# -- the layout `docker/build-push-action` and the merge job already use.
+# Usage: verify-manifest-children.sh <image> <published-index-json> <digests-dir>
 
 set -euo pipefail
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
-[[ $# -eq 2 ]] || die "usage: $0 <index-json> <digests-dir>"
+[[ $# -eq 3 ]] || die "usage: $0 <image> <published-index-json> <digests-dir>"
 
-index_json="$1"
-digests_dir="$2"
+image="$1"
+published="$2"
+digests_dir="$3"
 
-[[ -f "${index_json}" ]] || die "manifest index ${index_json} does not exist"
+[[ -f "${published}" ]] || die "manifest index ${published} does not exist"
 [[ -d "${digests_dir}" ]] || die "digests directory ${digests_dir} does not exist"
 
 checked=0
 for digest_file in "${digests_dir}"/*; do
   [[ -f "${digest_file}" ]] || continue
-  want="sha256:${digest_file##*/}"
-  jq --exit-status --arg want "${want}" \
-    'any(.manifests[]?; .digest == $want)' "${index_json}" > /dev/null \
-    || die "the published index does not list ${want}, which this job pushed"
-  checked=$((checked + 1))
+  source_digest="sha256:${digest_file##*/}"
+
+  raw="$(docker buildx imagetools inspect "${image}@${source_digest}" --raw)" \
+    || die "cannot read ${source_digest}, which this job pushed"
+
+  # With provenance off a build pushes a plain manifest instead of an index. It
+  # has no children, and then the source digest is itself what must appear.
+  expected="$(jq --raw-output '.manifests[]?.digest' <<< "${raw}")"
+  [[ -n "${expected}" ]] || expected="${source_digest}"
+
+  while read -r want; do
+    jq --exit-status --arg want "${want}" \
+      'any(.manifests[]?; .digest == $want)' "${published}" > /dev/null \
+      || die "the published index does not list ${want}, pushed under ${source_digest}"
+    checked=$((checked + 1))
+  done <<< "${expected}"
 done
 
 # Without this an empty directory would satisfy the loop vacuously, and the
 # check would wave through any index at all.
 [[ "${checked}" -gt 0 ]] || die "no pushed digests to check in ${digests_dir}"
 
-echo "index lists all ${checked} manifests this job pushed"
+echo "published index lists all ${checked} manifests this job pushed"

--- a/hack/verify-manifest-children.sh
+++ b/hack/verify-manifest-children.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# verify-manifest-children.sh — assert a published manifest index still lists
+# the per-arch images the build job pushed.
+#
+# The merge job reads its manifest-list digest back from a tag, and ttl.sh has
+# no authentication while the run id in that tag is public for as long as the
+# run is. In the seconds between the push and the read-back, anyone can repoint
+# that tag; the digest read back would then be theirs, and every check
+# downstream would pass it, because it really is a well-formed content address
+# to a real image. It is just not this build.
+#
+# The per-arch digests are the part an attacker cannot reproduce, so the index
+# has to carry all of them. Containment rather than set equality: buildx
+# attaches provenance and SBOM manifests of its own.
+#
+# Usage: verify-manifest-children.sh <index-json> <digests-dir>
+# <digests-dir> holds one empty file per pushed image, named by its bare digest
+# -- the layout `docker/build-push-action` and the merge job already use.
+
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[[ $# -eq 2 ]] || die "usage: $0 <index-json> <digests-dir>"
+
+index_json="$1"
+digests_dir="$2"
+
+[[ -f "${index_json}" ]] || die "manifest index ${index_json} does not exist"
+[[ -d "${digests_dir}" ]] || die "digests directory ${digests_dir} does not exist"
+
+checked=0
+for digest_file in "${digests_dir}"/*; do
+  [[ -f "${digest_file}" ]] || continue
+  want="sha256:${digest_file##*/}"
+  jq --exit-status --arg want "${want}" \
+    'any(.manifests[]?; .digest == $want)' "${index_json}" > /dev/null \
+    || die "the published index does not list ${want}, which this job pushed"
+  checked=$((checked + 1))
+done
+
+# Without this an empty directory would satisfy the loop vacuously, and the
+# check would wave through any index at all.
+[[ "${checked}" -gt 0 ]] || die "no pushed digests to check in ${digests_dir}"
+
+echo "index lists all ${checked} manifests this job pushed"

--- a/hack/verify-manifest-children.sh
+++ b/hack/verify-manifest-children.sh
@@ -14,7 +14,16 @@
 # manifest plus an attestation manifest -- and `imagetools create` flattens
 # index sources, so the published index carries those children and never the
 # source digests. Each pushed digest is therefore resolved to its own index, and
-# it is that index's children that have to appear.
+# it is that index's children that are compared.
+#
+# The comparison is equality, not containment. Nothing here constrains the
+# `platform` field, and `pull-ci-image.sh` picks what to deploy by platform, so
+# an index that keeps all of this job's manifests, relabels the amd64 one and
+# puts a foreign manifest in the linux/amd64 slot would satisfy a subset test
+# and still hand over a substituted image. Requiring the published set to hold
+# nothing else is what closes that. `imagetools create` adds nothing of its own
+# to a flattened index -- a real run publishes exactly the union of its sources'
+# children -- so equality is what the merge job actually produces.
 #
 # Usage: verify-manifest-children.sh <image> <published-index-json> <digests-dir>
 
@@ -31,7 +40,7 @@ digests_dir="$3"
 [[ -f "${published}" ]] || die "manifest index ${published} does not exist"
 [[ -d "${digests_dir}" ]] || die "digests directory ${digests_dir} does not exist"
 
-checked=0
+expected=""
 for digest_file in "${digests_dir}"/*; do
   [[ -f "${digest_file}" ]] || continue
   source_digest="sha256:${digest_file##*/}"
@@ -41,19 +50,27 @@ for digest_file in "${digests_dir}"/*; do
 
   # With provenance off a build pushes a plain manifest instead of an index. It
   # has no children, and then the source digest is itself what must appear.
-  expected="$(jq --raw-output '.manifests[]?.digest' <<< "${raw}")"
-  [[ -n "${expected}" ]] || expected="${source_digest}"
-
-  while read -r want; do
-    jq --exit-status --arg want "${want}" \
-      'any(.manifests[]?; .digest == $want)' "${published}" > /dev/null \
-      || die "the published index does not list ${want}, pushed under ${source_digest}"
-    checked=$((checked + 1))
-  done <<< "${expected}"
+  children="$(jq --raw-output '.manifests[]?.digest' <<< "${raw}")"
+  [[ -n "${children}" ]] || children="${source_digest}"
+  expected+="${children}"$'\n'
 done
 
-# Without this an empty directory would satisfy the loop vacuously, and the
+# Without this an empty directory would leave both sets empty and equal, and the
 # check would wave through any index at all.
-[[ "${checked}" -gt 0 ]] || die "no pushed digests to check in ${digests_dir}"
+[[ -n "${expected//[[:space:]]/}" ]] \
+  || die "no pushed digests to check in ${digests_dir}"
 
-echo "published index lists all ${checked} manifests this job pushed"
+expected="$(grep --invert-match '^$' <<< "${expected}" | LC_ALL=C sort --unique)"
+found="$(jq --raw-output '.manifests[]?.digest' "${published}" | LC_ALL=C sort --unique)"
+
+missing="$(grep --fixed-strings --line-regexp --invert-match \
+  --file=<(printf '%s\n' "${found}") <<< "${expected}" || true)"
+[[ -z "${missing}" ]] \
+  || die "the published index does not list $(tr '\n' ' ' <<< "${missing}")-- pushed by this job"
+
+extra="$(grep --fixed-strings --line-regexp --invert-match \
+  --file=<(printf '%s\n' "${expected}") <<< "${found}" || true)"
+[[ -z "${extra}" ]] \
+  || die "the published index also lists $(tr '\n' ' ' <<< "${extra}")-- not pushed by this job"
+
+echo "published index matches the $(wc -l <<< "${expected}" | tr -d ' ') manifests this job pushed"

--- a/renovate.json
+++ b/renovate.json
@@ -109,13 +109,25 @@
     },
     {
       "customType": "regex",
-      "description": "Update versioned binaries in GitHub Actions workflows",
+      "description": "Update digest-pinned tool images in GitHub Actions workflows. The tag is there for humans; the digest is what docker resolves, so both have to move together and a single matchString keeps them in step",
       "fileMatch": [
         "^\\.github/workflows/.*\\.ya?ml$",
         "^\\.github/actions/.*\\.ya?ml$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s+[A-Z_]+VERSION=\"(?<currentValue>.*?)\""
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s+[A-Z_]+_IMAGE=\"[^\"]+:(?<currentValue>[^\"@]+)@(?<currentDigest>sha256:[a-f0-9]{64})\""
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update versioned binaries in GitHub Actions workflows, both the SOMETHING_VERSION=\"...\" shell form and an action's version: input",
+      "fileMatch": [
+        "^\\.github/workflows/.*\\.ya?ml$",
+        "^\\.github/actions/.*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s+[A-Z_]+VERSION=\"(?<currentValue>.*?)\"",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s+version: '(?<currentValue>[^']+)'"
       ]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -98,36 +98,36 @@
     {
       "customType": "regex",
       "description": "Update Go version in GitHub Actions",
-      "fileMatch": [
-        "^\\.github/workflows/.*\\.ya?ml$"
-      ],
       "matchStrings": [
         "go-version:\\s*['\"]?(?<currentValue>[\\d.]+)['\"]?"
       ],
       "depNameTemplate": "golang",
-      "datasourceTemplate": "golang-version"
+      "datasourceTemplate": "golang-version",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.*\\.ya?ml$/"
+      ]
     },
     {
       "customType": "regex",
       "description": "Update digest-pinned tool images in GitHub Actions workflows. The tag is there for humans; the digest is what docker resolves, so both have to move together and a single matchString keeps them in step",
-      "fileMatch": [
-        "^\\.github/workflows/.*\\.ya?ml$",
-        "^\\.github/actions/.*\\.ya?ml$"
-      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s+[A-Z_]+_IMAGE=\"[^\"]+:(?<currentValue>[^\"@]+)@(?<currentDigest>sha256:[a-f0-9]{64})\""
+      ],
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.*\\.ya?ml$/",
+        "/^\\.github/actions/.*\\.ya?ml$/"
       ]
     },
     {
       "customType": "regex",
       "description": "Update versioned binaries in GitHub Actions workflows, both the SOMETHING_VERSION=\"...\" shell form and an action's version: input",
-      "fileMatch": [
-        "^\\.github/workflows/.*\\.ya?ml$",
-        "^\\.github/actions/.*\\.ya?ml$"
-      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s+[A-Z_]+VERSION=\"(?<currentValue>.*?)\"",
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s+version: '(?<currentValue>[^']+)'"
+      ],
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.*\\.ya?ml$/",
+        "/^\\.github/actions/.*\\.ya?ml$/"
       ]
     }
   ]


### PR DESCRIPTION
# Pull Request

## Summary

Four supply-chain findings in CI and in local verification. Each one is a mutable or unverified reference in front of something that runs with real credentials or real signing authority.

Closes #720
Closes #721
Closes #717
Closes #702
Closes #724

## Changes

- `hack/conformance-setup.sh --use-ci-images N` no longer resolves anything by tag. CI publishes the packaged chart, the commit it was built from, and each image's manifest-list digest as artifacts of the run. The script picks the newest successful `pull_request` run for the PR's current head, downloads those artifacts, and refuses to continue unless both image references are digest-pinned, the recorded commit matches the head being verified, and the chart carries that PR's version. No tag is resolved on the trusted path: CI reads the digest back from a run-scoped tag (`pr-N-run-<run_id>`) that only that run writes, and `pr-N-1d` stays as the human alias. A digest binds content, not trust, so on a fork PR the artifacts still come from the fork's own copy of `pr.yaml` and the fork diff still needs reading before an un-sandboxed run. Images are pulled by digest and loaded into the kind nodes, so the nodes never reach a registry themselves. The digests are not written into the chart's values because the template renders `repository:tag`, so a digest there would need `repository` to end in `@sha256` and would trip the existing `*-ctrl` suffix validator in `build-chart`; retagging locally reuses the path already in the script and keeps the kind nodes off any registry.
- The manifest-list digest the merge job publishes is no longer whatever a tag happened to resolve to. `imagetools` reads it back from the run-scoped tag, the index is then re-read by that digest, and `hack/verify-manifest-children.sh` requires it to have been assembled out of the images this job pushed. ttl.sh has no authentication and the run id is public for as long as the run is, so between the manifest push and the read-back that tag is a name anyone can write; the digest recorded off a substituted index would be a real, well-formed content address, and both the bundle verifier and the puller would accept it, because the thing it is not is this build. What `/tmp/digests` names is not what the published index lists: provenance is on, so each per-arch build pushes an OCI index of its own -- a platform manifest plus an attestation manifest -- and `imagetools create` flattens index sources. So each pushed digest is resolved to its own index and it is that index's children that have to appear. A source that is a plain manifest, which is what a build with provenance off pushes, is matched by its own digest instead; one that cannot be read stops the job rather than being skipped.
- The comparison is equality, not containment. Nothing in the check constrains `platform`, and `hack/pull-ci-image.sh` selects what to deploy by platform, so an index that keeps every manifest this job pushed, relabels the amd64 one and puts a foreign manifest in the `linux/amd64` slot would satisfy a subset test and still hand over a substituted image. Requiring the published set to hold nothing else is what closes that. It is also what the merge job produces: a real run's published index is exactly the union of its sources' children, which I checked against the index a live run left on ttl.sh.
- `release.yaml` grants permissions per job over a `contents: read` floor instead of `contents`, `packages` and `id-token: write` workflow-wide, and pins the tools it installs.
- `scheduled-e2e.yaml` declares the five Cloudflare secrets on the two steps that need them instead of on the job, and builds `kind` from source instead of curling a release asset.
- The colima prerequisite is keyed on `uname -s` being Darwin instead of on `GITHUB_ACTIONS` being unset, so a Linux host with a native docker daemon can run the setup script.

## Why cosign signing is not part of this

The plan for #720 was digest pinning plus keyless cosign signatures on the PR artifacts. `ttl.sh` is not the obstacle. It accepts a `sha256-<digest>.sig` tag, which I confirmed by pushing one. The obstacle is that `pr.yaml` runs on `pull_request`, and GitHub refuses to mint an OIDC token for a fork-triggered run even when `id-token: write` is requested. Signing would work on my own branches and silently not on fork PRs, which is the case `--use-ci-images` exists for. Granting `id-token: write` to a workflow that builds untrusted code is a downgrade on its own terms. And for same-repo PRs the signature adds nothing over the channel it would be verified through: the digests already arrive over the authenticated Actions artifact API, from a run in this repository.

## `release.yaml` permissions

| Job | Before | After | Why |
| --- | --- | --- | --- |
| `lint-chart` | contents:write, packages:write, id-token:write | contents:read | Checkout, lint, template, helm-docs. No registry, no signing. |
| `build-and-push` | contents:write, packages:write, id-token:write | contents:read, packages:write | `Login to GitHub Container Registry` and `Build and Push by Digest`. Signing happens one job later. |
| `merge-manifests` | contents:write, packages:write, id-token:write | contents:read, packages:write, id-token:write | `Create manifest list and push` needs the registry, `Sign container images` runs `cosign sign`. |
| `publish-chart` | contents:write, packages:write, id-token:write | contents:read, packages:write, id-token:write | Two `oras push` steps to ghcr, `Sign Helm chart with cosign` runs `cosign sign`. |
| `create-release` | contents:write, packages:write, id-token:write | contents:write | `softprops/action-gh-release` creates the release and uploads the chart tarball. |

The risky installs are workflow-level co-tenants of the signing jobs. That holds for `publish-chart`, where `yq` is extracted from an image in the same job that runs `cosign sign`. It does not hold for `merge-manifests`, whose signing step has no adjacent installs. Those live in `lint-chart`.

Pinned in the same pass: `artifacthub/ah`, `jnorwood/helm-docs` and `mikefarah/yq` by `repo:tag@sha256:`, `helm plugin install --version`, `check-jsonschema==0.38.0`, and in `pr.yaml` the `setup-envtest@latest` that was floating. That pin reads `v0.24.1` while master now carries controller-runtime v0.25.0, and it stays there: `setup-envtest` is a standalone downloader, not something the test binary links against, and v0.24.1 still resolves and still fetches current control-plane binaries (k8s 1.37.0 on a Linux amd64 host). The `# renovate: datasource=go` comment above it is what moves that version, on Renovate's own schedule. Nothing in the workflow claims the two have to match, so there is no constraint here to encode. `actionlint` moved from a bare curl to `go install`, so the Go checksum database attests it. `shellcheck` stays a plain download: its releases carry no `.sha256`, `.pem` or `.sig` asset to verify against. A comment there claimed a tag "binds both version and content digest". It does not, and it is gone from `release.yaml` and from `pr.yaml`'s copy of the same install block. `renovate.json` gained a custom manager for the `repo:tag@sha256:` form so the tag and the digest move together.

## Why `kind` is built from source

Pinning a `KIND_SHA256` literal next to `KIND_VERSION` would have worked, but Renovate's `github-releases` datasource carries no digest, so nothing keeps the two in step. This repository automerges minor and patch updates, so a version bump would land a workflow whose checksum no longer matches, and the weekly job would break unnoticed until the next Monday. `go install sigs.k8s.io/kind@v0.33.0` moves the integrity claim to the Go checksum database, which is a transparency log instead of a hand-maintained literal, and lets the version keep automerging. Costs a minute or two of build time on a job that runs once a week.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`), 0 issues
- [x] Markdown linting passes (`markdownlint **/*.md`), 0 issues in 71 files
- [x] Manual testing completed (if applicable). The Gateway API conformance suite (430 passed, 0 failed) and the custom e2e suite (30 passed, 0 failed) ran against a live tunnel on kind, deployed through `--use-ci-images 733` — so this branch's own digest-pinned path is what fetched the images under test.

`hack/conformance-setup_test.sh` is new and runs in CI from a job in `scripts.yaml`. It covers both branches of the colima guard with a stubbed `uname`, and the bundle verifier against fixtures. Also run: `actionlint`, `shellcheck hack/*.sh`, `hack/lint-action-shell.sh`, `hack/check-doc-links.sh`, `mkdocs build --strict`, and `helm unittest` at the newly pinned plugin version (287 tests, 16 suites, all green).

Each guard was checked by mutation rather than assumed to bite:

| Mutation | Test that died |
| --- | --- |
| Colima guard reverted to `GITHUB_ACTIONS` | `Linux host must not require colima`, `Linux host reaches the credential check` |
| Digest regex loosened to "non-empty" | `a tag in place of a digest is rejected`, `a truncated digest is rejected` |
| Head-SHA equality dropped | `a bundle built from another commit is rejected` |
| Verifier call removed from the setup script | `conformance-setup.sh invokes the bundle verifier` |
| Published index compared against the pushed digests instead of their children | `an index assembled from this job's images is accepted` |
| Equality relaxed to containment | `an index carrying a manifest this job did not push is rejected` |
| Missing-manifest check dropped | `an index missing a pushed image's manifests is rejected`, `an index missing an attestation manifest is rejected` |
| Unreadable source tolerated instead of fatal | `an unreadable source is rejected even when its own digest is listed` |
| Empty-digest-set guard dropped | `an empty digest set is refused by name, not by a pipeline error` |
| Each of the four run-selection filters, dropped one at a time | `a failed run is refused`; `a workflow_dispatch run is refused` + `a push run is refused`; `a run for an earlier head is refused`; `another workflow's run is refused` |
| Newest-wins reversed to oldest-wins | `the newest successful run wins` |
| Finder call removed from `conformance-setup.sh` | `conformance-setup.sh resolves the run through the finder` |
| `.manifests[]?` reverted to `.manifests[]` | `a plain manifest gets the script's own diagnosis, not a jq error` |
| Verifier call removed from `pr.yaml` | `pr.yaml verifies the manifest list it publishes` |
| `scripts.yaml` paths entries removed | `scripts.yaml runs on changes to hack/verify-manifest-children.sh`, `… to .github/workflows/pr.yaml` |

Two of those rows exist only because the first attempt at them was worthless, which is worth stating plainly for anyone deciding how much to trust the table. An early run of the harness reported four mutations as applied and surviving; none of them had applied at all, because the loop feeding it multi-line anchors mangled them and the helper printed its success line unconditionally. Nothing caught that except the implausibility of four escapes at once. A mutation harness that cannot fail loudly does not grade the tests, it manufactures passes, so it now diffs against the backup and refuses to report a result when the file it was asked to change is unchanged.

The other is the empty-digest-set guard. Removing it does not change the exit code, because `set -o pipefail` and a `grep` that selects nothing already fail the run, so two successive versions of that case passed against a script with the guard deleted. Its only observable effect is telling the operator which of the two inputs was empty, so the case reads the message rather than the exit code. A guard whose only effect is a message needs a test that reads the message.

The first of those is the one that matters: the fixtures originally put platform manifests in `/tmp/digests`, which is not the shape CI produces, and a green suite sat on top of a merge job that failed on every run. They now follow the production shape. Two of the others were found the same way -- a wiring grep that matched its own scaffolding, and an unreadable-source case that was being rejected by the fallback path rather than by the guard meant to reject it -- and both were tightened until the mutation bit.

That last wiring check matches the invocation rather than the bare filename: the merge job's checkout step names the script in a comment, which satisfies a filename grep on its own and would have let a removed call pass.

Run selection moved into `hack/find-ci-run.sh` so it could be tested rather than eyeballed. It is the trust root of the flag -- whatever run it names gets its artifacts deployed into a cluster holding live Cloudflare credentials -- and each of its four filters is pinned by a case that fails when that filter alone is removed: a failed run, a `workflow_dispatch` or `push` run, a run for an earlier head, and another workflow's run are each refused, and the newest of two successful runs wins.

## Documentation

- [ ] README updated (if needed). Not needed: README describes the product, and nothing here changes what the controller does, only how CI builds it and how a maintainer verifies a PR locally.
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed). Its `--use-ci-images` block described the ttl.sh chart, the ttl.sh expiry clock, and no `gh`/`jq` requirement, all of which this diff invalidated.

`docs/development/testing.md` gained the setup script's prerequisites and a section on `--use-ci-images`, including the one-day artifact retention.

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any): none
- [x] Related issues referenced (if any)

## ttl.sh retention

The PR notices promised 24 hours on the strength of the `-1d` suffix in the tag. That suffix does nothing: ttl.sh reads a TTL only from a tag that is entirely a duration (`tagRe` in its `sidecar/internal/ttl/ttl.go` is anchored), so `pr-N-1d` never matched and the images always got the service default. The number happened to be right anyway -- `sidecar/internal/config/config.go` defaults both `DefaultTTL` and `MaxTTL` to 24 hours -- but it was right by luck, and it is an env-var default in someone else's deployment rather than anything this repository controls. So the notices now explain the mechanism and name no number, which is the part that stays true if that default moves. That closes #724.

The same notices used to offer the run's artifacts as a second window on the images. They are not one: `controller.ref` records a digest, so once ttl.sh drops the blobs the artifact holds a pointer to nothing. The chart artifact is a real fallback, because `ci-chart-bundle` carries the `.tgz` itself, and only the chart notice says so now.

`pr-privileged.yaml` carries one of those notices and runs the default-branch copy of itself, so the contributor-facing comment only changes after this merges.

## Additional Notes

Everything this PR reaches but does not fix has a home. Two unpinned dependencies in this surface are #729 and, for shellcheck's unverifiable tarball, #723; a Renovate customManager that still parses but silently matches nothing is #730, and the separate fact that nothing validates `renovate.json` at all is #753. The PR comment in `pr-privileged.yaml` still hands reviewers `podman pull …:pr-<N>-1d` and `--version 0.0.0-pr.<N>-1d`, the mutable forms this PR took off the automated path: #745. `merge-manifests` has no `fail-fast: false`, so one leg's failure cancels its sibling and hides whether it hit the same problem: #747. The prerequisite gaps below are #754, and the remaining review recommendations this PR deliberately leaves alone are #752.

`--use-ci-images` always passes `HELM_IMAGE_ARGS`, so the chart's own `image.*` defaults and its `pullPolicy: Always` are no longer exercised on this path. A chart change that broke either is still caught by an ordinary run, which is what covers them.

Four named improvements this PR leaves alone. The prerequisite list omits `xxd` and `curl`, which the setup script uses before and during the checks; `CLUSTER_SUFFIX` calls `xxd` before the check loop even runs, so adding it to `TOOLS` without moving that line would change nothing. The gap costs a worse error message rather than a wrong outcome, and it is #754. `verify-ci-bundle.sh` hardcodes the two image names without pointing at `pr.yaml` as their source, so a rename there is found by a failing verification rather than by reading. `on_exit` removes the downloaded bundle before it dumps cluster diagnostics, so a post-deploy failure loses the chart tarball it could have re-examined. And `actionlint`'s `go install` has no retry while `kind`'s does: a PR job is rerunnable by anyone, while the scheduled job files an issue when it fails, which is what the retry is protecting.

`pr-privileged.yaml` runs the default-branch copy of itself because it is triggered by `workflow_run`. Nothing here touches that file. The `pr.yaml` steps added in this PR do run on this PR's own checks, since `pr.yaml` fires on `pull_request` and uses the PR's copy, so the three new artifacts (`ci-chart-bundle`, `image-ref-controller`, `image-ref-proxy`) should show up on this run and can be inspected there.

Issue #322 is already satisfied. Across `.github/workflows/` and `.github/actions/` there are 79 `uses:` references: 77 pinned to a full 40-character SHA with a trailing version comment, and 2 in-repo `./.github/actions/setup-chart-testing` references that the issue puts out of scope. Nothing unpinned. OpenSSF Scorecard's pinned-dependencies check also scores Containerfile base images and shell-installed downloads, so that bullet may not go green on `uses:` lines alone.
