### PR TITLE
docs(upgrading): say what the upgrade needs instead of counting it

### DIFF
--- a/docs/upgrading/index.md
+++ b/docs/upgrading/index.md
@@ -6,7 +6,7 @@ This section documents version-to-version upgrade paths and the breaking changes
 
 - [v2 → v3](v2-to-v3.md) — the v3 chart collapses to a single L7-proxy data plane, slims the GatewayClassConfig CRD spec, drops the AmneziaWG sidecar, and tightens RBAC.
 - [v3.0 → v3.1](v3-to-v3.1.md) — multi-tenant isolation hardening: data-plane metrics and config-API NetworkPolicy default on, a new `RouteShadowed` condition/Event, and a longer proxy drain window. No CRD or values migration.
-- [v3.4 → v3.5](v3.4-to-v3.5.md) — two isolation fixes that can break a working setup: a dedicated data plane sharing a tunnel across namespaces is now refused (and its proxy removed), and the `X-Original-Host` header is no longer trusted without an opt-in. The `GatewayClassConfig` CRD gains fields, so re-apply it (see [CRD upgrades](#crd-upgrades)); no values migration.
+- [v3.4 → v3.5](v3.4-to-v3.5.md) — changes that can break a working setup, some needing a values edit. `proxy.networkPolicy.enabled` defaults to `true`, so a scraper sharing the release namespace loses the proxy's `/metrics` after the upgrade even on an install that never set the key; and a values file with `networkPolicy.enabled: true` and `networkPolicy.cloudflareIpRanges` emptied now [stops the render](v3.4-to-v3.5.md#change-that-can-break-an-emptied-cloudflareipranges-stops-the-render). The `GatewayClassConfig` CRD also needs a one-time re-apply (see [CRD upgrades](#crd-upgrades)).
 
 ## Conventions
 

--- a/docs/upgrading/v3.4-to-v3.5.md
+++ b/docs/upgrading/v3.4-to-v3.5.md
@@ -1,6 +1,6 @@
 # Upgrading from v3.4 to v3.5
 
-v3.5 closes five ways a request, a tenant, an unauthenticated caller, or the controller's own egress could reach something that was not theirs, and stops one request's bug from taking the whole data plane down. There is no CR migration, but the `GatewayClassConfig` CRD gains fields and must be re-applied by hand, and each change below can stop something that works today: a Gateway, a deployment's request routing, a hand-written proxy Deployment's startup, a scraper that shares the controller's namespace, or the render itself — one values file the chart used to accept is now refused, and both ways out of that are values changes. All are described below with what to do about them.
+v3.5 closes five ways a request, a tenant, an unauthenticated caller, or the controller's own egress could reach something that was not theirs, and stops one request's bug from taking the whole data plane down. There is no CR migration, but the `GatewayClassConfig` CRD gains fields and must be re-applied by hand, and each change below can stop something that works today: a Gateway, a deployment's request routing, a hand-written proxy Deployment's startup, a scraper that shares the controller's namespace, or the render itself. Several of them need a values edit to keep working, and each section that needs one names it. All are described below with what to do about them.
 
 ## Do this first: re-apply the GatewayClassConfig CRD
 
@@ -164,5 +164,4 @@ Reading the policy does not touch the Cloudflare credentials Secret, so rotating
 ## What does not change
 
 - No CR migration. Existing `GatewayClassConfig` and `GatewayConfig` objects keep working — but the `GatewayClassConfig` CRD itself needs the one-time re-apply above.
-- No required values change, unless your values file both enables `networkPolicy` and empties `networkPolicy.cloudflareIpRanges` — that one combination is now refused, with two ways out [above](#change-that-can-break-an-emptied-cloudflareipranges-stops-the-render).
 - The shared data plane, the tunnel document format, and route status semantics are unchanged for every deployment not covered above.


### PR DESCRIPTION
# Pull Request

## Summary

The upgrading index told an operator the v3.4 to v3.5 entry needs "no values migration" and called it "two isolation fixes". Both claims were written before the later changes landed and neither was revisited, so the page an operator reads before the guide both undercounted what could break and denied that any values edit was needed.

This is the page an operator reads before the guide, so it decides whether they open the guide at all.

Closes #769

## Changes

- The index entry names the two configurations that need a values edit and links the render abort into its section, without counting them. Names do not drift; counts do.
- It leads with `proxy.networkPolicy.enabled` defaulting to `true`, so the scraper case reads as reaching an install that never set the key. Three of the changes are exotic, so without that the warning reads as somebody else's problem.
- The guide's opening said no values edit was needed at all. It now says several of the changes need one and that each section names its own. It does not partition the set: the partition needs a criterion that takes a paragraph to state, and stating it in a clause produced a sentence that excluded cases matching its own wording.
- The guide's "no required values change" bullet is removed rather than extended again. It sat under `## What does not change` while describing something that does change for a default install (`proxy.networkPolicy.enabled` defaults to `true`, so a scraper sharing the release namespace is denied after the upgrade). Each attempt to keep it has narrowed it once more and still left a case out. The two configurations have their own sections, which is where a reader deciding whether they are affected has to end up anyway.

## Testing

- [ ] All tests pass locally (`go test ./...`). Not run: the diff is documentation prose and contains no Go.
- [ ] Linters pass locally (`golangci-lint run --timeout=5m --build-tags e2e,conformance,envtest`). Not run, same reason.
- [x] Markdown linting passes (`markdownlint **/*.md`), 0 issues.
- [ ] Manual testing completed (if applicable). Not applicable.

Also run: `mkdocs build --strict`, clean, which is what validates the surviving intra-page links.

**Conformance and custom e2e were deliberately not run for this PR.** The diff touches documentation prose only, with no Go, chart, workflow or test file, so neither suite exercises anything this change can affect. Both ran green against a live tunnel on `618e7307`: conformance 422 pass / 0 fail / 76 skip, custom e2e 88 pass / 0 fail.

## Documentation

- [x] README updated (if needed). Not needed: the change is inside the upgrade docs themselves.
- [ ] Code comments added for complex logic. No code.
- [ ] CLAUDE.md updated (if workflow/standards changed). No workflow change.

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any). None; this describes existing behaviour more accurately.
- [x] Related issues referenced (if any)

## Additional Notes

The entry names the two configurations that need a values edit and links the second into its section. It does not name every change v3.5 makes, and that is a decision rather than an omission: the guide is one click away and carries all of them, while an index line that enumerates a subset is how the "two isolation fixes" claim this PR removes got there in the first place.
