### PR TITLE
fix(ci): scope helm-docs to the chart it is told to document

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -585,13 +585,13 @@ jobs:
         run: |
           CHART_DIR="charts/cloudflare-tunnel-gateway-controller"
           echo "Validating README.md is up to date..."
-          helm-docs "$CHART_DIR"
+          helm-docs --chart-search-root "$CHART_DIR"
 
           if git diff --exit-code "$CHART_DIR/README.md" > /dev/null 2>&1; then
             echo "README.md is up to date"
           else
             echo "ERROR: README.md is out of date!"
-            echo "Please run: helm-docs $CHART_DIR"
+            echo "Please run: helm-docs --chart-search-root $CHART_DIR"
             echo ""
             echo "Diff:"
             git diff "$CHART_DIR/README.md"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,13 +146,13 @@ jobs:
         run: |
           CHART_DIR="charts/cloudflare-tunnel-gateway-controller"
           echo "Validating README.md is up to date..."
-          helm-docs "$CHART_DIR"
+          helm-docs --chart-search-root "$CHART_DIR"
 
           if git diff --exit-code "$CHART_DIR/README.md" > /dev/null 2>&1; then
             echo "README.md is up to date"
           else
             echo "ERROR: README.md is out of date!"
-            echo "Please run: helm-docs $CHART_DIR"
+            echo "Please run: helm-docs --chart-search-root $CHART_DIR"
             echo ""
             echo "Diff:"
             git diff "$CHART_DIR/README.md"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ helm package charts/cloudflare-tunnel-gateway-controller
 helm unittest charts/cloudflare-tunnel-gateway-controller
 
 # Generate README from values.yaml (REQUIRED before commit)
-helm-docs charts/cloudflare-tunnel-gateway-controller
+helm-docs --chart-search-root charts/cloudflare-tunnel-gateway-controller
 
 # Lint chart
 helm lint charts/cloudflare-tunnel-gateway-controller
@@ -410,7 +410,7 @@ go test -race ./... && golangci-lint run --timeout=5m --build-tags e2e,conforman
 # Helm chart changes
 helm unittest charts/cloudflare-tunnel-gateway-controller && \
 helm lint charts/cloudflare-tunnel-gateway-controller && \
-helm-docs charts/cloudflare-tunnel-gateway-controller
+helm-docs --chart-search-root charts/cloudflare-tunnel-gateway-controller
 
 # Markdown changes
 markdownlint-cli2 '**/*.md'
@@ -431,7 +431,7 @@ Before creating a PR, verify all checklist items from `.github/pull_request_temp
    - Markdown linting passes (`markdownlint-cli2 '**/*.md'`)
    - Helm tests pass (`helm unittest charts/cloudflare-tunnel-gateway-controller`)
    - Helm lint passes (`helm lint charts/cloudflare-tunnel-gateway-controller`)
-   - Helm README is up to date (`helm-docs charts/cloudflare-tunnel-gateway-controller`)
+   - Helm README is up to date (`helm-docs --chart-search-root charts/cloudflare-tunnel-gateway-controller`)
    - Manual testing completed (if applicable)
 
 2. **Documentation**

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ helm-test: ## Run Helm unit tests
 	helm unittest $(CHART_PATH)
 
 helm-docs: ## Regenerate chart README from values.yaml
-	helm-docs $(CHART_PATH)
+	helm-docs --chart-search-root $(CHART_PATH)
 
 helm-template: ## Template the chart locally for debugging
 	helm template test $(CHART_PATH) \
@@ -78,7 +78,7 @@ ci-go: ## Run all Go CI gates (test + lint)
 ci-helm: ## Run all Helm CI gates (test + lint + docs)
 	helm unittest $(CHART_PATH) && \
 	helm lint $(CHART_PATH) && \
-	helm-docs $(CHART_PATH) && git diff --exit-code $(CHART_PATH)/README.md
+	helm-docs --chart-search-root $(CHART_PATH) && git diff --exit-code $(CHART_PATH)/README.md
 
 ci-docs: ## Run docs CI gate
 	mkdocs build --strict

--- a/internal/docsdrift/helmdocsscope_test.go
+++ b/internal/docsdrift/helmdocsscope_test.go
@@ -1,0 +1,79 @@
+package docsdrift_test
+
+// helm-docs scope guard: `helm-docs` takes no positional argument. It
+// accepts only flags, and --chart-search-root defaults to ".", so a
+// chart path passed positionally is discarded and every chart reachable
+// from the working directory is regenerated -- including sibling git
+// worktrees under .claude/worktrees, whose owners then find a modified
+// chart README in a branch that never touched the chart.
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// helmDocsPositionalArg matches a helm-docs command word followed by a
+// non-flag token. The leading class rejects paths and hyphenated names
+// (/usr/local/bin/helm-docs, helm-docs-tmp) that merely contain the
+// binary name; group 2 is the discarded positional argument.
+var helmDocsPositionalArg = regexp.MustCompile(`(?:^|[^\w./-])helm-docs[ \t]+([^-\s]\S*)`)
+
+func TestHelmDocsInvocationsAreScopedToTheChart(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := findRepoRoot(t)
+
+	out, err := exec.CommandContext(t.Context(), "git", "-C", repoRoot, "ls-files", "-z", ":!vendor/**").Output()
+	if err != nil {
+		t.Fatalf("git ls-files: %v", err)
+	}
+
+	for _, rel := range strings.Split(strings.TrimRight(string(out), "\x00"), "\x00") {
+		checkHelmDocsScope(t, repoRoot, rel)
+	}
+}
+
+// checkHelmDocsScope fails for each helm-docs invocation in the file
+// whose FIRST argument is a chart path rather than --chart-search-root,
+// which is the copy-paste form the documented command had. Separating a
+// flag's value from a positional further along the line would need a
+// table of which helm-docs flags take a value, and no freshness check
+// is written that way. Every match on a line is examined: a benign
+// leading match (`which helm-docs > /dev/null`) must not shadow a real
+// invocation appended after it.
+func checkHelmDocsScope(t *testing.T, repoRoot, rel string) {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join(repoRoot, rel))
+	if errors.Is(err, fs.ErrNotExist) {
+		return // tracked but absent from the working tree; nothing to scan
+	}
+
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err) // a file the guard cannot read is a file it does not cover
+	}
+
+	for i, line := range strings.Split(string(body), "\n") {
+		for _, m := range helmDocsPositionalArg.FindAllStringSubmatch(line, -1) {
+			if !namesChartDir(m[1]) {
+				continue
+			}
+
+			t.Errorf("%s:%d passes %q to helm-docs positionally; helm-docs takes only flags, so the path is discarded and every chart under the working directory is regenerated. Use --chart-search-root:\n  %s",
+				rel, i+1, m[1], strings.TrimSpace(line))
+		}
+	}
+}
+
+// namesChartDir reports whether a positional token is a chart directory
+// -- a path or a variable holding one. Prose that merely contains the
+// word "chart" after the binary name is not an invocation.
+func namesChartDir(token string) bool {
+	return strings.Contains(strings.ToLower(token), "chart") && strings.ContainsAny(token, "/$")
+}


### PR DESCRIPTION
# Pull Request

## Summary

`helm-docs` takes no positional argument. `helm-docs --help` prints `Usage: helm-docs [flags]`, and `--chart-search-root` defaults to `.`. Every invocation in this repo passed the chart path positionally, so the path was discarded and helm-docs regenerated every chart it could reach from the working directory. From the repo root that includes any git worktree checked out below it, so `make helm-docs` on one branch rewrites the chart README in every other branch checked out beside it. With #697 on top (a `go install`-built helm-docs drops the `Autogenerated from chart metadata` footer) the rewrite also loses two lines.

CI is unaffected: a fresh checkout has one chart under `.`.

## Changes

- `--chart-search-root charts/cloudflare-tunnel-gateway-controller` at all nine invocation sites: both Makefile targets, three command listings in `CLAUDE.md`, and the `Validate helm-docs` step plus its error message in `pr.yaml` and `release.yaml`.
- A guard in `internal/docsdrift` that scans tracked files via `git ls-files` and fails on any `helm-docs` invocation handed a chart path positionally. It catches the copy-paste form, not every spelling. Telling a flag's value apart from a positional would need a table of which helm-docs flags take a value, and no freshness check is written that way.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable). Reproduced the defect and the fix by hand: from the repo root the positional form reports three chart directories including two sibling worktrees, the scoped form reports one, and the pinned v1.14.2 image with the new flag leaves the committed chart README byte-identical so the CI freshness check does not flip. No conformance or e2e run is owed here: nothing in this change reaches runtime code.

Guard written first, red on the unfixed tree naming all nine sites. Then each site mutation-tested on its own: revert one line to the positional form and the test dies with that exact `file:line`. All nine mutants caught, plus the `which helm-docs > /dev/null && helm-docs $(CHART_PATH)` shape that hides a real invocation behind a benign first match. `actionlint` clean. `make helm-docs` with the fix reports `Found Chart directories [.]` and leaves the sibling worktrees byte-identical, checked by hash before and after.

## Documentation

- [x] README updated (if needed)
- [x] Code comments added for complex logic
- [x] CLAUDE.md updated (if workflow/standards changed)

Contributor tooling, nothing a user can observe. `README.md` and the docs site mention `helm-docs` only in prose ("the README is auto-generated by `helm-docs`"), which stays true. The command listings live in `CLAUDE.md` and are fixed here.

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any)
- [x] Related issues referenced (if any)

## Additional Notes

The chart README is unchanged by this branch. If you regenerate it while checking this out, use the pinned `jnorwood/helm-docs:v1.14.2` binary extracted from the image and not whatever is on `PATH`. See #697.

A bare `helm-docs` with no argument at all still walks from `.`, and neither the flag fix nor the guard can reach that form. A root `.helmdocsignore` listing `.claude/worktrees/**` would close it for any invocation form; left out of this PR deliberately.

Three neighbouring gaps found while reviewing this and deliberately left out. A bare `helm-docs` with no argument at all still walks from the current directory, which neither the flag nor the guard can reach; a root ignore file would close it for any invocation form and is #760. Both workflows carry the helm-docs install and the whole validation step verbatim, so this change had to be made twice (#761). And #697 remains the other half of the compound failure: a `go install`-built helm-docs still drops the footer, now only for the chart the contributor meant to touch.

Closes #746
