### PR TITLE
docs(upgrading): narrow the no-values-change claim to the deployments it holds for

### DIFF
--- a/docs/upgrading/v3.4-to-v3.5.md
+++ b/docs/upgrading/v3.4-to-v3.5.md
@@ -164,5 +164,5 @@ Reading the policy does not touch the Cloudflare credentials Secret, so rotating
 ## What does not change
 
 - No CR migration. Existing `GatewayClassConfig` and `GatewayConfig` objects keep working — but the `GatewayClassConfig` CRD itself needs the one-time re-apply above.
-- No required values change.
+- No required values change, unless your values file both enables `networkPolicy` and empties `networkPolicy.cloudflareIpRanges` — that one combination is now refused, with two ways out [above](#change-that-can-break-an-emptied-cloudflareipranges-stops-the-render).
 - The shared data plane, the tunnel document format, and route status semantics are unchanged for every deployment not covered above.


### PR DESCRIPTION
# Pull Request

## Summary

The v3.4-to-v3.5 upgrade page contradicted itself. Its intro says one values file the chart used to accept is now refused and that both ways out are values changes; `## What does not change` still said "No required values change". That bullet predates the refusal and was never revisited when it landed.

An operator who enables `networkPolicy` and empties its `cloudflareIpRanges`, and reads only the summary, concludes the upgrade is safe and gets a render that aborts with no manifests.

Closes #766

## Changes

- One line. The bullet now names the combination that is refused (enabling `networkPolicy` AND emptying `networkPolicy.cloudflareIpRanges`) and links to the section that already describes both exits. Both halves, because the policy is off by default and an emptied list alone still renders.

Narrowed rather than deleted: the reassurance stays true for everyone who never touched the field, on a page whose job is telling an operator what they must do before upgrading.

## Testing

- [ ] All tests pass locally (`go test ./...`). Not run: the diff is one line of documentation prose and contains no Go.
- [ ] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`). Not run, same reason.
- [x] Markdown linting passes (`markdownlint **/*.md`), 0 issues.
- [ ] Manual testing completed (if applicable). Not applicable.

Also run: `mkdocs build --strict`, clean — which is what validates the new intra-page anchor.

**Conformance and custom e2e were deliberately not run for this PR.** The diff touches one line of documentation prose and no Go, chart, workflow or test file, so neither suite exercises anything this change can affect. Both ran green against a live tunnel on `618e7307`, the commit this branch is based on: conformance 422 pass / 0 fail / 76 skip, custom e2e 88 pass / 0 fail.

## Documentation

- [x] README updated (if needed). Not needed: the change is inside the upgrade guide itself.
- [ ] Code comments added for complex logic. No code.
- [ ] CLAUDE.md updated (if workflow/standards changed). No workflow change.

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any). None; this describes an existing behaviour more accurately.
- [x] Related issues referenced (if any)

## Additional Notes

`proxy.networkPolicy.egressRestricted` arms a similar refusal on empty ranges and is deliberately not named here: it has behaved that way since v3.2, so a v3.4 values file in that state could not install v3.4 either. This page owes only what differs between the version being left and the one being entered.
